### PR TITLE
DragonFlyBSD support

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -51,6 +51,10 @@ case $host_os in
     AC_DEFINE(HAVE_NETBSD, 1, [NetBSD])
     [ rm -f src/device.c; ln -sf bsd/device.c src/device.c ]
   ;;
+  *dragonfly*)
+    AC_DEFINE(HAVE_DRAGONFLY, 1, [DragonFly])
+    [ rm -f src/device.c; ln -sf bsd/device.c src/device.c ]
+  ;;
   *bsd*)
     AC_MSG_WARN("Unknown BSD variant, tinc might not compile or work!")
     AC_DEFINE(HAVE_BSD, 1, [Unknown BSD variant])
@@ -99,8 +103,8 @@ dnl Checks for header files.
 dnl We do this in multiple stages, because unlike Linux all the other operating systems really suck and don't include their own dependencies.
 
 AC_HEADER_STDC
-AC_CHECK_HEADERS([stdbool.h syslog.h sys/file.h sys/ioctl.h sys/mman.h sys/param.h sys/socket.h sys/time.h sys/uio.h sys/wait.h netdb.h arpa/inet.h dirent.h])
-AC_CHECK_HEADERS([net/if.h net/if_types.h linux/if_tun.h net/if_tun.h net/if_tap.h net/ethernet.h net/if_arp.h netinet/in_systm.h netinet/in.h netinet/in6.h],
+AC_CHECK_HEADERS([stdbool.h syslog.h sys/file.h sys/ioctl.h sys/mman.h sys/param.h sys/resource.h sys/socket.h sys/time.h sys/uio.h sys/wait.h netdb.h arpa/inet.h dirent.h])
+AC_CHECK_HEADERS([net/if.h net/if_types.h linux/if_tun.h net/if_tun.h net/tun/if_tun.h net/if_tap.h net/tap/if_tap.h net/ethernet.h net/if_arp.h netinet/in_systm.h netinet/in.h netinet/in6.h],
   [], [], [#include "have.h"]
 )
 AC_CHECK_HEADERS([netinet/if_ether.h netinet/ip.h netinet/ip6.h],

--- a/have.h
+++ b/have.h
@@ -95,6 +95,10 @@
 #include <sys/param.h>
 #endif
 
+#ifdef HAVE_SYS_RESOURCE_H
+#include <sys/resource.h>
+#endif
+
 #ifdef HAVE_SYS_UIO_H
 #include <sys/uio.h>
 #endif
@@ -126,8 +130,16 @@
 #include <net/if_tun.h>
 #endif
 
+#ifdef HAVE_NET_TUN_IF_TUN_H
+#include <net/tun/if_tun.h>
+#endif
+
 #ifdef HAVE_NET_IF_TAP_H
 #include <net/if_tap.h>
+#endif
+
+#ifdef HAVE_NET_TAP_IF_TAP_H
+#include <net/tap/if_tap.h>
 #endif
 
 #ifdef HAVE_NETINET_IN_SYSTM_H

--- a/src/bsd/device.c
+++ b/src/bsd/device.c
@@ -51,7 +51,7 @@ static uint64_t device_total_in = 0;
 static uint64_t device_total_out = 0;
 #if defined(TUNEMU)
 static device_type_t device_type = DEVICE_TYPE_TUNEMU;
-#elif defined(HAVE_OPENBSD) || defined(HAVE_FREEBSD)
+#elif defined(HAVE_OPENBSD) || defined(HAVE_FREEBSD) || defined(HAVE_DRAGONFLY)
 static device_type_t device_type = DEVICE_TYPE_TUNIFHEAD;
 #else
 static device_type_t device_type = DEVICE_TYPE_TUN;


### PR DESCRIPTION
We had to add some additional patches in pkgsrc to make tinc work properly on DragonFly BSD (mostly just finding the if_tun and if_tap headers), but since the git repo does not hold the 1.0, the patches were adapted and a bit expanded for the master branch.
