### PR TITLE
Fix the Kruskal's algorithm in generating MST.

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -48,6 +48,8 @@ typedef struct node_t {
 	sockaddr_t address;                     /* his real (internet) ip to send UDP packets to */
 	char *hostname;                         /* the hostname of its real ip */
 
+	struct node_t *disjoint_set;            /* Pointer to the parent node in the disjoint set (used in Kruskal's algorithm) */
+
 	node_status_t status;
 	time_t last_state_change;
 	time_t last_req_key;


### PR DESCRIPTION
Current implementation uses only a "visited" mark to indicate whether an edge is needed to be added into MST. This can sometimes generate incorrect result.

For example, suppose Node A has 2 connections to B and C, and the network has following edges (sorted by weight):
-  C <---> D, weight 10
-  A <---> B, weight 20
-  A <---> C, weight 30.

C<->D & A<->B are added respectively and all of A/B/C/D are marked visited but only A<->B is marked as MST (C<->D does not associate with a connection in Node A). Then A<->C will not be added because both A&C are marked visited. The generated MST is not even connected and all broadcast packets from A to C are lost.

To fix the problem a structure of disjoint-set is added. The structure is used to decide if two nodes are already connected when adding an edge.
