### PR TITLE
Fix segfault when connecting an experimental node to a normal one

### DIFF
--- a/src/protocol_auth.c
+++ b/src/protocol_auth.c
@@ -368,6 +368,10 @@ bool id_h(connection_t *c, const char *request) {
 
 		return sptps_start(&c->sptps, c, c->outgoing, false, myself->connection->ecdsa, c->ecdsa, label, sizeof label, send_meta_sptps, receive_meta_sptps);
 	} else {
+		if (ecdsa_active(c->ecdsa)) {
+			ecdsa_free(c->ecdsa);
+			c->ecdsa = NULL;
+		}
 		return send_metakey(c);
 	}
 }


### PR DESCRIPTION
When a node has `ExperimentalProtocol` enabled, has an ECDSA public key in its configuration file, and tries to connect to a node which has `ExperimentalProtocol` disabled, the following happens:
1. `send_id()` initializes `c->ecdsa`.
2. `id_h()` runs without touching `c->ecdsa`.
3. `send_metakey()` calls `read_rsa_public_key(c)`, which returns true without setting `c->rsa` since `c->ecdsa` is active.
4. `send_metakey()` calls `rsa_size(c->rsa)`. SEGFAULT ensues.

This patch fixes the issue by disabling ECDSA in `id_h()` if the minor protocol version indicates that the other side doesn't support ECDSA.
