### PR TITLE
Disable PMTU discovery when TCPOnly is set

### DIFF
--- a/src/protocol_key.c
+++ b/src/protocol_key.c
@@ -386,7 +386,7 @@ bool ans_key_h(connection_t *c, const char *request) {
 				update_node_udp(from, &sa);
 			}
 
-			if(from->options & OPTION_PMTU_DISCOVERY)
+			if(from->options & OPTION_PMTU_DISCOVERY && !(from->options & OPTION_TCPONLY))
 				send_mtu_probe(from);
 		}
 
@@ -435,7 +435,7 @@ bool ans_key_h(connection_t *c, const char *request) {
 		update_node_udp(from, &sa);
 	}
 
-	if(from->options & OPTION_PMTU_DISCOVERY)
+	if(from->options & OPTION_PMTU_DISCOVERY && !(from->options & OPTION_TCPONLY))
 		send_mtu_probe(from);
 
 	return true;


### PR DESCRIPTION
Obviously, PMTU discovery doesn't make much sense when we know we'll be using TCP anyway.
