### PR TITLE
Make public keys and configuration files world-readable

### DIFF
--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -324,7 +324,7 @@ static FILE *ask_and_open(const char *filename, const char *what, const char *mo
 		filename = buf2;
 	}
 
-	umask(0077); /* Disallow everything for group and other */
+	umask(0022); /* Disallow writing for group and other */
 
 	disable_old_keys(filename, what);
 


### PR DESCRIPTION
There is no reason to keep others from seeing the contents of public key files and configuration files. It makes exchanging host files slightly less convenient for no benefit.

In fact, this can even hurt security because it makes it less obvious to the user what is actually private and what isn't.

Private key files are of course still only accessible by the owner.
