### PR TITLE
Fix broken build with --with-openssl, --with-libgcrypt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -201,8 +201,8 @@ else
 	tinc_OPENSSL
 fi
 	
-AM_CONDITIONAL(OPENSSL, test "$openssl" = true)
-AM_CONDITIONAL(GCRYPT, test "$grypt" = true)
+AM_CONDITIONAL(OPENSSL, test -n "$openssl")
+AM_CONDITIONAL(GCRYPT, test "$gcrypt" = true)
 
 dnl Check if support for jumbograms is requested 
 AC_ARG_ENABLE(jumbograms,


### PR DESCRIPTION
When `--with-openssl` is used, `$openssl` is set to the specified path. Unfortunately, that confuses the `OPENSSL` conditional which expects it to be set to `true`. The result is that the contents of the `openssl/` directory are not built when `--with-openssl` is used, resulting in undefined references and a broken build.

In addition, there is a typo in the `GCRYPT` conditional definition (`grypt` instead of `gcrypt`) which means `GCRYPT` never gets set, (presumably) breaking builds using libgcrypt.

These regressions were introduced in 9b9230a0a79c670b86f54fadd2807b864ff9d91f.
