### PR TITLE
Adding "conf.d" configuration dir support.

### DIFF
--- a/doc/tinc.conf.5.in
+++ b/doc/tinc.conf.5.in
@@ -668,6 +668,8 @@ The top directory for configuration files.
 .It Pa @sysconfdir@/tinc/ Ns Ar NETNAME Ns Pa /tinc.conf
 The default name of the server configuration file for net
 .Ar NETNAME .
+.It Pa @sysconfdir@/tinc/ Ns Ar NETNAME Ns Pa /conf.d/
+Optional directory from which any .conf file will be loaded
 .It Pa @sysconfdir@/tinc/ Ns Ar NETNAME Ns Pa /hosts/
 Host configuration files are kept in this directory.
 .It Pa @sysconfdir@/tinc/ Ns Ar NETNAME Ns Pa /tinc-up

--- a/doc/tinc.texi
+++ b/doc/tinc.texi
@@ -793,6 +793,9 @@ The actual configuration of the daemon is done in the file
 @file{@value{sysconfdir}/tinc/@var{netname}/tinc.conf} and at least one other file in the directory
 @file{@value{sysconfdir}/tinc/@var{netname}/hosts/}.
 
+An optionnal directory @file{@value{sysconfdir}/tinc/@var{netname}/conf.d} can be added from which
+any .conf file will be read.
+
 These file consists of comments (lines started with a #) or assignments
 in the form of
 


### PR DESCRIPTION
Hi Guus,

It's a copy of pull request #12 to avoid incompatibility issues between versions 1.0 and 1.1.

Any file matching the pattern /etc/tinc/$NETNAME/conf.d/*.conf will be
parsed after the tinc.conf file.

Differences with pull requests #12 are:
- I'm not using logger anymore (as you removed it in your last commit)
- I'm using the SLASH definition
