### PR TITLE
Updated android build instruction

### DIFF
--- a/README.android
+++ b/README.android
@@ -6,9 +6,9 @@ tar xfj android-ndk-r9d-linux-x86.tar.bz2
 ./android-ndk-r9d/build/tools/make-standalone-toolchain.sh --platform=android-5 --install-dir=/tmp/my-android-toolchain
 
 - Download and cross-compile openSSL for ARM:
-wget http://www.openssl.org/source/openssl-1.0.1f.tar.gz
-tar xfz openssl-1.0.1f.tar.gz
-cd openssl-1.0.1f
+wget http://www.openssl.org/source/openssl-1.0.1g.tar.gz
+tar xfz openssl-1.0.1g.tar.gz
+cd openssl-1.0.1g
 ./Configure dist
 make CC=/tmp/my-android-toolchain/bin/arm-linux-androideabi-gcc AR="/tmp/my-android-toolchain/bin/arm-linux-androideabi-ar r" RANLIB=/tmp/my-android-toolchain/bin/arm-linux-androideabi-ranlib
 
@@ -16,7 +16,7 @@ make CC=/tmp/my-android-toolchain/bin/arm-linux-androideabi-gcc AR="/tmp/my-andr
 git clone git://tinc-vpn.org/tinc
 cd tinc
 autoreconf -fsi
-CC=/tmp/my-android-toolchain/bin/arm-linux-androideabi-gcc ./configure --host=arm-linux --disable-lzo --with-openssl-lib=$HOME/android/openssl-1.0.1f --with-openssl-include=$HOME/android/openssl-1.0.1f/include/ --disable-hardening
+CC=/tmp/my-android-toolchain/bin/arm-linux-androideabi-gcc ./configure --host=arm-linux --disable-lzo --with-openssl-lib=$HOME/android/openssl-1.0.1g --with-openssl-include=$HOME/android/openssl-1.0.1g/include/ --disable-hardening
 make -j5
 
 - Strip tincd binary to make it smaller


### PR DESCRIPTION
instructions update by Vilbrekin and me
additonally updated openssl due to heartbleed bug

see http://heartbleed.com/ :
    OpenSSL 1.0.1 through 1.0.1f (inclusive) are vulnerable
    OpenSSL 1.0.1g is NOT vulnerable
    OpenSSL 1.0.0 branch is NOT vulnerable
    OpenSSL 0.9.8 branch is NOT vulnerable
