### PR TITLE
Add support to find libresolv on Homebrew/Mac OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -202,7 +202,7 @@ AC_CHECK_DECLS([freeaddrinfo, gai_strerror, getaddrinfo, getnameinfo],
   [], [], [#include "src/have.h"]
 )
 
-AC_CHECK_DECLS([res_init], [], [], [
+AC_CHECK_DECLS([res_init], [LIBS="$LIBS -lresolv"], [], [
   #include <netinet/in.h>
   #include <resolv.h>
 ])


### PR DESCRIPTION
When building tinc 1.0.24 on Mac OS X using [Homebrew](http://brew.sh) the compile fails due to:

```
Undefined symbols for architecture x86_64:
  "_res_9_init", referenced from:
      _main_loop in net.o
```

since `-lresolv` is not passed to the linker.

This pull request adds changes with which libresolv is found when installing tinc with homebrew.

I have only tested these changes on Mac OS X and welcome feedback for improvement.
