### PR TITLE
Fix Windows includes

### DIFF
--- a/src/ed25519/seed.c
+++ b/src/ed25519/seed.c
@@ -3,8 +3,8 @@
 #ifndef ED25519_NO_SEED
 
 #ifdef _WIN32
-#include <Windows.h>
-#include <Wincrypt.h>
+#include <windows.h>
+#include <wincrypt.h>
 #else
 #include <stdio.h>
 #endif


### PR DESCRIPTION
These Windows include lines are capitalized, which causes the build to fail when cross-compiling from Linux to Windows using MinGW as the MinGW headers are entirely lower case.
