### PR TITLE
Fix errno references when handling socket errors

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -178,7 +178,7 @@ bool init_control(void) {
 #ifndef HAVE_MINGW
 	int unix_fd = socket(AF_UNIX, SOCK_STREAM, 0);
 	if(unix_fd < 0) {
-		logger(DEBUG_ALWAYS, LOG_ERR, "Could not create UNIX socket: %s", sockstrerror(errno));
+		logger(DEBUG_ALWAYS, LOG_ERR, "Could not create UNIX socket: %s", sockstrerror(sockerrno));
 		return false;
 	}
 
@@ -198,12 +198,12 @@ bool init_control(void) {
 	umask(mask);
 
 	if(result < 0) {
-		logger(DEBUG_ALWAYS, LOG_ERR, "Could not bind UNIX socket to %s: %s", unixsocketname, sockstrerror(errno));
+		logger(DEBUG_ALWAYS, LOG_ERR, "Could not bind UNIX socket to %s: %s", unixsocketname, sockstrerror(sockerrno));
 		return false;
 	}
 
 	if(listen(unix_fd, 3) < 0) {
-		logger(DEBUG_ALWAYS, LOG_ERR, "Could not listen on UNIX socket %s: %s", unixsocketname, sockstrerror(errno));
+		logger(DEBUG_ALWAYS, LOG_ERR, "Could not listen on UNIX socket %s: %s", unixsocketname, sockstrerror(sockerrno));
 		return false;
 	}
 

--- a/src/event.c
+++ b/src/event.c
@@ -225,7 +225,7 @@ bool event_loop(void) {
 #endif
 
 		if(n < 0) {
-			if(sockwouldblock(errno))
+			if(sockwouldblock(sockerrno))
 				continue;
 			else
 				return false;

--- a/src/meta.c
+++ b/src/meta.c
@@ -142,7 +142,7 @@ bool receive_meta(connection_t *c) {
 	inlen = recv(c->socket, inbuf, sizeof inbuf - c->inbuf.len, 0);
 
 	if(inlen <= 0) {
-		if(!inlen || !errno) {
+		if(!inlen || !sockerrno) {
 			logger(DEBUG_CONNECTIONS, LOG_NOTICE, "Connection closed by %s (%s)",
 					   c->name, c->hostname);
 		} else if(sockwouldblock(sockerrno))

--- a/src/multicast_device.c
+++ b/src/multicast_device.c
@@ -164,7 +164,7 @@ static bool read_packet(vpn_packet_t *packet) {
 
 	if((lenin = recv(device_fd, (void *)packet->data, MTU, 0)) <= 0) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Error while reading from %s %s: %s", device_info,
-			   device, strerror(errno));
+			   device, sockstrerror(sockerrno));
 		return false;
 	}
 
@@ -187,7 +187,7 @@ static bool write_packet(vpn_packet_t *packet) {
 
 	if(sendto(device_fd, (void *)packet->data, packet->len, 0, ai->ai_addr, ai->ai_addrlen) < 0) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Can't write to %s %s: %s", device_info, device,
-			   strerror(errno));
+			   sockstrerror(sockerrno));
 		return false;
 	}
 

--- a/src/net.c
+++ b/src/net.c
@@ -465,7 +465,7 @@ int main_loop(void) {
 #endif
 
 	if(!event_loop()) {
-		logger(DEBUG_ALWAYS, LOG_ERR, "Error while waiting for input: %s", strerror(errno));
+		logger(DEBUG_ALWAYS, LOG_ERR, "Error while waiting for input: %s", sockstrerror(sockerrno));
 		return 1;
 	}
 

--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -744,7 +744,7 @@ static void send_udppacket(node_t *n, vpn_packet_t *origpkt) {
 		priority = origpriority;
 		logger(DEBUG_TRAFFIC, LOG_DEBUG, "Setting outgoing packet priority to %d", priority);
 		if(setsockopt(listen_socket[n->sock].udp.fd, SOL_IP, IP_TOS, &priority, sizeof(priority))) /* SO_PRIORITY doesn't seem to work */
-			logger(DEBUG_ALWAYS, LOG_ERR, "System call `%s' failed: %s", "setsockopt", strerror(errno));
+			logger(DEBUG_ALWAYS, LOG_ERR, "System call `%s' failed: %s", "setsockopt", sockstrerror(sockerrno));
 	}
 #endif
 

--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -417,7 +417,7 @@ char *get_name(void) {
 				return false;
 			}
 			if(gethostname(hostname, sizeof hostname) || !*hostname) {
-				logger(DEBUG_ALWAYS, LOG_ERR, "Could not get hostname: %s\n", strerror(errno));
+				logger(DEBUG_ALWAYS, LOG_ERR, "Could not get hostname: %s\n", sockstrerror(sockerrno));
 				return false;
 			}
 			hostname[31] = 0;
@@ -980,7 +980,7 @@ static bool setup_myself(void) {
 		for(int i = 0; i < listen_sockets; i++) {
 			salen = sizeof sa;
 			if(getsockname(i + 3, &sa.sa, &salen) < 0) {
-				logger(DEBUG_ALWAYS, LOG_ERR, "Could not get address of listen fd %d: %s", i + 3, sockstrerror(errno));
+				logger(DEBUG_ALWAYS, LOG_ERR, "Could not get address of listen fd %d: %s", i + 3, sockstrerror(sockerrno));
 				return false;
 			}
 

--- a/src/sptps_speed.c
+++ b/src/sptps_speed.c
@@ -18,6 +18,7 @@
 */
 
 #include "system.h"
+#include "utils.h"
 
 #include <poll.h>
 
@@ -121,7 +122,7 @@ int main(int argc, char *argv[]) {
 
 	int fd[2];
 	if(socketpair(AF_UNIX, SOCK_STREAM, 0, fd)) {
-		fprintf(stderr, "Could not create a UNIX socket pair: %s\n", strerror(errno));
+		fprintf(stderr, "Could not create a UNIX socket pair: %s\n", sockstrerror(sockerrno));
 		return 1;
 	}
 
@@ -174,7 +175,7 @@ int main(int argc, char *argv[]) {
 	close(fd[1]);
 
 	if(socketpair(AF_UNIX, SOCK_DGRAM, 0, fd)) {
-		fprintf(stderr, "Could not create a UNIX socket pair: %s\n", strerror(errno));
+		fprintf(stderr, "Could not create a UNIX socket pair: %s\n", sockstrerror(sockerrno));
 		return 1;
 	}
 

--- a/src/sptps_test.c
+++ b/src/sptps_test.c
@@ -210,13 +210,13 @@ int main(int argc, char *argv[]) {
 	hint.ai_flags = initiator ? 0 : AI_PASSIVE;
 
 	if(getaddrinfo(initiator ? argv[3] : NULL, initiator ? argv[4] : argv[3], &hint, &ai) || !ai) {
-		fprintf(stderr, "getaddrinfo() failed: %s\n", strerror(errno));
+		fprintf(stderr, "getaddrinfo() failed: %s\n", sockstrerror(sockerrno));
 		return 1;
 	}
 
 	int sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
 	if(sock < 0) {
-		fprintf(stderr, "Could not create socket: %s\n", strerror(errno));
+		fprintf(stderr, "Could not create socket: %s\n", sockstrerror(sockerrno));
 		return 1;
 	}
 
@@ -225,26 +225,26 @@ int main(int argc, char *argv[]) {
 
 	if(initiator) {
 		if(connect(sock, ai->ai_addr, ai->ai_addrlen)) {
-			fprintf(stderr, "Could not connect to peer: %s\n", strerror(errno));
+			fprintf(stderr, "Could not connect to peer: %s\n", sockstrerror(sockerrno));
 			return 1;
 		}
 		fprintf(stderr, "Connected\n");
 	} else {
 		if(bind(sock, ai->ai_addr, ai->ai_addrlen)) {
-			fprintf(stderr, "Could not bind socket: %s\n", strerror(errno));
+			fprintf(stderr, "Could not bind socket: %s\n", sockstrerror(sockerrno));
 			return 1;
 		}
 
 		if(!datagram) {
 			if(listen(sock, 1)) {
-				fprintf(stderr, "Could not listen on socket: %s\n", strerror(errno));
+				fprintf(stderr, "Could not listen on socket: %s\n", sockstrerror(sockerrno));
 				return 1;
 			}
 			fprintf(stderr, "Listening...\n");
 
 			sock = accept(sock, NULL, NULL);
 			if(sock < 0) {
-				fprintf(stderr, "Could not accept connection: %s\n", strerror(errno));
+				fprintf(stderr, "Could not accept connection: %s\n", sockstrerror(sockerrno));
 				return 1;
 			}
 		} else {
@@ -255,12 +255,12 @@ int main(int argc, char *argv[]) {
 			socklen_t addrlen = sizeof addr;
 
 			if(recvfrom(sock, buf, sizeof buf, MSG_PEEK, &addr, &addrlen) <= 0) {
-				fprintf(stderr, "Could not read from socket: %s\n", strerror(errno));
+				fprintf(stderr, "Could not read from socket: %s\n", sockstrerror(sockerrno));
 				return 1;
 			}
 
 			if(connect(sock, &addr, addrlen)) {
-				fprintf(stderr, "Could not accept connection: %s\n", strerror(errno));
+				fprintf(stderr, "Could not accept connection: %s\n", sockstrerror(sockerrno));
 				return 1;
 			}
 		}
@@ -331,7 +331,7 @@ int main(int argc, char *argv[]) {
 		if(FD_ISSET(sock, &fds)) {
 			ssize_t len = recv(sock, buf, sizeof buf, 0);
 			if(len < 0) {
-				fprintf(stderr, "Could not read from socket: %s\n", strerror(errno));
+				fprintf(stderr, "Could not read from socket: %s\n", sockstrerror(sockerrno));
 				return 1;
 			}
 			if(len == 0) {

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -485,7 +485,7 @@ bool recvline(int fd, char *line, size_t len) {
 
 	while(!(newline = memchr(buffer, '\n', blen))) {
 		int result = recv(fd, buffer + blen, sizeof buffer - blen, 0);
-		if(result == -1 && errno == EINTR)
+		if(result == -1 && sockerrno == EINTR)
 			continue;
 		else if(result <= 0)
 			return false;
@@ -511,7 +511,7 @@ bool recvdata(int fd, char *data, size_t len) {
 
 	while(blen < len) {
 		int result = recv(fd, buffer + blen, sizeof buffer - blen, 0);
-		if(result == -1 && errno == EINTR)
+		if(result == -1 && sockerrno == EINTR)
 			continue;
 		else if(result <= 0)
 			return false;
@@ -543,7 +543,7 @@ bool sendline(int fd, char *format, ...) {
 
 	while(blen) {
 		int result = send(fd, p, blen, MSG_NOSIGNAL);
-		if(result == -1 && errno == EINTR)
+		if(result == -1 && sockerrno == EINTR)
 			continue;
 		else if(result <= 0)
 			return false;
@@ -723,7 +723,7 @@ bool connect_tincd(bool verbose) {
 
 	if(getaddrinfo(host, port, &hints, &res) || !res) {
 		if(verbose)
-			fprintf(stderr, "Cannot resolve %s port %s: %s", host, port, strerror(errno));
+			fprintf(stderr, "Cannot resolve %s port %s: %s", host, port, sockstrerror(sockerrno));
 		return false;
 	}
 


### PR DESCRIPTION
When using socket functions, `sockerrno` is supposed to be used to retrieve the error code as opposed to `errno`, so that it is translated to the correct call on Windows (`WSAGetLastError()` - Windows does not update `errno` on socket errors). Unfortunately, the use of `sockerrno` is inconsistent throughout the tinc codebase, as `errno` is often used incorrectly on socket-related calls.

This commit fixes these oversights, which improves socket error handling on Windows.

This was originally discovered in #20.
