### PR TITLE
Protect against spurious connection events

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -37,6 +37,8 @@ extern const char *winerror(int);
 #define sockmsgsize(x) ((x) == WSAEMSGSIZE)
 #define sockinprogress(x) ((x) == WSAEINPROGRESS || (x) == WSAEWOULDBLOCK)
 #define sockinuse(x) ((x) == WSAEADDRINUSE)
+#define sockalready(x) ((x) == WSAEALREADY || (x) == WSAEINVAL || (x) == WSAEWOULDBLOCK) /* See MSDN for connect() */
+#define sockisconn(x) ((x) == WSAEISCONN)
 #else
 #define sockerrno errno
 #define sockstrerror(x) strerror(x)
@@ -44,6 +46,8 @@ extern const char *winerror(int);
 #define sockmsgsize(x) ((x) == EMSGSIZE)
 #define sockinprogress(x) ((x) == EINPROGRESS)
 #define sockinuse(x) ((x) == EADDRINUSE)
+#define sockalready(x) ((x) == EALREADY)
+#define sockisconn(x) ((x) == EISCONN)
 #endif
 
 extern unsigned int bitfield_to_int(const void *bitfield, size_t size);


### PR DESCRIPTION
The event loop does not guarantee that spurious write I/O events do not happen; in fact, they are guaranteed to happen on Windows when `event_flush_output()` is called. Because `handle_meta_io()` does not check for spurious events, a metaconnection socket might appear connected even though it's not, and will fail immediately when sending the ID request.

This commit fixes this issue by making `handle_meta_io()` check the connection status before assuming the socket is connected. It seems that the only reliable way to do that is to try to call `connect()` again and look at the error code, which will be `EISCONN` if the socket is connected, or `EALREADY` if it's not.

I was originally planning to do this in #20, but I changed my mind when I realized both changes are independent from each other.
