### PR TITLE
Fix connection event error handling

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -37,8 +37,7 @@ extern const char *winerror(int);
 #define sockmsgsize(x) ((x) == WSAEMSGSIZE)
 #define sockinprogress(x) ((x) == WSAEINPROGRESS || (x) == WSAEWOULDBLOCK)
 #define sockinuse(x) ((x) == WSAEADDRINUSE)
-#define sockalready(x) ((x) == WSAEALREADY || (x) == WSAEINVAL || (x) == WSAEWOULDBLOCK) /* See MSDN for connect() */
-#define sockisconn(x) ((x) == WSAEISCONN)
+#define socknotconn(x) ((x) == WSAENOTCONN)
 #else
 #define sockerrno errno
 #define sockstrerror(x) strerror(x)
@@ -46,8 +45,7 @@ extern const char *winerror(int);
 #define sockmsgsize(x) ((x) == EMSGSIZE)
 #define sockinprogress(x) ((x) == EINPROGRESS)
 #define sockinuse(x) ((x) == EADDRINUSE)
-#define sockalready(x) ((x) == EALREADY)
-#define sockisconn(x) ((x) == EISCONN)
+#define socknotconn(x) ((x) == ENOTCONN)
 #endif
 
 extern unsigned int bitfield_to_int(const void *bitfield, size_t size);


### PR DESCRIPTION
Commit 86a99c6b999671ed444711139db1937617e802a0 changed the way we handle connection events to protect against spurious event loop callbacks. Unfortunately, it turns out that calling `connect()` twice on the same socket results in different behaviors depending on the platform (even though it seems well defined in POSIX). On Windows this resulted in the connection handling code being unable to react to connection errors (such as connection refused), always hitting the timeout; on Linux this resulted in spurious error messages about `connect()` returning success.

The truth table used in this commit is based on the POSIX standard itself and on empirical observation for platform-specific behaviors. The new code should be correct for Linux, Windows, and any POSIX-compliant platform.
