### PR TITLE
Implement sptps_verify_datagram()

### DIFF
--- a/src/sptps.c
+++ b/src/sptps.c
@@ -431,13 +431,12 @@ bool sptps_verify_datagram(sptps_t *s, const char *data, size_t len) {
 	uint32_t seqno;
 	memcpy(&seqno, data, 4);
 	seqno = ntohl(seqno);
+	if (!sptps_check_seqno(s, seqno, false))
+		return false;
 
 	char buffer[len];
 	size_t outlen;
-	if(!chacha_poly1305_decrypt(s->incipher, seqno, data + 4, len - 4, buffer, &outlen))
-		return false;
-
-	return sptps_check_seqno(s, seqno, false);
+	return chacha_poly1305_decrypt(s->incipher, seqno, data + 4, len - 4, buffer, &outlen);
 }
 
 // Receive incoming data, datagram version.


### PR DESCRIPTION
Implementation of `sptps_verify_datagram()` was left as a TODO. This causes problems when using SPTPS in tinc, because this function is used in `try_mac()`, which itself is used in `try_harder()` to locate nodes sending UDP packets from unexpected addresses. In the current state this function always returns `true`, resulting in UDP addresses of random nodes getting changed which makes UDP communication fragile and unreliable. In addition, this makes UDP communication impossible through port translation and local discovery.

This commit adds the missing implementation, thus fixing the issue.

I discovered this while working on #26.
