### PR TITLE
Improve version generation at build time

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,14 @@ ACLOCAL_AMFLAGS = -I m4
 
 EXTRA_DIST = COPYING.README README.android
 
+# If git describe works, force autoconf to run in order to make sure we have the
+# current version number from git in the resulting configure script.
+configure-version:
+	-git describe && autoconf --force
+
+# Triggering the README target means we are building a distribution (make dist).
+README: configure-version
+
 ChangeLog:
 	git log > ChangeLog
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT([tinc], [1.1pre11])
+AC_INIT([tinc], m4_esyscmd([echo -n "`git describe || echo UNKNOWN | sed 's/release-//'`"]))
 AC_CONFIG_SRCDIR([src/tincd.c])
 AC_GNU_SOURCE
-AM_INIT_AUTOMAKE([check-news std-options subdir-objects -Wall])
+AM_INIT_AUTOMAKE([std-options subdir-objects -Wall])
 AC_CONFIG_HEADERS([config.h])
 
 # Enable GNU extensions.


### PR DESCRIPTION
This branch brings two improvements to how tinc determines its own version and build time:

- It makes sure the build date and time are regenerated every time tinc is built, even if there are no changes, so that the date and time returned by `tincd --version` is always accurate.
- It moves from hardcoded version numbers to autogenerated ones using `git describe` to ease maintenance and make `tincd --version` output more useful.