### PR TITLE
Fix event loop io tree inconsistency on Windows

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -91,8 +91,8 @@ void io_add(io_t *io, io_cb_t cb, void *data, int fd, int flags) {
 
 #ifdef HAVE_MINGW
 void io_add_event(io_t *io, io_cb_t cb, void *data, WSAEVENT event) {
-	io_add(io, cb, data, -1, 0);
 	io->event = event;
+	io_add(io, cb, data, -1, 0);
 }
 #endif
 


### PR DESCRIPTION
On Windows, the event loop io tree uses the Windows Event handle to differentiate between `io_t` objects. Unfortunately, there is a bug in the `io_add_event()` function (introduced in 2f9a1d4ab5ff51b05a5e8cc41a1528fdeb36c723) as it sets the event after inserting the object into the tree, resulting in objects appearing in `io_tree` out of order.

This can lead to crashes on Windows as the event loop is unable to determine which events fired.
