### PR TITLE
Handle the "no local address" case in send_sptps_data()

### DIFF
--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -769,12 +769,12 @@ bool send_sptps_data(void *handle, uint8_t type, const char *data, size_t len) {
 
 	/* Otherwise, send the packet via UDP */
 
-	const sockaddr_t *sa;
+	const sockaddr_t *sa = NULL;
 	int sock;
 
 	if(to->status.send_locally)
 		choose_local_address(to, &sa, &sock);
-	else
+	if(!sa)
 		choose_udp_address(to, &sa, &sock);
 
 	if(sendto(listen_socket[sock].udp.fd, data, len, 0, &sa->sa, SALEN(sa->sa)) < 0 && !sockwouldblock(sockerrno)) {


### PR DESCRIPTION
If `choose_local_address()` is unable to find a local address (e.g. because of old nodes that don't send their local address information), then `send_sptps_data()` ends up using uninitialized variables for the socket and address.

This regression was introduced in 415910897122da0073a862784d148802ca390020. The commit took care of handling that case in `send_udppacket()` but was missing the same fix for `send_sptps_data()`.

This bug was found by the clang static analyzer tool: http://clang-analyzer.llvm.org/
