### PR TITLE
Remove redundant connection_t::status.active field

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -36,7 +36,6 @@
 
 typedef struct connection_status_t {
 		unsigned int pinged:1;                  /* sent ping */
-		unsigned int active:1;                  /* 1 if active.. */
 		unsigned int connecting:1;              /* 1 if we are waiting for a non-blocking connect() to finish */
 		unsigned int unused_termreq:1;          /* the termination of this connection was requested */
 		unsigned int remove_unused:1;           /* Set to 1 if you want this connection removed */

--- a/src/control.c
+++ b/src/control.c
@@ -106,7 +106,7 @@ bool control_h(connection_t *c, const char *request) {
 			for list_each(connection_t, other, connection_list) {
 				if(strcmp(other->name, name))
 					continue;
-				terminate_connection(other, other->status.active);
+				terminate_connection(other, other->edge);
 				found = true;
 			}
 

--- a/src/meta.c
+++ b/src/meta.c
@@ -76,7 +76,7 @@ bool send_meta(connection_t *c, const char *buffer, int length) {
 
 void broadcast_meta(connection_t *from, const char *buffer, int length) {
 	for list_each(connection_t, c, connection_list)
-		if(c != from && c->status.active)
+		if(c != from && c->edge)
 			send_meta(c, buffer, length);
 }
 

--- a/src/net.c
+++ b/src/net.c
@@ -97,8 +97,6 @@ void purge(void) {
 void terminate_connection(connection_t *c, bool report) {
 	logger(DEBUG_CONNECTIONS, LOG_NOTICE, "Closing connection with %s (%s)", c->name, c->hostname);
 
-	c->status.active = false;
-
 	if(c->node && c->node->connection == c)
 		c->node->connection = NULL;
 
@@ -155,7 +153,7 @@ static void timeout_handler(void *data) {
 			continue;
 
 		if(c->last_ping_time + pingtimeout <= now.tv_sec) {
-			if(c->status.active) {
+			if(c->edge) {
 				if(c->status.pinged) {
 					logger(DEBUG_CONNECTIONS, LOG_INFO, "%s (%s) didn't respond to PING in %ld seconds", c->name, c->hostname, (long)now.tv_sec - c->last_ping_time);
 				} else if(c->last_ping_time + pinginterval <= now.tv_sec) {
@@ -170,7 +168,7 @@ static void timeout_handler(void *data) {
 				else
 					logger(DEBUG_CONNECTIONS, LOG_WARNING, "Timeout from %s (%s) during authentication", c->name, c->hostname);
 			}
-			terminate_connection(c, c->status.active);
+			terminate_connection(c, c->edge);
 		}
 	}
 
@@ -204,7 +202,7 @@ static void periodic_handler(void *data) {
 		/* Count number of active connections */
 		int nc = 0;
 		for list_each(connection_t, c, connection_list) {
-			if(c->status.active && !c->status.control)
+			if(c->edge)
 				nc++;
 		}
 
@@ -251,7 +249,7 @@ static void periodic_handler(void *data) {
 			int i = 0;
 
 			for list_each(connection_t, c, connection_list) {
-				if(!c->status.active || c->status.control)
+				if(!c->edge)
 					continue;
 
 				if(i++ != r)
@@ -263,7 +261,7 @@ static void periodic_handler(void *data) {
 				logger(DEBUG_CONNECTIONS, LOG_INFO, "Autodisconnecting from %s", c->name);
 				list_delete(outgoing_list, c->outgoing);
 				c->outgoing = NULL;
-				terminate_connection(c, c->status.active);
+				terminate_connection(c, c->edge);
 				break;
 			}
 		}
@@ -293,7 +291,7 @@ static void periodic_handler(void *data) {
 
 void handle_meta_connection_data(connection_t *c) {
 	if (!receive_meta(c)) {
-		terminate_connection(c, c->status.active);
+		terminate_connection(c, c->edge);
 		return;
 	}
 }
@@ -418,7 +416,7 @@ int reload_configuration(void) {
 		struct stat s;
 		if(stat(fname, &s) || s.st_mtime > last_config_check) {
 			logger(DEBUG_CONNECTIONS, LOG_INFO, "Host config file of %s has been changed", c->name);
-			terminate_connection(c, c->status.active);
+			terminate_connection(c, c->edge);
 		}
 		free(fname);
 	}

--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -937,7 +937,7 @@ void broadcast_packet(const node_t *from, vpn_packet_t *packet) {
 		// usually distributes the sending of broadcast packets over all nodes.
 		case BMODE_MST:
 			for list_each(connection_t, c, connection_list)
-				if(c->status.active && c->status.mst && c != from->nexthop->connection)
+				if(c->edge && c->status.mst && c != from->nexthop->connection)
 					send_packet(c->node, packet);
 			break;
 

--- a/src/net_socket.c
+++ b/src/net_socket.c
@@ -388,7 +388,7 @@ static void handle_meta_write(connection_t *c) {
 			logger(DEBUG_CONNECTIONS, LOG_ERR, "Could not send %d bytes of data to %s (%s): %s", c->outbuf.len - c->outbuf.offset, c->name, c->hostname, sockstrerror(sockerrno));
 		}
 
-		terminate_connection(c, c->status.active);
+		terminate_connection(c, c->edge);
 		return;
 	}
 
@@ -820,7 +820,7 @@ void try_outgoing_connections(void) {
 		if(c->outgoing && c->outgoing->timeout == -1) {
 			c->outgoing = NULL;
 			logger(DEBUG_CONNECTIONS, LOG_INFO, "No more outgoing connection to %s", c->name);
-			terminate_connection(c, c->status.active);
+			terminate_connection(c, c->edge);
 		}
 	}
 

--- a/src/protocol_auth.c
+++ b/src/protocol_auth.c
@@ -805,7 +805,6 @@ bool ack_h(connection_t *c, const char *request) {
 	/* Activate this connection */
 
 	c->allow_request = ALL;
-	c->status.active = true;
 
 	logger(DEBUG_CONNECTIONS, LOG_NOTICE, "Connection with %s (%s) activated", c->name,
 			   c->hostname);

--- a/src/protocol_key.c
+++ b/src/protocol_key.c
@@ -41,7 +41,7 @@ void send_key_changed(void) {
 	/* Immediately send new keys to directly connected nodes to keep UDP mappings alive */
 
 	for list_each(connection_t, c, connection_list)
-		if(c->status.active && c->node && c->node->status.reachable && !c->node->status.sptps)
+		if(c->edge && c->node && c->node->status.reachable && !c->node->status.sptps)
 			send_ans_key(c->node);
 
 	/* Force key exchange for connections using SPTPS */

--- a/src/route.c
+++ b/src/route.c
@@ -203,7 +203,7 @@ static void age_subnets(void *data) {
 			}
 
 			for list_each(connection_t, c, connection_list)
-				if(c->status.active)
+				if(c->edge)
 					send_del_subnet(c, s);
 
 			subnet_del(myself, s);
@@ -238,7 +238,7 @@ static void learn_mac(mac_t *address) {
 		/* And tell all other tinc daemons it's our MAC */
 
 		for list_each(connection_t, c, connection_list)
-			if(c->status.active)
+			if(c->edge)
 				send_add_subnet(c, subnet);
 
 		timeout_add(&age_subnets_timeout, age_subnets, NULL, &(struct timeval){10, rand() % 100000});


### PR DESCRIPTION
The only places where `connection_t::status.active` is modified is in `ack_h()` and `terminate_connection()`. In both cases, `connection_t::edge` is added and removed at the same time, and that's the only places `connection_t::edge` is set. Therefore, the following is true at all times:

```
!c->status.active == !c->edge
```

This commit removes the redundant state information by getting rid of `connection_t::status.active`, and using `connection_t::edge` instead.
