### PR TITLE
Check if devops is valid before closing the device

### DIFF
--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -1141,7 +1141,8 @@ void close_network_connections(void) {
 
 	if (device_fd >= 0)
 		io_del(&device_io);
-	devops.close();
+	if (devops.close)
+		devops.close();
 
 	exit_control();
 


### PR DESCRIPTION
This fixes a segfault that occurs on exit if tinc fails before the device is initialized (for example, if it fails to read the private key).
