### PR TITLE
Fix undefined HOST_NAME_MAX on Windows

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -191,6 +191,11 @@ bool check_id(const char *id) {
 	return true;
 }
 
+/* Windows doesn't define HOST_NAME_MAX. */
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX 255
+#endif
+
 char *replace_name(const char *name) {
 	char *ret_name;
 


### PR DESCRIPTION
The Windows build was broken by commit 826ad11e419db90b66b3f76a90b54df021bb39fc (by @wkennington) which introduced a dependency on the `HOST_NAME_MAX` macro, which is not defined on Windows. According to MSDN for `gethostname()`, the maximum length of the returned string is 256 bytes (including the terminating null byte), so let's use that as a fallback.
