### PR TITLE
Don't enable the device if the reachable count is zero

### DIFF
--- a/src/graph.c
+++ b/src/graph.c
@@ -292,7 +292,7 @@ static void check_reachability(void) {
 	if (device_standby) {
 		if (reachable_count == 0 && became_unreachable_count > 0)
 			device_disable();
-		else if (reachable_count == became_reachable_count)
+		else if (reachable_count > 0 && reachable_count == became_reachable_count)
 			device_enable();
 	}
 }


### PR DESCRIPTION
A logic bug was introduced in bd451cfe1512fa69eac35a60dbe6df17bfc39154 in which running `graph()` several times with zero reachable nodes had the effect of calling `device_enable()` (instead of keeping the device disabled).

This results in weird behavior when `DeviceStandby` is enabled, especially on Windows where calling `device_enable()` several times in a row corrupts I/O structures for the device, rendering it unusable.
