### PR TITLE
Fix wrong identifier in SO_NOSIGPIPE call

### DIFF
--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -763,7 +763,7 @@ bool connect_tincd(bool verbose) {
 
 #ifdef SO_NOSIGPIPE
 	static const int one = 1;
-	setsockopt(c, SOL_SOCKET, SO_NOSIGPIPE, (void *)&one, sizeof one);
+	setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, (void *)&one, sizeof one);
 #endif
 
 	char data[4096];


### PR DESCRIPTION
f134bd0c9c2213fbbb3967f3d784759cb65e2c76 broke the Mac OS X build by introducing a reference to an identifier, `c`, that doesn't exist.
