### PR TITLE
tinc-gui: Use /usr/bin/env to resolve path to python

### DIFF
--- a/gui/tinc-gui
+++ b/gui/tinc-gui
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # tinc-gui -- GUI for controlling a running tincd
 # Copyright (C) 2009-2014 Guus Sliepen <guus@tinc-vpn.org>


### PR DESCRIPTION
This fixes `tinc-gui` for distributions where `python` is not in `/usr/bin`, e.g. on NixOS.
