### PR TITLE
Fix protocol version check for type 2 MTU probe replies

### DIFF
--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -182,7 +182,7 @@ static void mtu_probe_h(node_t *n, vpn_packet_t *packet, length_t len) {
 		/* It's a probe request, send back a reply */
 
 		/* Type 2 probe replies were introduced in protocol 17.3 */
-		if ((n->options >> 24) == 3) {
+		if ((n->options >> 24) >= 3) {
 			uint8_t* data = packet->data;
 			*data++ = 2;
 			uint16_t len16 = htons(len); memcpy(data, &len16, 2); data += 2;


### PR DESCRIPTION
Currently tinc only uses type 2 MTU probe replies if the recipient uses protocol version 17.3. It should of course support any higher minor protocol version as well.
