### PR TITLE
Query the Linux device for its MAC address

### DIFF
--- a/src/linux/device.c
+++ b/src/linux/device.c
@@ -105,6 +105,14 @@ static bool setup_device(void) {
 
 	logger(DEBUG_ALWAYS, LOG_INFO, "%s is a %s", device, device_info);
 
+	if(ifr.ifr_flags & IFF_TAP) {
+		struct ifreq ifr_mac;
+		if(!ioctl(device_fd, SIOCGIFHWADDR, &ifr_mac))
+			memcpy(mymac.x, ifr_mac.ifr_hwaddr.sa_data, ETH_ALEN);
+		else
+			logger(DEBUG_ALWAYS, LOG_WARNING, "Could not get MAC address of %s: %s", device, strerror(errno));
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
On Linux, tinc doesn't know the MAC address of the TAP device until the first read. This means that if no packets are sent through the interface, tinc won't be able to figure out which MAC address to tag incoming packets with. As a result, it is impossible to receive any packet until at least one packet has been sent.

When IPv6 is disabled Linux does not spontaneously send any packets when the interface comes up. At first users wonder why the node is not responding to ICMP pings, and then as soon as at least one packet is sent through the interface, pings mysteriously start working, resulting in user confusion.

This change fixes that problem by making sure tinc is aware of the device's MAC address even before the first packet is sent.
