### PR TITLE
Fixes compile failure when setting "--disable-legacy-protocol"

### DIFF
--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -958,6 +958,7 @@ static length_t choose_initial_maxmtu(node_t *n) {
 		mtu -= SPTPS_DATAGRAM_OVERHEAD;
 		if((n->options >> 24) >= 4)
 			mtu -= sizeof(node_id_t) + sizeof(node_id_t);
+#ifndef DISABLE_LEGACY
 	} else {
 		mtu -= digest_length(n->outdigest);
 
@@ -977,6 +978,7 @@ static length_t choose_initial_maxmtu(node_t *n) {
 		}
 
 		mtu -= 4; // seqno
+#endif
 	}
 
 	if (mtu < 512) {


### PR DESCRIPTION
Compiling with `--disable-legacy-protocol` resulted in failure caused by the missing exclusion of some symbols in net_packet.c.