### PR TITLE
Fix UDP SPTPS relaying regressions

### DIFF
--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -1396,6 +1396,7 @@ skip_harder:
 
 		if(to != myself) {
 			send_sptps_data_priv(to, n, 0, DATA(&pkt), pkt.len - 2 * sizeof(node_id_t));
+			try_tx_sptps(n, true);
 			return;
 		}
 	} else {


### PR DESCRIPTION
This branch fixes a couple of regressions that were introduced among the numerous code changes that happened since SPTPS relaying was introduced. These regressions could result in packets being sent over TCP instead of UDP.