### PR TITLE
Add a new --syslog option for tincd.

### DIFF
--- a/doc/tincd.8.in
+++ b/doc/tincd.8.in
@@ -8,7 +8,7 @@
 .Nd tinc VPN daemon
 .Sh SYNOPSIS
 .Nm
-.Op Fl cdDKnoLRU
+.Op Fl cdDKnsoLRU
 .Op Fl -config Ns = Ns Ar DIR
 .Op Fl -no-detach
 .Op Fl -debug Ns Op = Ns Ar LEVEL
@@ -16,6 +16,7 @@
 .Op Fl -option Ns = Ns Ar [HOST.]KEY=VALUE
 .Op Fl -mlock
 .Op Fl -logfile Ns Op = Ns Ar FILE
+.Op Fl -syslog
 .Op Fl -bypass-security
 .Op Fl -chroot
 .Op Fl -user Ns = Ns Ar USER
@@ -88,6 +89,8 @@ If
 .Ar FILE
 is omitted, the default is
 .Pa @localstatedir@/log/tinc. Ns Ar NETNAME Ns Pa .log.
+.It Fl s, -syslog
+When this option is is set, tinc uses syslog instead of stderr in --no-detach mode.
 .It Fl -pidfile Ns = Ns Ar FILENAME
 Store a cookie in
 .Ar FILENAME

--- a/src/process.c
+++ b/src/process.c
@@ -41,6 +41,7 @@ bool sigalrm = false;
 
 extern char **g_argv;
 extern bool use_logfile;
+extern bool use_syslog;
 
 /* Some functions the less gifted operating systems might lack... */
 
@@ -185,6 +186,8 @@ bool init_service(void) {
   Detach from current terminal
 */
 bool detach(void) {
+	logmode_t logmode;
+
 #ifndef HAVE_MINGW
 	signal(SIGPIPE, SIG_IGN);
 	signal(SIGUSR1, SIG_IGN);
@@ -206,12 +209,13 @@ bool detach(void) {
 #endif
 	}
 
-	openlogger(identname, use_logfile?LOGMODE_FILE:(do_detach?LOGMODE_SYSLOG:LOGMODE_STDERR));
+	logmode = use_logfile?LOGMODE_FILE:LOGMODE_SYSLOG;
+	if(do_detach && !use_syslog)
+		logmode = LOGMODE_STDERR;
+	openlogger(identname, logmode);
 
 	logger(DEBUG_ALWAYS, LOG_NOTICE, "tincd %s (%s %s) starting, debug level %d",
 			   VERSION, __DATE__, __TIME__, debug_level);
 
 	return true;
 }
-
-

--- a/src/tincd.c
+++ b/src/tincd.c
@@ -83,6 +83,9 @@ static const char *switchuser = NULL;
 /* If nonzero, write log entries to a separate file. */
 bool use_logfile = false;
 
+/* If nonzero, use syslog instead of stderr in no-detach mode. */
+bool use_syslog = false;
+
 char **g_argv;                  /* a copy of the cmdline arguments */
 
 static int status = 1;
@@ -99,6 +102,7 @@ static struct option const long_options[] = {
 	{"chroot", no_argument, NULL, 'R'},
 	{"user", required_argument, NULL, 'U'},
 	{"logfile", optional_argument, NULL, 4},
+	{"syslog", no_argument, NULL, 's'},
 	{"pidfile", required_argument, NULL, 5},
 	{"option", required_argument, NULL, 'o'},
 	{NULL, 0, NULL, 0}
@@ -124,6 +128,7 @@ static void usage(bool status) {
 				"  -L, --mlock                   Lock tinc into main memory.\n"
 #endif
 				"      --logfile[=FILENAME]      Write log entries to a logfile.\n"
+				"  -s  --syslog                  Use syslog instead of stderr with --no-detach.\n"
 				"      --pidfile=FILENAME        Write PID and control socket cookie to FILENAME.\n"
 				"      --bypass-security         Disables meta protocol security, for debugging.\n"
 				"  -o, --option[HOST.]KEY=VALUE  Set global/host configuration value.\n"
@@ -145,7 +150,7 @@ static bool parse_options(int argc, char **argv) {
 
 	cmdline_conf = list_alloc((list_action_t)free_config);
 
-	while((r = getopt_long(argc, argv, "c:DLd::n:o:RU:", long_options, &option_index)) != EOF) {
+	while((r = getopt_long(argc, argv, "c:DLd::n:so:RU:", long_options, &option_index)) != EOF) {
 		switch (r) {
 			case 0:   /* long option */
 				break;
@@ -178,6 +183,10 @@ static bool parse_options(int argc, char **argv) {
 
 			case 'n': /* net name given */
 				netname = xstrdup(optarg);
+				break;
+
+			case 's': /* syslog */
+				use_syslog = true;
 				break;
 
 			case 'o': /* option */


### PR DESCRIPTION
This commit adds a new command line option for tincd which allows to
use tincd in non-detached mode with log messages still going to
syslog.  The motivation for this change is to ease use of tincd
in Docker containers.