### PR TITLE
Don't send UDP probes past static relays

### DIFF
--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -1137,7 +1137,7 @@ static void try_tx_sptps(node_t *n, bool mtu) {
 	/* If we do have a static relay, try everything with that one instead. */
 
 	if(via != n)
-		try_tx_sptps(via, mtu);
+		return try_tx_sptps(via, mtu);
 
 	/* Otherwise, try to establish UDP connectivity. */
 


### PR DESCRIPTION
Ironically, commit 0f8e2cc78cafe47a087d3fc9b480551b841aeb30 introduced a regression on its own, since it accidently removed a return statement that prevented `try_tx_sptps()` from sending UDP/MTU probes to nodes that are past static relays.