### PR TITLE
Improve tinc defaults for maximum performance

### DIFF
--- a/doc/tinc.conf.5.in
+++ b/doc/tinc.conf.5.in
@@ -500,12 +500,14 @@ The minimum amount of time between sending UDP ping datagrams to try to establis
 .It Va UDPDiscoveryTimeout Li = Ar seconds Pq 30
 If tinc doesn't receive any UDP ping replies over the specified interval,
 it will assume UDP communication is broken and will fall back to TCP.
-.It Va UDPRcvBuf Li = Ar bytes Pq OS default
+.It Va UDPRcvBuf Li = Ar bytes Pq 1048576
 Sets the socket receive buffer size for the UDP socket, in bytes.
-If unset, the default buffer size will be used by the operating system.
-.It Va UDPSndBuf Li = Ar bytes Pq OS default
+If set to zero, the default buffer size will be used by the operating system.
+Note: this setting can have a significant impact on performance, especially raw throughput.
+.It Va UDPSndBuf Li = Ar bytes Pq 1048576
 Sets the socket send buffer size for the UDP socket, in bytes.
-If unset, the default buffer size will be used by the operating system.
+If set to zero, the default buffer size will be used by the operating system.
+Note: this setting can have a significant impact on performance, especially raw throughput.
 .El
 .Sh HOST CONFIGURATION FILES
 The host configuration files contain all information needed

--- a/doc/tinc.conf.5.in
+++ b/doc/tinc.conf.5.in
@@ -464,10 +464,10 @@ and
 .Ev REMOTEPORT
 are available.
 .El
-.It Va ReplayWindow Li = Ar bytes Pq 16
+.It Va ReplayWindow Li = Ar bytes Pq 32
 This is the size of the replay tracking window for each remote node, in bytes.
 The window is a bitfield which tracks 1 packet per bit, so for example
-the default setting of 16 will track up to 128 packets in the window. In high
+the default setting of 32 will track up to 256 packets in the window. In high
 bandwidth scenarios, setting this to a higher value can reduce packet loss from
 the interaction of replay tracking with underlying real packet loss and/or
 reordering. Setting this to zero will disable replay tracking completely and

--- a/doc/tinc.texi
+++ b/doc/tinc.texi
@@ -1254,14 +1254,16 @@ If tinc doesn't receive any UDP ping replies over the specified interval,
 it will assume UDP communication is broken and will fall back to TCP.
 
 @cindex UDPRcvBuf
-@item UDPRcvBuf = <bytes> (OS default)
+@item UDPRcvBuf = <bytes> (1048576)
 Sets the socket receive buffer size for the UDP socket, in bytes.
-If unset, the default buffer size will be used by the operating system.
+If set to zero, the default buffer size will be used by the operating system.
+Note: this setting can have a significant impact on performance, especially raw throughput.
 
 @cindex UDPSndBuf
-@item UDPSndBuf = <bytes> Pq OS default
+@item UDPSndBuf = <bytes> (1048576)
 Sets the socket send buffer size for the UDP socket, in bytes.
-If unset, the default buffer size will be used by the operating system.
+If set to zero, the default buffer size will be used by the operating system.
+Note: this setting can have a significant impact on performance, especially raw throughput.
 
 @end table
 

--- a/doc/tinc.texi
+++ b/doc/tinc.texi
@@ -1207,10 +1207,10 @@ The environment variables @env{NAME}, @env{NODE}, @env{REMOTEADDRES} and @env{RE
 @end table
 
 @cindex ReplayWindow
-@item ReplayWindow = <bytes> (16)
+@item ReplayWindow = <bytes> (32)
 This is the size of the replay tracking window for each remote node, in bytes.
 The window is a bitfield which tracks 1 packet per bit, so for example
-the default setting of 16 will track up to 128 packets in the window. In high
+the default setting of 32 will track up to 256 packets in the window. In high
 bandwidth scenarios, setting this to a higher value can reduce packet loss from
 the interaction of replay tracking with underlying real packet loss and/or
 reordering. Setting this to zero will disable replay tracking completely and

--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -64,7 +64,7 @@ static char lzo_wrkmem[LZO1X_999_MEM_COMPRESS > LZO1X_1_MEM_COMPRESS ? LZO1X_999
 
 static void send_udppacket(node_t *, vpn_packet_t *);
 
-unsigned replaywin = 16;
+unsigned replaywin = 32;
 bool localdiscovery = true;
 bool udp_discovery = true;
 int udp_discovery_keepalive_interval = 10;

--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -854,14 +854,14 @@ static bool setup_myself(void) {
 	}
 
 	if(get_config_int(lookup_config(config_tree, "UDPRcvBuf"), &udp_rcvbuf)) {
-		if(udp_rcvbuf <= 0) {
+		if(udp_rcvbuf < 0) {
 			logger(DEBUG_ALWAYS, LOG_ERR, "UDPRcvBuf cannot be negative!");
 			return false;
 		}
 	}
 
 	if(get_config_int(lookup_config(config_tree, "UDPSndBuf"), &udp_sndbuf)) {
-		if(udp_sndbuf <= 0) {
+		if(udp_sndbuf < 0) {
 			logger(DEBUG_ALWAYS, LOG_ERR, "UDPSndBuf cannot be negative!");
 			return false;
 		}

--- a/src/net_socket.c
+++ b/src/net_socket.c
@@ -43,8 +43,8 @@
 int addressfamily = AF_UNSPEC;
 int maxtimeout = 900;
 int seconds_till_retry = 5;
-int udp_rcvbuf = 0;
-int udp_sndbuf = 0;
+int udp_rcvbuf = 1024 * 1024;
+int udp_sndbuf = 1024 * 1024;
 int max_connection_burst = 100;
 
 listen_socket_t listen_socket[MAXSOCKETS];


### PR DESCRIPTION
These commits improve some defaults for tinc configuration options in order to obtain optimal performance on high-speed links. Details can be found in the individual commits.