### PR TITLE
tinc-1.1 better RTT estimated weight computation.

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -99,7 +99,7 @@ typedef struct connection_t {
 	int tcplen;                     /* length of incoming TCPpacket */
 	int allow_request;              /* defined if there's only one request possible */
 
-	time_t last_ping_time;          /* last time we saw some activity from the other end or pinged them */
+	struct timeval last_ping_time;  /* last time we saw some activity from the other end or pinged them */
 
 	splay_tree_t *config_tree;      /* Pointer to configuration tree belonging to him */
 } connection_t;

--- a/src/net.c
+++ b/src/net.c
@@ -148,12 +148,12 @@ static void timeout_handler(void *data) {
 		if(c->status.control)
 			continue;
 
-		if(c->last_ping_time + pingtimeout <= now.tv_sec) {
+		if(c->last_ping_time.tv_sec + pingtimeout <= now.tv_sec) {
 			if(c->edge) {
 				try_tx(c->node, false);
 				if(c->status.pinged) {
-					logger(DEBUG_CONNECTIONS, LOG_INFO, "%s (%s) didn't respond to PING in %ld seconds", c->name, c->hostname, (long)now.tv_sec - c->last_ping_time);
-				} else if(c->last_ping_time + pinginterval <= now.tv_sec) {
+					logger(DEBUG_CONNECTIONS, LOG_INFO, "%s (%s) didn't respond to PING in %ld seconds", c->name, c->hostname, (long)now.tv_sec - c->last_ping_time.tv_sec);
+				} else if(c->last_ping_time.tv_sec + pinginterval <= now.tv_sec) {
 					send_ping(c);
 					continue;
 				} else {
@@ -432,7 +432,8 @@ void retry(void) {
 	/* Check for outgoing connections that are in progress, and reset their ping timers */
 	for list_each(connection_t, c, connection_list) {
 		if(c->outgoing && !c->node)
-			c->last_ping_time = 0;
+			c->last_ping_time.tv_sec = 0;
+			c->last_ping_time.tv_usec = 0;
 	}
 
 	/* Kick the ping timeout handler */

--- a/src/net_socket.c
+++ b/src/net_socket.c
@@ -319,7 +319,7 @@ void retry_outgoing(outgoing_t *outgoing) {
 void finish_connecting(connection_t *c) {
 	logger(DEBUG_CONNECTIONS, LOG_INFO, "Connected to %s (%s)", c->name, c->hostname);
 
-	c->last_ping_time = now.tv_sec;
+	c->last_ping_time = now;
 	c->status.connecting = false;
 
 	send_id(c);
@@ -555,7 +555,7 @@ begin:
 #endif
 	c->outmaclength = myself->connection->outmaclength;
 	c->outcompression = myself->connection->outcompression;
-	c->last_ping_time = now.tv_sec;
+	c->last_ping_time = now;
 
 	connection_add(c);
 
@@ -708,7 +708,7 @@ void handle_new_meta_connection(void *data, int flags) {
 	c->address = sa;
 	c->hostname = sockaddr2hostname(&sa);
 	c->socket = fd;
-	c->last_ping_time = now.tv_sec;
+	c->last_ping_time = now;
 
 	logger(DEBUG_CONNECTIONS, LOG_NOTICE, "Connection from %s", c->hostname);
 
@@ -747,7 +747,7 @@ void handle_new_unix_connection(void *data, int flags) {
 	c->address = sa;
 	c->hostname = xstrdup("localhost port unix");
 	c->socket = fd;
-	c->last_ping_time = now.tv_sec;
+	c->last_ping_time = now;
 
 	logger(DEBUG_CONNECTIONS, LOG_NOTICE, "Connection from %s", c->hostname);
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -85,6 +85,7 @@ extern bool receive_request(struct connection_t *, const char *);
 extern void init_requests(void);
 extern void exit_requests(void);
 extern bool seen_request(const char *);
+extern void update_estimated_weight(connection_t *);
 
 /* Requests */
 

--- a/src/protocol_auth.c
+++ b/src/protocol_auth.c
@@ -295,7 +295,8 @@ bool id_h(connection_t *c, const char *request) {
 	if(name[0] == '^' && !strcmp(name + 1, controlcookie)) {
 		c->status.control = true;
 		c->allow_request = CONTROL;
-		c->last_ping_time = now.tv_sec + 3600;
+		c->last_ping_time = now;
+		c->last_ping_time.tv_sec += 3600;
 
 		free(c->name);
 		c->name = xstrdup("<control>");

--- a/src/protocol_auth.c
+++ b/src/protocol_auth.c
@@ -136,9 +136,9 @@ static bool send_proxyrequest(connection_t *c) {
 }
 
 bool send_id(connection_t *c) {
-	gettimeofday(&c->start, NULL);
 
 	int minor = 0;
+        logger(DEBUG_SCARY_THINGS, LOG_DEBUG, "%s:%d:%s: peer: %s (%s)", __FILE__, __LINE__, __func__, c->name, c->hostname);
 
 	if(experimental) {
 		if(c->outgoing && !read_ecdsa_public_key(c))
@@ -147,6 +147,7 @@ bool send_id(connection_t *c) {
 			minor = myself->connection->protocol_minor;
 	}
 
+	gettimeofday(&c->start, NULL);
 	if(proxytype && c->outgoing)
 		if(!send_proxyrequest(c))
 			return false;
@@ -284,6 +285,7 @@ static bool receive_invitation_sptps(void *handle, uint8_t type, const void *dat
 bool id_h(connection_t *c, const char *request) {
 	char name[MAX_STRING_SIZE];
 
+        logger(DEBUG_SCARY_THINGS, LOG_DEBUG, "%s:%d:%s: peer: %s (%s)", __FILE__, __LINE__, __func__, c->name, c->hostname);
 	if(sscanf(request, "%*d " MAX_STRING " %d.%d", name, &c->protocol_major, &c->protocol_minor) < 2) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Got bad %s from %s (%s)", "ID", c->name,
 			   c->hostname);
@@ -303,6 +305,8 @@ bool id_h(connection_t *c, const char *request) {
 
 		return send_request(c, "%d %d %d", ACK, TINC_CTL_VERSION_CURRENT, getpid());
 	}
+
+        update_estimated_weight(c);
 
 	if(name[0] == '?') {
 		if(!invitation_key) {
@@ -414,6 +418,7 @@ bool send_metakey(connection_t *c) {
 #ifdef DISABLE_LEGACY
 	return false;
 #else
+        logger(DEBUG_SCARY_THINGS, LOG_DEBUG, "%s:%d:%s: peer: %s (%s)", __FILE__, __LINE__, __func__, c->name, c->hostname);
 	if(!myself->connection->rsa) {
 		logger(DEBUG_CONNECTIONS, LOG_ERR, "Peer %s (%s) uses legacy protocol which we don't support", c->name, c->hostname);
 		return false;
@@ -489,8 +494,11 @@ bool metakey_h(connection_t *c, const char *request) {
 #ifdef DISABLE_LEGACY
 	return false;
 #else
+        logger(DEBUG_SCARY_THINGS, LOG_DEBUG, "%s:%d:%s: peer: %s (%s)", __FILE__, __LINE__, __func__, c->name, c->hostname);
 	if(!myself->connection->rsa)
 		return false;
+
+        update_estimated_weight(c);
 
 	char hexkey[MAX_STRING_SIZE];
 	int cipher, digest, maclength, compression;
@@ -558,6 +566,7 @@ bool send_challenge(connection_t *c) {
 #ifdef DISABLE_LEGACY
 	return false;
 #else
+        logger(DEBUG_SCARY_THINGS, LOG_DEBUG, "%s:%d:%s: peer: %s (%s)", __FILE__, __LINE__, __func__, c->name, c->hostname);
 	const size_t len = rsa_size(c->rsa);
 	char buffer[len * 2 + 1];
 
@@ -582,6 +591,7 @@ bool challenge_h(connection_t *c, const char *request) {
 #ifdef DISABLE_LEGACY
 	return false;
 #else
+        logger(DEBUG_SCARY_THINGS, LOG_DEBUG, "%s:%d:%s: peer: %s (%s)", __FILE__, __LINE__, __func__, c->name, c->hostname);
 	if(!myself->connection->rsa)
 		return false;
 
@@ -627,7 +637,10 @@ bool chal_reply_h(connection_t *c, const char *request) {
 #ifdef DISABLE_LEGACY
 	return false;
 #else
+        logger(DEBUG_SCARY_THINGS, LOG_DEBUG, "%s:%d:%s: peer: %s (%s)", __FILE__, __LINE__, __func__, c->name, c->hostname);
 	char hishash[MAX_STRING_SIZE];
+
+        update_estimated_weight(c);
 
 	if(sscanf(request, "%*d " MAX_STRING, hishash) != 1) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Got bad %s from %s (%s)", "CHAL_REPLY", c->name,
@@ -684,22 +697,42 @@ static bool send_upgrade(connection_t *c) {
 #endif
 }
 
+void update_estimated_weight(connection_t *c) {
+        /* Estimate weight */
+        struct timeval now;
+        int temp_ew = 0;
+
+        if (c->status.control == true)
+          return;
+
+        gettimeofday(&now, NULL);
+
+        temp_ew = (now.tv_sec - c->start.tv_sec) * 1000 + (now.tv_usec - c->start.tv_usec) / 1000;
+        if (c->estimated_weight == 0) {
+          c->estimated_weight = temp_ew;
+        }
+        else {
+          c->estimated_weight = (c->estimated_weight + temp_ew)/2;
+        }
+
+        logger(DEBUG_ALWAYS, LOG_INFO, "%s: Estimated weight for %s (%d) (%d-%d) (%d-%d) (%d).", __func__, c->name, c->estimated_weight,
+               now.tv_sec,c->start.tv_sec,now.tv_usec,c->start.tv_usec, temp_ew);
+}
+
 bool send_ack(connection_t *c) {
+
 	if(c->protocol_minor == 1)
 		return send_upgrade(c);
+
+        logger(DEBUG_SCARY_THINGS, LOG_DEBUG, "%s:%d:%s: peer: %s (%s)", __FILE__, __LINE__, __func__, c->name, c->hostname);
 
 	/* ACK message contains rest of the information the other end needs
 	   to create node_t and edge_t structures. */
 
-	struct timeval now;
 	bool choice;
-
-	/* Estimate weight */
-
-	gettimeofday(&now, NULL);
-	c->estimated_weight = (now.tv_sec - c->start.tv_sec) * 1000 + (now.tv_usec - c->start.tv_usec) / 1000;
-
 	/* Check some options */
+
+        update_estimated_weight(c);
 
 	if((get_config_bool(lookup_config(c->config_tree, "IndirectData"), &choice) && choice) || myself->options & OPTION_INDIRECT)
 		c->options |= OPTION_INDIRECT;
@@ -723,7 +756,7 @@ bool send_ack(connection_t *c) {
 
 static void send_everything(connection_t *c) {
 	/* Send all known subnets and edges */
-
+        logger(DEBUG_SCARY_THINGS, LOG_DEBUG, "%s:%d:%s: peer: %s (%s)", __FILE__, __LINE__, __func__, c->name, c->hostname);
 	if(disablebuggypeers) {
 		static struct {
 			vpn_packet_t pkt;

--- a/src/protocol_misc.c
+++ b/src/protocol_misc.c
@@ -89,7 +89,7 @@ bool termreq_h(connection_t *c, const char *request) {
 
 bool send_ping(connection_t *c) {
 	c->status.pinged = true;
-	c->last_ping_time = now.tv_sec;
+	c->last_ping_time = now;
 
 	return send_request(c, "%d", PING);
 }


### PR DESCRIPTION
I have this problem:
Node A - slow CPU/embedded device
Node D - laptop/"road warrior"

while connecting to D on LAN the estimated wieght was ~2000. I can connect to this node via direct connection which is OK and the RTT ~1ms. But the tool which generates a network graph shows the edge between A and D as very slow - which is not fully true. With this patch we compute c->estimated_weight few times taking the average.

Better solution would be to have the last timestamp of the protocol internal communication.