### PR TITLE
Fix for partial keyexchange using EC - send_ans_key()

### DIFF
--- a/src/protocol_key.c
+++ b/src/protocol_key.c
@@ -263,7 +263,7 @@ bool req_key_h(connection_t *c, const char *request) {
 }
 
 bool send_ans_key(node_t *to) {
-	if(to->status.sptps)
+	if(to->status.sptps && to->status.validkey_in)
 		abort();
 
 #ifdef DISABLE_LEGACY


### PR DESCRIPTION
In some cases the remote host does not know our key yet but we have got theirs.
So we send him our key but send_ans_key() aborted on this point.