### PR TITLE
Add support for out-of-tree ("VPATH") builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,13 +11,13 @@ EXTRA_DIST = COPYING.README README.android
 # If git describe works, force autoconf to run in order to make sure we have the
 # current version number from git in the resulting configure script.
 configure-version:
-	-git describe && autoconf --force
+	-cd $(srcdir) && git describe && autoconf --force
 
 # Triggering the README target means we are building a distribution (make dist).
 README: configure-version
 
 ChangeLog:
-	git log > ChangeLog
+	(cd $(srcdir) && git log) > ChangeLog
 
 deb:
 	dpkg-buildpackage -rfakeroot
@@ -31,5 +31,5 @@ release:
 	rm -f ChangeLog
 	$(MAKE) ChangeLog
 	echo "Please edit the NEWS file now..."
-	/usr/bin/editor NEWS
+	/usr/bin/editor $(srcdir)/NEWS
 	$(MAKE) dist

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@
 
 AUTOMAKE_OPTIONS = gnu
 
-SUBDIRS =  m4 src doc gui test
+SUBDIRS =  src doc gui test
 
 ACLOCAL_AMFLAGS = -I m4 
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ(2.61)
 AC_INIT([tinc], m4_esyscmd_s((git describe || echo UNKNOWN) | sed 's/release-//'))
 AC_CONFIG_SRCDIR([src/tincd.c])
 AC_GNU_SOURCE
-AM_INIT_AUTOMAKE([std-options subdir-objects -Wall])
+AM_INIT_AUTOMAKE([info-in-builddir std-options subdir-objects -Wall])
 AC_CONFIG_HEADERS([config.h])
 
 # Enable GNU extensions.
@@ -161,13 +161,13 @@ dnl We do this in multiple stages, because unlike Linux all the other operating 
 AC_HEADER_STDC
 AC_CHECK_HEADERS([stdbool.h syslog.h sys/file.h sys/ioctl.h sys/mman.h sys/param.h sys/resource.h sys/socket.h sys/time.h sys/uio.h sys/un.h sys/wait.h netdb.h arpa/inet.h dirent.h])
 AC_CHECK_HEADERS([net/if.h net/if_types.h linux/if_tun.h net/if_tun.h net/tun/if_tun.h net/if_tap.h net/tap/if_tap.h net/ethernet.h net/if_arp.h netinet/in_systm.h netinet/in.h netinet/in6.h time.h netpacket/packet.h],
-  [], [], [#include "src/have.h"]
+  [], [], [#include "$srcdir/src/have.h"]
 )
 AC_CHECK_HEADERS([netinet/if_ether.h netinet/ip.h netinet/ip6.h resolv.h],
-  [], [], [#include "src/have.h"]
+  [], [], [#include "$srcdir/src/have.h"]
 )
 AC_CHECK_HEADERS([netinet/tcp.h netinet/ip_icmp.h netinet/icmp6.h],
-  [], [], [#include "src/have.h"]
+  [], [], [#include "$srcdir/src/have.h"]
 )
 
 dnl Checks for typedefs, structures, and compiler characteristics.
@@ -182,13 +182,13 @@ tinc_ATTRIBUTE(__malloc__)
 tinc_ATTRIBUTE(__warn_unused_result__)
 
 AC_CHECK_TYPES([socklen_t, struct ether_header, struct arphdr, struct ether_arp, struct in_addr, struct addrinfo, struct ip, struct icmp, struct in6_addr, struct sockaddr_in6, struct ip6_hdr, struct icmp6_hdr, struct nd_neighbor_solicit, struct nd_opt_hdr], , ,
-  [#include "src/have.h"]
+  [#include "$srcdir/src/have.h"]
 )
 
 dnl Checks for library functions.
 AC_TYPE_SIGNAL
 AC_CHECK_FUNCS([asprintf daemon fchmod flock ftime fork get_current_dir_name gettimeofday mlockall putenv random select strdup strerror strsignal strtol system time usleep unsetenv vsyslog writev],
-  [], [], [#include "src/have.h"]
+  [], [], [#include "$srcdir/src/have.h"]
 )
 
 dnl Support for SunOS
@@ -201,7 +201,7 @@ AC_CHECK_FUNC(gethostbyname, [], [
 ])
 
 AC_CHECK_DECLS([freeaddrinfo, gai_strerror, getaddrinfo, getnameinfo],
-  [], [], [#include "src/have.h"]
+  [], [], [#include "$srcdir/src/have.h"]
 )
 
 AC_CHECK_DECLS([res_init], [AC_CHECK_LIB(resolv, res_init)], [], [

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,6 @@ AC_ARG_ENABLE(jumbograms,
   ]
 )
 
-AC_CONFIG_FILES([Makefile src/Makefile doc/Makefile m4/Makefile gui/Makefile test/Makefile])
+AC_CONFIG_FILES([Makefile src/Makefile doc/Makefile gui/Makefile test/Makefile])
 
 AC_OUTPUT

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -17,7 +17,7 @@ transform = s/ginstall/install/; @program_transform_name@
 # see GNUmakefile and Makefile.maint.
 
 sample-config.tar.gz: sample-config
-	GZIP=$(GZIP_ENV) $(AMTAR) chozf sample-config.tar.gz --exclude .svn sample-config
+	GZIP=$(GZIP_ENV) $(AMTAR) chozf $@ --exclude .svn $<
 
 tincd.8.html: tincd.8
 	w3mman2html $? > $@

--- a/m4/Makefile.am
+++ b/m4/Makefile.am
@@ -1,4 +1,0 @@
-## Process this file with automake to produce Makefile.in   -*-Makefile-*-
-
-EXTRA_DIST = README *.m4
-

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,11 +3,11 @@
 sbin_PROGRAMS = tincd tinc sptps_test sptps_keypair
 
 ## Make sure version.c is always rebuilt with the latest git information
-.PHONY: version.c version_git.h
+.PHONY: $(srcdir)/version.c version_git.h
 version_git.h:
 	echo >$@
-	-git describe && echo '#define GIT_DESCRIPTION "'`git describe | sed 's/release-//'`'"' >$@
-version.c: version_git.h
+	-(cd $(srcdir) && git describe) && echo '#define GIT_DESCRIPTION "'`(cd $(srcdir) && git describe) | sed 's/release-//'`'"' >$@
+$(srcdir)/version.c: version_git.h
 
 if LINUX
 sbin_PROGRAMS += sptps_speed
@@ -260,4 +260,4 @@ if TUNEMU
 LIBS += -lpcap
 endif
 
-AM_CFLAGS = -DCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DSBINDIR=\"$(sbindir)\"
+AM_CFLAGS = -DCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DSBINDIR=\"$(sbindir)\" -I.


### PR DESCRIPTION
This fixes some issues with the build system when building out of tree.

With these commits, it is now possible to do the following:
    
    $ cd /tmp/build
    $ /path/to/tinc/configure
    $ make