### PR TITLE
Improve SPTPS operation over TCP

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -97,6 +97,7 @@ typedef struct connection_t {
 	struct buffer_t outbuf;
 	io_t io;                        /* input/output event on this metadata connection */
 	int tcplen;                     /* length of incoming TCPpacket */
+	int sptpslen;			/* length of incoming SPTPS packet */
 	int allow_request;              /* defined if there's only one request possible */
 
 	time_t last_ping_time;          /* last time we saw some activity from the other end or pinged them */

--- a/src/meta.c
+++ b/src/meta.c
@@ -159,8 +159,14 @@ bool receive_meta(connection_t *c) {
 	}
 
 	do {
-		if(c->protocol_minor >= 2)
-			return sptps_receive_data(&c->sptps, bufp, inlen);
+		if(c->protocol_minor >= 2) {
+			int len = sptps_receive_data(&c->sptps, bufp, inlen);
+			if(!len)
+				return false;
+			bufp += len;
+			inlen -= len;
+			continue;
+		}
 
 		if(!c->status.decryptin) {
 			endp = memchr(bufp, '\n', inlen);

--- a/src/meta.h
+++ b/src/meta.h
@@ -24,6 +24,7 @@
 #include "connection.h"
 
 extern bool send_meta(struct connection_t *, const char *, int);
+extern void send_meta_raw(struct connection_t *, const char *, int);
 extern bool send_meta_sptps(void *, uint8_t, const void *, size_t);
 extern bool receive_meta_sptps(void *, uint8_t, const void *, uint16_t);
 extern void broadcast_meta(struct connection_t *, const char *, int);

--- a/src/net.h
+++ b/src/net.h
@@ -195,6 +195,7 @@ extern bool send_sptps_data(node_t *to, node_t *from, int type, const void *data
 extern bool receive_sptps_record(void *handle, uint8_t type, const void *data, uint16_t len);
 extern void send_packet(struct node_t *, vpn_packet_t *);
 extern void receive_tcppacket(struct connection_t *, const char *, int);
+extern bool receive_tcppacket_sptps(struct connection_t *, const char *, int);
 extern void broadcast_packet(const struct node_t *, vpn_packet_t *);
 extern char *get_name(void);
 extern void device_enable(void);

--- a/src/net.h
+++ b/src/net.h
@@ -191,7 +191,7 @@ extern void handle_new_meta_connection(void *, int);
 extern void handle_new_unix_connection(void *, int);
 extern int setup_listen_socket(const sockaddr_t *);
 extern int setup_vpn_in_socket(const sockaddr_t *);
-extern bool send_sptps_data(void *handle, uint8_t type, const void *data, size_t len);
+extern bool send_sptps_data(node_t *to, node_t *from, int type, const void *data, size_t len);
 extern bool receive_sptps_record(void *handle, uint8_t type, const void *data, uint16_t len);
 extern void send_packet(struct node_t *, vpn_packet_t *);
 extern void receive_tcppacket(struct connection_t *, const char *, int);

--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -698,7 +698,7 @@ bool send_sptps_data(node_t *to, node_t *from, int type, const void *data, size_
 			to->incompression = myself->incompression;
 			return send_request(to->nexthop->connection, "%d %s %s %s -1 -1 -1 %d", ANS_KEY, from->name, to->name, buf, to->incompression);
 		} else {
-			return send_request(to->nexthop->connection, "%d %s %s %d %s", REQ_KEY, from->name, to->name, REQ_SPTPS, buf);
+			return send_request(to->nexthop->connection, "%d %s %s %d %s", REQ_KEY, from->name, to->name, SPTPS_PACKET, buf);
 		}
 	}
 

--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -681,7 +681,7 @@ end:
 #endif
 }
 
-static bool send_sptps_data_priv(node_t *to, node_t *from, int type, const void *data, size_t len) {
+bool send_sptps_data(node_t *to, node_t *from, int type, const void *data, size_t len) {
 	node_t *relay = (to->via != myself && (type == PKT_PROBE || (len - SPTPS_DATAGRAM_OVERHEAD) <= to->via->minmtu)) ? to->via : to->nexthop;
 	bool direct = from == myself && to == relay;
 	bool relay_supported = (relay->options >> 24) >= 4;
@@ -742,10 +742,6 @@ static bool send_sptps_data_priv(node_t *to, node_t *from, int type, const void 
 	}
 
 	return true;
-}
-
-bool send_sptps_data(void *handle, uint8_t type, const void *data, size_t len) {
-	return send_sptps_data_priv(handle, myself, type, data, len);
 }
 
 bool receive_sptps_record(void *handle, uint8_t type, const void *data, uint16_t len) {
@@ -1404,7 +1400,7 @@ skip_harder:
 		/* If we're not the final recipient, relay the packet. */
 
 		if(to != myself) {
-			send_sptps_data_priv(to, from, 0, DATA(&pkt), pkt.len - 2 * sizeof(node_id_t));
+			send_sptps_data(to, from, 0, DATA(&pkt), pkt.len - 2 * sizeof(node_id_t));
 			try_tx_sptps(to, true);
 			return;
 		}

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -41,7 +41,8 @@ static bool (*request_handlers[])(connection_t *, const char *) = {
 		add_subnet_h, del_subnet_h,
 		add_edge_h, del_edge_h,
 		key_changed_h, req_key_h, ans_key_h, tcppacket_h, control_h,
-		NULL, NULL, NULL, /* Not "real" requests (yet) */
+		NULL, NULL, /* Not "real" requests (yet) */
+		sptps_tcppacket_h,
 		udp_info_h, mtu_info_h,
 };
 

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -53,7 +53,7 @@ static char (*request_name[]) = {
 		"PING", "PONG",
 		"ADD_SUBNET", "DEL_SUBNET",
 		"ADD_EDGE", "DEL_EDGE", "KEY_CHANGED", "REQ_KEY", "ANS_KEY", "PACKET", "CONTROL",
-		"REQ_PUBKEY", "ANS_PUBKEY", "REQ_SPTPS", "UDP_INFO", "MTU_INFO",
+		"REQ_PUBKEY", "ANS_PUBKEY", "SPTPS_PACKET", "UDP_INFO", "MTU_INFO",
 };
 
 static splay_tree_t *past_request_tree;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -48,7 +48,7 @@ typedef enum request_t {
 	/* Tinc 1.1 requests */
 	CONTROL,
 	REQ_PUBKEY, ANS_PUBKEY,
-	REQ_SPTPS,
+	SPTPS_PACKET,
 	UDP_INFO, MTU_INFO,
 	LAST                                            /* Guardian for the highest request number */
 } request_t;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -26,7 +26,7 @@
 /* Protocol version. Different major versions are incompatible. */
 
 #define PROT_MAJOR 17
-#define PROT_MINOR 6 /* Should not exceed 255! */
+#define PROT_MINOR 7 /* Should not exceed 255! */
 
 /* Silly Windows */
 
@@ -108,6 +108,7 @@ extern void send_key_changed(void);
 extern bool send_req_key(struct node_t *);
 extern bool send_ans_key(struct node_t *);
 extern bool send_tcppacket(struct connection_t *, const struct vpn_packet_t *);
+extern bool send_sptps_tcppacket(struct connection_t *, const char*, int);
 extern bool send_udp_info(struct node_t *, struct node_t *);
 extern bool send_mtu_info(struct node_t *, struct node_t *, int);
 
@@ -131,6 +132,7 @@ extern bool key_changed_h(struct connection_t *, const char *);
 extern bool req_key_h(struct connection_t *, const char *);
 extern bool ans_key_h(struct connection_t *, const char *);
 extern bool tcppacket_h(struct connection_t *, const char *);
+extern bool sptps_tcppacket_h(struct connection_t *, const char *);
 extern bool control_h(struct connection_t *, const char *);
 extern bool udp_info_h(struct connection_t *, const char *);
 extern bool mtu_info_h(struct connection_t *, const char *);

--- a/src/protocol_key.c
+++ b/src/protocol_key.c
@@ -129,16 +129,16 @@ static bool req_key_ext_h(connection_t *c, const char *request, node_t *from, no
 	/* If this is a SPTPS packet, see if sending UDP info helps.
 	   Note that we only do this if we're the destination or the static relay;
 	   otherwise every hop would initiate its own UDP info message, resulting in elevated chatter. */
-	if((reqno == REQ_KEY || reqno == REQ_SPTPS) && to->via == myself)
+	if((reqno == REQ_KEY || reqno == SPTPS_PACKET) && to->via == myself)
 		send_udp_info(myself, from);
 
-	if(reqno == REQ_SPTPS) {
+	if(reqno == SPTPS_PACKET) {
 		/* This is a SPTPS data packet. */
 
 		char buf[MAX_STRING_SIZE];
 		int len;
 		if(sscanf(request, "%*d %*s %*s %*d " MAX_STRING, buf) != 1 || !(len = b64decode(buf, buf, strlen(buf)))) {
-			logger(DEBUG_ALWAYS, LOG_ERR, "Got bad %s from %s (%s) to %s (%s): %s", "REQ_SPTPS", from->name, from->hostname, to->name, to->hostname, "invalid SPTPS data");
+			logger(DEBUG_ALWAYS, LOG_ERR, "Got bad %s from %s (%s) to %s (%s): %s", "SPTPS_PACKET", from->name, from->hostname, to->name, to->hostname, "invalid SPTPS data");
 			return true;
 		}
 
@@ -149,7 +149,7 @@ static bool req_key_ext_h(connection_t *c, const char *request, node_t *from, no
 		} else {
 			/* The packet is for us */
 			if(!from->status.validkey) {
-				logger(DEBUG_PROTOCOL, LOG_ERR, "Got REQ_SPTPS from %s (%s) but we don't have a valid key yet", from->name, from->hostname);
+				logger(DEBUG_PROTOCOL, LOG_ERR, "Got SPTPS_PACKET from %s (%s) but we don't have a valid key yet", from->name, from->hostname);
 				return true;
 			}
 			sptps_receive_data(&from->sptps, buf, len);

--- a/src/sptps.h
+++ b/src/sptps.h
@@ -88,7 +88,7 @@ extern void (*sptps_log)(sptps_t *s, int s_errno, const char *format, va_list ap
 extern bool sptps_start(sptps_t *s, void *handle, bool initiator, bool datagram, ecdsa_t *mykey, ecdsa_t *hiskey, const void *label, size_t labellen, send_data_t send_data, receive_record_t receive_record);
 extern bool sptps_stop(sptps_t *s);
 extern bool sptps_send_record(sptps_t *s, uint8_t type, const void *data, uint16_t len);
-extern bool sptps_receive_data(sptps_t *s, const void *data, size_t len);
+extern size_t sptps_receive_data(sptps_t *s, const void *data, size_t len);
 extern bool sptps_force_kex(sptps_t *s);
 extern bool sptps_verify_datagram(sptps_t *s, const void *data, size_t len);
 


### PR DESCRIPTION
This pull request brings two important features to the SPTPS protocol:

- tinc now uses the relay code when receiving a SPTPS packet in an extended `REQ_KEY` message. This allows SPTPS packets to "jump" from TCP to UDP along the relay path if possible.

- A new protocol message, `SPTPS_PACKET`, is introduced for highly efficient SPTPS packet transport over TCP.

Further details can be found in the commit messages.

I am pleased to announce that this is the very last series of patches required to bridge the efficiency gap between the old legacy protocol and the SPTPS protocol. Thanks to the relaying mechanisms and efficient TCP transport, there is no performance downside for using SPTPS anymore.