### PR TITLE
Fix UDP communication with old 1.1 nodes that don't support relaying

### DIFF
--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -1190,15 +1190,13 @@ static void try_tx_sptps(node_t *n, bool mtu) {
 
 	node_t *via = (n->via == myself) ? n->nexthop : n->via;
 
-	/* If the static relay doesn't support SPTPS, everything goes via TCP anyway. */
+	/* If we do have a static relay, try everything with that one instead, if it supports relaying. */
 
-	if((via->options >> 24) < 4)
-		return;
-
-	/* If we do have a static relay, try everything with that one instead. */
-
-	if(via != n)
+	if(via != n) {
+		if((via->options >> 24) < 4)
+			return;
 		return try_tx_sptps(via, mtu);
+	}
 
 	/* Otherwise, try to establish UDP connectivity. */
 

--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -1350,7 +1350,7 @@ static node_t *try_harder(const sockaddr_t *from, const vpn_packet_t *pkt) {
 		if(!n->status.reachable || n == myself)
 			continue;
 
-		if((n->status.sptps && !n->sptps.instate) || !n->status.validkey_in)
+		if(!n->status.validkey_in && !(n->status.sptps && n->sptps.instate))
 			continue;
 
 		bool soft = false;


### PR DESCRIPTION
Refactorings made after SPTPS UDP relaying was originally implemented broke UDP communication between modern tinc-1.1 nodes with relaying support and older 1.1 nodes that do not support relaying. There are multiple bugs involved; this pull request fixes all of them.