### PR TITLE
Don't set up an ongoing connection to myself

### DIFF
--- a/src/net_socket.c
+++ b/src/net_socket.c
@@ -800,6 +800,11 @@ void try_outgoing_connections(void) {
 			continue;
 		}
 
+		if(!strcmp(name, myself->name)) {
+			free(name);
+			continue;
+		}
+
 		bool found = false;
 
 		for list_each(outgoing_t, outgoing, outgoing_list) {


### PR DESCRIPTION
It is entirely possible that the configuration file could contain a `ConnectTo` statement refering to its own name; that's a reasonable scenario when one deploys semi-automatically generated `tinc.conf` files.

Amusingly, tinc does not like that at all, and actually sets up an `outgoing_t` structure to myself (which obviously makes no sense). This is mostly benign, though it does result in non-sensical "Already  connected to myself" messages every retry interval.

However, that also makes things blow up in `close_network_connections()`, because there we delete the entire outgoing list and *then* the myself node, which still has a reference to the freshly deleted outgoing structure. Boom.