### PR TITLE
Fix memory leaks on exit and edge_add

### DIFF
--- a/src/edge.c
+++ b/src/edge.c
@@ -64,6 +64,12 @@ void free_edge_tree(splay_tree_t *edge_tree) {
 }
 
 void exit_edges(void) {
+	// since edge_weight_tree does not have delete action defined
+	// we have to cleanup it on exit
+	for splay_each(edge_t, e, edge_weight_tree) {
+			sockaddrfree(&e->address);
+			sockaddrfree(&e->local_address);
+		}
 	splay_delete_tree(edge_weight_tree);
 }
 

--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -364,6 +364,7 @@ void load_all_subnets(void) {
 
 			if((s2 = lookup_subnet(n, s))) {
 				s2->expires = -1;
+				free(s);
 			} else {
 				subnet_add(n, s);
 			}
@@ -962,6 +963,8 @@ static bool setup_myself(void) {
 			devops = vde_devops;
 #endif
 	}
+	if (type)
+		free(type);
 
 	get_config_bool(lookup_config(config_tree, "DeviceStandby"), &device_standby);
 

--- a/src/protocol_edge.c
+++ b/src/protocol_edge.c
@@ -137,6 +137,7 @@ bool add_edge_h(connection_t *c, const char *request) {
 				logger(DEBUG_PROTOCOL, LOG_WARNING, "Got %s from %s (%s) for ourself which does not match existing entry",
 						   "ADD_EDGE", c->name, c->hostname);
 				send_add_edge(c, e);
+				sockaddrfree(&local_address);
 				return true;
 			} else {
 				logger(DEBUG_PROTOCOL, LOG_WARNING, "Got %s from %s (%s) which does not match existing entry",
@@ -151,9 +152,11 @@ bool add_edge_h(connection_t *c, const char *request) {
 					logger(DEBUG_PROTOCOL, LOG_WARNING, "Got %s from %s (%s) for ourself which does not match existing entry",
 							   "ADD_EDGE", c->name, c->hostname);
 					send_add_edge(c, e);
+					sockaddrfree(&local_address);
 					return true;
 				}
 				// Otherwise, just ignore it.
+				sockaddrfree(&local_address);
 				return true;
 			} else if(local_address.sa.sa_family) {
 				// We learned a new local address for this edge.
@@ -166,8 +169,10 @@ bool add_edge_h(connection_t *c, const char *request) {
 
 				return true;
 			}
-		} else
+		} else {
+			sockaddrfree(&local_address);
 			return true;
+		}
 	} else if(from == myself) {
 		logger(DEBUG_PROTOCOL, LOG_WARNING, "Got %s from %s (%s) for ourself which does not exist",
 				   "ADD_EDGE", c->name, c->hostname);
@@ -177,6 +182,7 @@ bool add_edge_h(connection_t *c, const char *request) {
 		e->to = to;
 		send_del_edge(c, e);
 		free_edge(e);
+		sockaddrfree(&local_address);
 		return true;
 	}
 


### PR DESCRIPTION
tincd slowly leaks memory on add_edge_h:

==8388== 112 bytes in 14 blocks are definitely lost in loss record 14 of 21
==8388==    at 0x4C29F90: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8388==    by 0x654F069: strdup (in /usr/lib/libc-2.21.so)
==8388==    by 0x4E59584: xstrdup (xalloc.h:64)
==8388==    by 0x4E594C4: str2sockaddr (netutl.c:74)
==8388==    by 0x4E5F869: add_edge_h (protocol_edge.c:131)
==8388==    by 0x4E5B56E: receive_request (protocol.c:136)
==8388==    by 0x4E49164: receive_meta_sptps (meta.c:142)
==8388==    by 0x4E6AF9C: sptps_receive_data (sptps.c:587)
==8388==    by 0x4E49467: receive_meta (meta.c:201)
==8388==    by 0x4E4B184: handle_meta_connection_data (net.c:291)
==8388==    by 0x4E5810C: handle_meta_io (net_socket.c:441)
==8388==    by 0x4E45978: event_loop (event.c:296)
==8388== 
==8388== 112 bytes in 14 blocks are definitely lost in loss record 15 of 21
==8388==    at 0x4C29F90: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8388==    by 0x654F069: strdup (in /usr/lib/libc-2.21.so)
==8388==    by 0x4E59584: xstrdup (xalloc.h:64)
==8388==    by 0x4E594D1: str2sockaddr (netutl.c:75)
==8388==    by 0x4E5F869: add_edge_h (protocol_edge.c:131)
==8388==    by 0x4E5B56E: receive_request (protocol.c:136)
==8388==    by 0x4E49164: receive_meta_sptps (meta.c:142)
==8388==    by 0x4E6AF9C: sptps_receive_data (sptps.c:587)
==8388==    by 0x4E49467: receive_meta (meta.c:201)
==8388==    by 0x4E4B184: handle_meta_connection_data (net.c:291)
==8388==    by 0x4E5810C: handle_meta_io (net_socket.c:441)
==8388==    by 0x4E45978: event_loop (event.c:296)
