### PR TITLE
Fix DecrementTTL option.

### DIFF
--- a/src/route.c
+++ b/src/route.c
@@ -891,7 +891,7 @@ static bool do_decrement_ttl(node_t *source, vpn_packet_t *packet) {
 			if(!checklength(source, packet, ethlen + ip_size))
 				return false;
 
-			if(packet->data[ethlen + 8] < 1) {
+			if(packet->data[ethlen + 8] <= 1) {
 				if(packet->data[ethlen + 11] != IPPROTO_ICMP || packet->data[ethlen + 32] != ICMP_TIME_EXCEEDED)
 					route_ipv4_unreachable(source, packet, ethlen, ICMP_TIME_EXCEEDED, ICMP_EXC_TTL);
 				return false;
@@ -914,7 +914,7 @@ static bool do_decrement_ttl(node_t *source, vpn_packet_t *packet) {
 			if(!checklength(source, packet, ethlen + ip6_size))
 				return false;
 
-			if(packet->data[ethlen + 7] < 1) {
+			if(packet->data[ethlen + 7] <= 1) {
 				if(packet->data[ethlen + 6] != IPPROTO_ICMPV6 || packet->data[ethlen + 40] != ICMP6_TIME_EXCEEDED)
 					route_ipv6_unreachable(source, packet, ethlen, ICMP6_TIME_EXCEEDED, ICMP6_TIME_EXCEED_TRANSIT);
 				return false;


### PR DESCRIPTION
Hello,

This patch fixes the DecrementTTL option.

The option was not actually working, as it could be seen on traceroute or mtr.

The problem is that it was checking if the TTL was < 1 (so equal to 0) before decrementing it.

This meant that a packet with a TTL of 1 was being sent with a TTL of 0 on the VPN, instead of being discarded with the ICMP error message.

Cheers,
Vittorio G