### PR TITLE
Include the subnets of each node in the graph dump.

### DIFF
--- a/src/graph.c
+++ b/src/graph.c
@@ -319,8 +319,10 @@ void graph(void) {
 
 void dump_graph(void) {
 	avl_node_t *node;
+	avl_node_t *subnet_node;
 	node_t *n;
 	edge_t *e;
+	char subnet_str[MAXNETSTR];
 	char *filename = NULL, *tmpname = NULL;
 	FILE *file, *pipe = NULL;
 	
@@ -350,7 +352,12 @@ void dump_graph(void) {
 	/* dump all nodes first */
 	for(node = node_tree->head; node; node = node->next) {
 		n = node->data;
-		fprintf(file, "	%s [label = \"%s\"];\n", n->name, n->name);
+		fprintf(file, "	%s [label = \"%s", n->name, n->name);
+		for(subnet_node = n->subnet_tree->head; subnet_node; subnet_node = subnet_node->next) {
+			net2str(subnet_str, MAXNETSTR, subnet_node->data);
+			fprintf(file, "\\n%s", subnet_str);
+		}
+		fprintf(file, "\"];\n");
 	}
 
 	/* now dump all edges */


### PR DESCRIPTION
Hi,
the graph dump feature, at the moment, dumps only the name of the nodes. This small patch adds the subnet to each node dumped:

```
digraph {
        NodeA [label = "NodeA\n10.0.0.1/32#10"];
        NodeB [label = "NodeB\n10.0.0.2/32#10"];
        NodeA -> NodeB;
        NodeB -> NodeA;
}
```

This might be useful if you want to post-process the graph, like adding colors for each subnet, or it may just be an important information to show.