### PR TITLE
Handle collisions gracefully in hash tables

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -20,11 +20,16 @@
 #ifndef __TINC_HASH_H__
 #define __TINC_HASH_H__
 
+typedef struct hash_node_t {
+	void *key;
+	const void *value;
+	struct hash_node_t *next;
+} hash_node_t;
+
 typedef struct hash_t {
 	size_t n;
 	size_t size;
-	char *keys;
-	const void **values;
+	hash_node_t **buckets;
 } hash_t;
 
 extern hash_t *hash_alloc(size_t n, size_t size) __attribute__ ((__malloc__));
@@ -37,6 +42,5 @@ extern void *hash_search(const hash_t *, const void *key);
 extern void *hash_search_or_insert(hash_t *, const void *key, const void *value);
 
 extern void hash_clear(hash_t *);
-extern void hash_resize(hash_t *, size_t n);
 
 #endif /* __TINC_HASH_H__ */


### PR DESCRIPTION
This rewrites the hash table implementation to make the hash table an actual container that will not randomly overwrite items when collisions occur. This is done in the usual way: by making each bucket a linked list (as opposed to just a single item).

I'm doing this for two reasons. The first reason is obvious - it's to make sure we don't suddenly degrade to O(n) performance when two "hot" items end up in the same bucket.

The second, and most important, reason, has to do with `node_udp_cache`. It turns out that there is one scenario in which the contents of `node_udp_cache` has *correctness* implications, not just performance implications. This has to do with the way `handle_incoming_vpn_data()` is implemented.

Assume the following topology:

    A <-> B <-> C

Now let's consider the perspective of tincd running on B, and let's assume the following is true:

- All nodes are using the 1.1 protocol with node IDs and relaying    support.
- Nodes A and C have UDP addresses that hash to the same value.
- Node C "wins" in the `node_udp_cache` (i.e. it overwrites A in the    cache).
- Node A has a "dynamic" UDP address (i.e. an UDP address that has been detected dynamically and cannot be deduced from edge addresses).

Then, before this commit, A would be unable to relay packets through B.

This is because `handle_incoming_vpn_data()` will fall back to `try_harder()`, which won't be able to match any edge addresses, doesn't check the dynamic UDP addresses, and won't be able to match any keys because this is a relayed packet which is encrypted with C's key, not B's. As a result, tinc will fail to match the source of the packet and will drop the packet with a "Received UDP packet from unknown source" message.

I have seen this happen in the wild; it is actually quite likely to occur when there are more than a handful of nodes because `node_udp_cache` only has 256 buckets, making collisions quite likely. This problem is quite severe because it can completely prevent all packet communication between nodes - indeed, if node A tries to initiate some communication with C, it will use relaying at first, until C responds and helps A establish direct communication with it (e.g. hole punching). If relaying is broken, C will not help establish direct communication, and as a result no packets can make it through at all.

The bug can be reproduced fairly easily by reproducing the topology above while changing the (hardcoded) `node_udp_cache` size to 1 to force a collision. One will quickly observe various issues when trying to make A talk to C. Setting `IndirectData` on B will make the issue even more severe and prevent all communication.

Arguably, another way to fix this problem is to make `try_harder()` compare the packet's source address to each node's dynamic UDP addresses. However, I do not like this solution because if two "hot" nodes are contending on the same hash bucket, `try_harder()` will be called very often and packet routing performance will degrade closer to O(N) (where N is the total number of nodes in the graph). Improving the hash table data structure fixes the bug without introducing this performance problem.