### PR TITLE
Use a splay tree for node UDP addresses in order to avoid collisions

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -34,7 +34,7 @@
 
 splay_tree_t *node_tree;
 static splay_tree_t *node_id_tree;
-static hash_t *node_udp_cache;
+static splay_tree_t *node_udp_tree;
 static hash_t *node_id_cache;
 
 node_t *myself;
@@ -47,16 +47,23 @@ static int node_id_compare(const node_t *a, const node_t *b) {
 	return memcmp(&a->id, &b->id, sizeof(node_id_t));
 }
 
+static int node_udp_compare(const node_t *a, const node_t *b) {
+	int result = sockaddrcmp(&a->address, &b->address);
+	if (result)
+		return result;
+	return (a->name && b->name) ? strcmp(a->name, b->name) : 0;
+}
+
 void init_nodes(void) {
 	node_tree = splay_alloc_tree((splay_compare_t) node_compare, (splay_action_t) free_node);
 	node_id_tree = splay_alloc_tree((splay_compare_t) node_id_compare, NULL);
-	node_udp_cache = hash_alloc(0x100, sizeof(sockaddr_t));
+	node_udp_tree = splay_alloc_tree((splay_compare_t) node_udp_compare, NULL);
 	node_id_cache = hash_alloc(0x100, sizeof(node_id_t));
 }
 
 void exit_nodes(void) {
 	hash_free(node_id_cache);
-	hash_free(node_udp_cache);
+	splay_delete_tree(node_udp_tree);
 	splay_delete_tree(node_id_tree);
 	splay_delete_tree(node_tree);
 }
@@ -116,7 +123,7 @@ void node_add(node_t *n) {
 }
 
 void node_del(node_t *n) {
-	hash_delete(node_udp_cache, &n->address);
+	splay_delete(node_udp_tree, n);
 	hash_delete(node_id_cache, &n->id);
 
 	for splay_each(subnet_t, s, n->subnet_tree)
@@ -150,7 +157,8 @@ node_t *lookup_node_id(const node_id_t *id) {
 }
 
 node_t *lookup_node_udp(const sockaddr_t *sa) {
-	return hash_search(node_udp_cache, sa);
+	node_t tmp = {.address = *sa};
+	return splay_search(node_udp_tree, &tmp);
 }
 
 void update_node_udp(node_t *n, const sockaddr_t *sa) {
@@ -159,7 +167,7 @@ void update_node_udp(node_t *n, const sockaddr_t *sa) {
 		return;
 	}
 
-	hash_delete(node_udp_cache, &n->address);
+	splay_delete(node_udp_tree, n);
 
 	if(sa) {
 		n->address = *sa;
@@ -170,7 +178,7 @@ void update_node_udp(node_t *n, const sockaddr_t *sa) {
 				break;
 			}
 		}
-		hash_insert(node_udp_cache, sa, n);
+		splay_insert(node_udp_tree, n);
 		free(n->hostname);
 		n->hostname = sockaddr2hostname(&n->address);
 		logger(DEBUG_PROTOCOL, LOG_DEBUG, "UDP address of %s set to %s", n->name, n->hostname);


### PR DESCRIPTION
See commit description for details. I also threw in a bonus commit that removes the node ID cache (which I believe is not useful). Feel free to discard the bonus commit if you disagree.

This supersedes #100, which was not a viable solution as @gsliepen pointed out in the comments.