### PR TITLE
Add upnp.h to tincd SOURCES

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -252,7 +252,7 @@ endif
 endif
 
 if MINIUPNPC
-tincd_SOURCES += upnp.c
+tincd_SOURCES += upnp.h upnp.c
 tincd_LDADD = $(MINIUPNPC_LIBS)
 tincd_LDFLAGS = -pthread
 endif


### PR DESCRIPTION
This was missing from 513bffe1fee07bcbcb50691e221874adc1507857.