### PR TITLE
Cygwin branch fixes

### DIFF
--- a/src/cygwin/device.c
+++ b/src/cygwin/device.c
@@ -61,7 +61,7 @@ static bool setup_device(void) {
 	get_config_string(lookup_config(config_tree, "Device"), &device);
 	get_config_string(lookup_config(config_tree, "Interface"), &iface);
 
-	if(device && interface)
+	if(device && iface)
 		logger(LOG_WARNING, "Warning: both Device and Interface specified, results may not be as expected");
 
 	/* Open registry and look for network adapters */

--- a/src/cygwin/device.c
+++ b/src/cygwin/device.c
@@ -19,6 +19,7 @@
 */
 
 #include "../system.h"
+#include "../net.h"
 
 #include <w32api/windows.h>
 #include <w32api/winioctl.h>
@@ -26,7 +27,6 @@
 #include "../conf.h"
 #include "../device.h"
 #include "../logger.h"
-#include "../net.h"
 #include "../route.h"
 #include "../utils.h"
 #include "../xalloc.h"


### PR DESCRIPTION
The pull request fix these two bugs in the cygwin branch, who block the compilation.
```
In file included from /usr/include/w32api/windows.h:95:0,
                 from cygwin/device.c:23:
/usr/include/openssl/ossl_typ.h:159:29: error: expected ‘)’ before numeric const                                                                                                                ant
 typedef struct X509_name_st X509_NAME;
                             ^
/usr/include/openssl/ossl_typ.h:205:33: error: expected ‘)’ before numeric const                                                                                                                ant
 typedef struct ocsp_response_st OCSP_RESPONSE;
                                 ^
In file included from /usr/include/w32api/oleidl.h:7:0,
                 from /usr/include/w32api/ole2.h:38,
                 from /usr/include/w32api/wtypes.h:12,
                 from /usr/include/w32api/winscard.h:10,
                 from /usr/include/w32api/windows.h:97,
                 from cygwin/device.c:23:
cygwin/device.c: In function ‘setup_device’:
cygwin/device.c:64:15: error: expected expression before ‘struct’
  if(device && interface)
```