### PR TITLE
Allow PKT_PROBE in sptps_send_record

### DIFF
--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -499,7 +499,7 @@ static void send_sptps_packet(node_t *n, vpn_packet_t *origpkt) {
 	uint8_t type = 0;
 	int offset = 0;
 
-	if(!(DATA(origpkt)[12] | DATA(origpkt)[13])) {
+	if((!(DATA(origpkt)[12] | DATA(origpkt)[13])) && (n->sptps.outstate))  {
 		sptps_send_record(&n->sptps, PKT_PROBE, (char *)DATA(origpkt), origpkt->len);
 		return;
 	}

--- a/src/sptps.c
+++ b/src/sptps.c
@@ -128,11 +128,13 @@ static bool send_record_priv(sptps_t *s, uint8_t type, const void *data, uint16_
 
 // Send an application record.
 bool sptps_send_record(sptps_t *s, uint8_t type, const void *data, uint16_t len) {
+
+	if((!s->outstate) && (type != PKT_PROBE))
+		return error(s, EINVAL, "Handshake phase not finished yet (outstate:%x type: %d)",
+									s->outstate, type);
+
 	// Sanity checks: application cannot send data before handshake is finished,
 	// and only record types 0..127 are allowed.
-	if(!s->outstate)
-		return error(s, EINVAL, "Handshake phase not finished yet");
-
 	if(type >= SPTPS_HANDSHAKE)
 		return error(s, EINVAL, "Invalid application record type");
 

--- a/src/sptps.c
+++ b/src/sptps.c
@@ -129,9 +129,8 @@ static bool send_record_priv(sptps_t *s, uint8_t type, const void *data, uint16_
 // Send an application record.
 bool sptps_send_record(sptps_t *s, uint8_t type, const void *data, uint16_t len) {
 
-	if((!s->outstate) && (type != PKT_PROBE))
-		return error(s, EINVAL, "Handshake phase not finished yet (outstate:%x type: %d)",
-									s->outstate, type);
+	if(!s->outstate)
+		return error(s, EINVAL, "Handshake phase not finished yet");
 
 	// Sanity checks: application cannot send data before handshake is finished,
 	// and only record types 0..127 are allowed.


### PR DESCRIPTION
sptps_send_record prevented PKT_PROBE to be send in send_sptps_packet.
This occurred mostly when data was on "the wire" for some subnet.
route() would then trigger try_tx/try_udp which would be dropped by
sptps_send_record producing annoying amount of "Handshake phase
not finished yet" log messages.