### PR TITLE
Prevent receive_tcppacket_sptps from forwarding data when in handshake

### DIFF
--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -470,8 +470,11 @@ bool receive_tcppacket_sptps(connection_t *c, const char *data, int len) {
 	/* If we're not the final recipient, relay the packet. */
 
 	if(to != myself) {
-		send_sptps_data(to, from, 0, data, len);
-		try_tx(to, true);
+		if (!to->status.waitingforkey) {
+			send_sptps_data(to, from, 0, data, len);
+			try_tx(to, true);
+		} else
+			logger(DEBUG_ALWAYS, LOG_INFO, "Cannot forward TCP packet from %s (%s) to %s (%s) because we are still wating for key", from->name, from->hostname, to->name, to->hostname);
 		return true;
 	}
 


### PR DESCRIPTION
Prevent receive_tcppacket_sptps from forwarding data to another nodes when we are in handshake phase with those nodes

Forwarding data to node which does not have vaildkey yet would destroy the running handshake.
