### PR TITLE
Fix error handling when setting up the UDP socket

### DIFF
--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -676,7 +676,7 @@ static bool add_listen_address(char *address, bool bindto) {
 
 		int udp_fd = setup_vpn_in_socket((sockaddr_t *) aip->ai_addr);
 
-		if(tcp_fd < 0) {
+		if(udp_fd < 0) {
 			close(tcp_fd);
 			continue;
 		}


### PR DESCRIPTION
Due to this typo, if tinc managed to set up the TCP socket but not the UDP socket, it would continue anyway.

The regression was introduced in 6bc5d626a8726fc23365ee705761a3c666a08ad4.