### PR TITLE
tincctl: Avoid falling back to 1024 bits RSA key generation when an invalid key size is specified.

### DIFF
--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -446,11 +446,13 @@ static bool rsa_keygen(int bits, bool ask) {
 	// Make sure the key size is a multiple of 8 bits.
 	bits &= ~0x7;
 
-	// Force them to be between 1024 and 8192 bits long.
-	if(bits < 1024)
-		bits = 1024;
-	if(bits > 8192)
-		bits = 8192;
+	// Make sure that a valid key size is used.
+	if(bits < 1024 || bits > 8192) {
+		fprintf(stderr, "Invalid key size %d specified! It should be between 1024 and 8192 bits.\n", bits);
+		return false;
+	} else if(bits < 2048) {
+		fprintf(stderr, "WARNING: generating a weak %d bits RSA key! 2048 or more bits are recommended.\n", bits);
+	}
 
 	fprintf(stderr, "Generating %d bits keys:\n", bits);
 


### PR DESCRIPTION
Also warn the user if a key smaller than 2048 bits is being generated.

Cheers,
Vittorio