### PR TITLE
Remove ExecStop in tinc@.service

### DIFF
--- a/distro/tinc@.service
+++ b/distro/tinc@.service
@@ -8,7 +8,6 @@ Type=simple
 WorkingDirectory=/etc/tinc/%i
 ExecStart=/usr/sbin/tincd -n %i -D
 ExecReload=/usr/sbin/tincd -n %i -kHUP
-ExecStop=/usr/sbin/tincd -n %i -k
 TimeoutStopSec=5
 Restart=always
 RestartSec=60


### PR DESCRIPTION
This avoid tinc to receive SIGTERM twice (through ExecStop and through systemd
directly) which prevented tinc-down script to be executed.

An other possibility is to KillMode=none, but this cause systemd to think tinc is terminated when the ExecStop end which is false. Let systemd send the SIGTERM is better as systemd willl directly observe the tinc processus status in order to know if it has completed.