### PR TITLE
Fix broken Windows build

### DIFF
--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -721,6 +721,8 @@ bool connect_tincd(bool verbose) {
 	}
 
 	fclose(f);
+
+#ifndef HAVE_MINGW
 	if ((pid == 0) || (kill(pid, 0) && (errno == ESRCH))) {
 		fprintf(stderr, "Could not find tincd running at pid %d\n", pid);
 		/* clean up the stale socket and pid file */
@@ -729,7 +731,6 @@ bool connect_tincd(bool verbose) {
 		return false;
 	}
 
-#ifndef HAVE_MINGW
 	struct sockaddr_un sa;
 	sa.sun_family = AF_UNIX;
 	strncpy(sa.sun_path, unixsocketname, sizeof sa.sun_path);


### PR DESCRIPTION
The regression was introduced in commit 4314df644e22778a554ca1760941a2bfae08bce2.

      CC       tincctl.o
    tincctl.c: In function ‘connect_tincd’:
    tincctl.c:724:21: warning: implicit declaration of function ‘kill’ [-Wimplicit-function-declaration]
      if ((pid == 0) || (kill(pid, 0) && (errno == ESRCH))) {
	        	     ^~~~
      CCLD     tinc.exe
    tincctl.o: In function `connect_tincd':
    /home/e-t172/dev/tinc/src/tincctl.c:724: undefined reference to `kill'
    collect2: error: ld returned 1 exit status
    Makefile:830: recipe for target 'tinc.exe' failed