### PR TITLE
Avoid infinite loop on EBADFD

### DIFF
--- a/src/linux/device.c
+++ b/src/linux/device.c
@@ -139,6 +139,9 @@ static bool read_packet(vpn_packet_t *packet) {
 			if(inlen <= 0) {
 				logger(DEBUG_ALWAYS, LOG_ERR, "Error while reading from %s %s: %s",
 					   device_info, device, strerror(errno));
+				if (errno == EBADFD) { /* File descriptor in bad state */
+					event_exit();
+				}
 				return false;
 			}
 


### PR DESCRIPTION
On Linux network restart, Tinc can get into a loop writing millions of error messages "Error while reading from Linux tun/tap device (tun mode) /dev/net/tun: File descriptor in bad state" to the log. https://github.com/NixOS/nixpkgs/pull/27675 

It should be somehow aborted.
Here is my quick hack.