### PR TITLE
Pass correct size to read_pem() in ecdsa_read_pem_private_key().

### DIFF
--- a/src/ed25519/ecdsa.c
+++ b/src/ed25519/ecdsa.c
@@ -122,7 +122,7 @@ ecdsa_t *ecdsa_read_pem_public_key(FILE *fp) {
 
 ecdsa_t *ecdsa_read_pem_private_key(FILE *fp) {
 	ecdsa_t *ecdsa = xmalloc(sizeof *ecdsa);
-	if(read_pem(fp, "ED25519 PRIVATE KEY", ecdsa->private, sizeof *ecdsa))
+	if(read_pem(fp, "ED25519 PRIVATE KEY", ecdsa->private, sizeof ecdsa->private))
 		return ecdsa;
 	free(ecdsa);
 	return 0;


### PR DESCRIPTION
Pass the size of the private key, not the entire struct.