### PR TITLE
Allow compilation from a build directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ(2.61)
 AC_INIT([tinc], [1.0.32])
 AC_CONFIG_SRCDIR([src/tincd.c])
-AM_INIT_AUTOMAKE([1.11 check-news std-options subdir-objects nostdinc silent-rules -Wall])
+AM_INIT_AUTOMAKE([1.11 check-news std-options subdir-objects nostdinc silent-rules -Wall info-in-builddir])
 AC_CONFIG_HEADERS([config.h])
 AM_MAINTAINER_MODE
 AM_SILENT_RULES([yes])
@@ -179,6 +179,8 @@ dnl Checks for libraries.
 dnl Checks for header files.
 dnl We do this in multiple stages, because unlike Linux all the other operating systems really suck and don't include their own dependencies.
 
+save_CPPFLAGS="$CPPFLAGS"
+CPPFLAGS="$CPPFLAGS -I${srcdir}"
 AC_HEADER_STDC
 AC_CHECK_HEADERS([stdbool.h syslog.h sys/file.h sys/ioctl.h sys/mman.h sys/param.h sys/resource.h sys/socket.h sys/time.h time.h sys/uio.h sys/wait.h netdb.h arpa/inet.h arpa/nameser.h dirent.h getopt.h])
 AC_CHECK_HEADERS([net/if.h net/if_types.h linux/if_tun.h net/if_tun.h net/if_utun.h net/tun/if_tun.h net/if_tap.h net/tap/if_tap.h net/ethernet.h net/if_arp.h netinet/in_systm.h netinet/in.h netinet/in6.h netpacket/packet.h],
@@ -226,6 +228,8 @@ AC_CHECK_FUNC(gethostbyname, [], [
 AC_CHECK_DECLS([freeaddrinfo, gai_strerror, getaddrinfo, getnameinfo],
   [], [], [#include "src/have.h"]
 )
+
+CPPFLAGS="$save_CPPFLAGS"
 
 AC_CHECK_DECLS([res_init], [AC_CHECK_LIB(resolv, res_init)], [], [
   #include <netinet/in.h>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -16,11 +16,11 @@ transform = s/ginstall/install/; @program_transform_name@
 # For additional rules usually of interest only to the maintainer,
 # see GNUmakefile and Makefile.maint.
 
-sample-config.tar.gz: sample-config
-	$(AM_V_GEN)GZIP=$(GZIP_ENV) $(AMTAR) chozf sample-config.tar.gz --exclude .svn sample-config
+sample-config.tar.gz: $(srcdir)/sample-config
+	$(AM_V_GEN)GZIP=$(GZIP_ENV) $(AMTAR) chozf $@ --exclude .svn $<
 
 texi2html: tinc.texi
-	$(AM_V_GEN)texi2html -split=chapter tinc.texi
+	$(AM_V_GEN)texi2html -split=chapter $<
 
 tincd.8.html: tincd.8
 	$(AM_V_GEN)w3mman2html $< > $@
@@ -34,13 +34,13 @@ substitute = sed \
 	-e s,'@sysconfdir\@',"$(sysconfdir)",g \
 	-e s,'@localstatedir\@',"$(localstatedir)",g
 
-tincd.8: tincd.8.in
-	$(AM_V_GEN)$(substitute) tincd.8.in > tincd.8
+tincd.8: $(srcdir)/tincd.8.in
+	$(AM_V_GEN)$(substitute) $< > $@
 
-tinc.conf.5: tinc.conf.5.in
-	$(AM_V_GEN)$(substitute) tinc.conf.5.in > tinc.conf.5
+tinc.conf.5: $(srcdir)/tinc.conf.5.in
+	$(AM_V_GEN)$(substitute) $< > $@
 
-tincinclude.texi: tincinclude.texi.in
-	$(AM_V_GEN)$(substitute) tincinclude.texi.in > tincinclude.texi
-	
+tincinclude.texi: $(srcdir)/tincinclude.texi.in
+	$(AM_V_GEN)$(substitute) $< > $@
+
 tinc.texi: tincinclude.texi

--- a/m4/Makefile.am
+++ b/m4/Makefile.am
@@ -1,4 +1,3 @@
 ## Process this file with automake to produce Makefile.in   -*-Makefile-*-
 
-EXTRA_DIST = README *.m4
-
+EXTRA_DIST = README attribute.m4 ax_append_flag.m4 ax_cflags_warn_all.m4 ax_check_compile_flag.m4 ax_check_link_flag.m4 ax_require_defined.m4 lzo.m4 openssl.m4 zlib.m4

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -88,4 +88,4 @@ if TUNEMU
 LIBS += -lpcap
 endif
 
-AM_CPPFLAGS = -DCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\"
+AM_CPPFLAGS = -DCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -I $(abs_top_builddir)/

--- a/src/system.h
+++ b/src/system.h
@@ -21,7 +21,7 @@
 #ifndef __TINC_SYSTEM_H__
 #define __TINC_SYSTEM_H__
 
-#include "../config.h"
+#include "config.h"
 
 #include "have.h"
 

--- a/src/xmalloc.c
+++ b/src/xmalloc.c
@@ -16,7 +16,7 @@
    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.  */
 
 #if HAVE_CONFIG_H
-# include "../config.h"
+# include "config.h"
 #endif
 
 #include <sys/types.h>


### PR DESCRIPTION
Currently, it is not possible to build the project from a separate directory than the one containing sources.

In fact:
```
$ make distcheck
[...]
  CC       avl_tree.o
In file included from ../../src/avl_tree.c:33:0:
../../src/system.h:24:23: fatal error: ../config.h: No such file or directory
 #include "../config.h"
```

This patch fixes that and then avoid creating exceptional behavior for `tinc` in some automated packager that relies on clean separate builds.

Moreover, one last error was due to the use of wildcard in `m4/Makefile.am` whereas [it is not supported by design](https://www.gnu.org/software/automake/manual/html_node/Wildcards.html).

Thanks for your project!