### PR TITLE
Move ResetEvent() call before ReadFile()

### DIFF
--- a/src/mingw/device.c
+++ b/src/mingw/device.c
@@ -54,6 +54,8 @@ static void device_issue_read() {
 	int status;
 
 	for(;;) {
+		ResetEvent(device_read_overlapped.hEvent);
+
 		DWORD len;
 		status = ReadFile(device_handle, (void *)device_read_packet.data, MTU, &len, &device_read_overlapped);
 
@@ -72,10 +74,7 @@ static void device_issue_read() {
 }
 
 static void device_handle_read(void *data, int flags) {
-	ResetEvent(device_read_overlapped.hEvent);
-
 	DWORD len;
-
 	if(!GetOverlappedResult(device_handle, &device_read_overlapped, &len, FALSE)) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Error getting read result from %s %s: %s", device_info,
 		       device, strerror(errno));


### PR DESCRIPTION
Commit 313a752 changed the Windows device code such that `ResetEvent()` is called on the read `OVERLAPPED` structure before `GetOverlappedResult()`, as opposed to before `ReadFile()`. [Guus pointed out][] that this doesn't make a ton of sense, and I agree with him; it must have been an oversight on my part when I wrote this code.

Surprisingly, none of this makes any difference in my testing, at least with the standard TAP 9.0.0.9 driver. Nevertheless, this code is probably wrong and fixing it will make me sleep better at night.

[Guus pointed out]: https://www.tinc-vpn.org/pipermail/tinc/2018-January/005091.html