### PR TITLE
Fix io_compare() for 64-bit Windows

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -41,7 +41,13 @@ static int io_compare(const io_t *a, const io_t *b) {
 #ifndef HAVE_MINGW
 	return a->fd - b->fd;
 #else
-	return a->event - b->event;
+	if(a->event < b->event) {
+		return -1;
+	}
+	if(a->event > b->event) {
+		return 1;
+	}
+	return 0;
 #endif
 }
 


### PR DESCRIPTION
WSAEVENT is a pointer, so we cannot simply return the different of two events in io_compare(), which returns an int.  This can return the wrong result for 64-bit executables.