### PR TITLE
src/route.c: pad the "next" field of ipv6 pseudo header correctly.

### DIFF
--- a/src/route.c
+++ b/src/route.c
@@ -225,8 +225,9 @@ static void route_ipv6_unreachable(node_t *source, vpn_packet_t *packet, length_
 		struct in6_addr ip6_src;        /* source address */
 		struct in6_addr ip6_dst;        /* destination address */
 		uint32_t length;
-		uint32_t next;
-	} pseudo;
+		uint32_t zero: 24,
+			next: 8;
+	} pseudo = { .zero = 0 };
 
 	if(ratelimit(3)) {
 		return;
@@ -302,7 +303,7 @@ static void route_ipv6_unreachable(node_t *source, vpn_packet_t *packet, length_
 	/* Create pseudo header */
 
 	pseudo.length = htonl(icmp6_size + pseudo.length);
-	pseudo.next = htonl(IPPROTO_ICMPV6);
+	pseudo.next = IPPROTO_ICMPV6;
 
 	/* Generate checksum */
 


### PR DESCRIPTION
  According to Section 8.1 of RFC2460 reproduced below, in the pseudo
  header of checksum calculation, 3 bytes of 0's should prepend the
  "next header" field.

  "uint32_t next" does not give the correct structure on little-endian
  systems, because "htonl(IPPROTO_ICMPV6)" puts the "next header" into
  the left most byte.

  Sympton of this bug: all the tinc-generated ICMPv6 packets have bad
  checksums and get ignored by the hosts.  For example, ICMPv6 Packet
  Too Big Messages with bad checksums are ignored and consequently
  path MTU discovery of tinc does not function for ipv6 VPN networks.
```

  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  |                                                               |
  +                                                               +
  |                                                               |
  +                         Source Address                        +
  |                                                               |
  +                                                               +
  |                                                               |
  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  |                                                               |
  +                                                               +
  |                                                               |
  +                      Destination Address                      +
  |                                                               |
  +                                                               +
  |                                                               |
  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  |                   Upper-Layer Packet Length                   |
  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  |                      zero                     |  Next Header  |
  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```