### PR TITLE
reset read event on error

### DIFF
--- a/src/mingw/device.c
+++ b/src/mingw/device.c
@@ -76,6 +76,12 @@ static void device_handle_read(void *data, int flags) {
 	if(!GetOverlappedResult(device_handle, &device_read_overlapped, &len, FALSE)) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Error getting read result from %s %s: %s", device_info,
 		       device, strerror(errno));
+
+		if(GetLastError() != ERROR_IO_INCOMPLETE) {
+			/* Must reset event or it will keep firing. */
+			ResetEvent(device_read_overlapped.hEvent);
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
In device_handle_read() we need to reset the read event on error or it will keep firing.  This is easy to reproduce by suspending the machine while tincd is running.