### PR TITLE
On Windows, fill the events[] array in reverse order.

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -403,11 +403,16 @@ bool event_loop(void) {
 		}
 
 		WSAEVENT *events = xmalloc(event_count * sizeof(*events));
-		DWORD event_index = 0;
+		DWORD event_index = event_count;
 
+		/*
+		 * Fill events[] in reverse order.  This helps guarantee the
+		 * events will be processed in round robin order even when one
+		 * event is busier than the others.  Otherwise we may starve
+		 * events other than the TAP, which is usually at the head.
+		 */
 		for splay_each(io_t, io, &io_tree) {
-			events[event_index] = io->event;
-			event_index++;
+			events[--event_index] = io->event;
 		}
 
 		DWORD result = WSAWaitForMultipleEvents(event_count, events, FALSE, timeout_ms, FALSE);


### PR DESCRIPTION
This helps guarantee the events will be processed in round robin order even when one event is busier than the others.  The event loop uses splay_search() to lookup the io_t by the selected event, splaying the tree.  As a result, the busy event (usually TAP) will always be first in the events[] array, which usually results in its index being returned by the next call to WSAWaitForMultipleEvents().  By putting the most active event last in events[], other active events get a chance to run.

Otherwise, we may starve events other than the TAP, which is usually at the head.  This can cause 
missed PING replies.