### PR TITLE
Expose traffic stats and UDP RTT

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -71,15 +71,16 @@ static int info_node(int fd, const char *item) {
 	node_status_t status;
 	long int last_state_change;
 	long int udp_ping_rtt;
+	uint64_t in_packets, in_bytes, out_packets, out_bytes;
 
 	while(recvline(fd, line, sizeof(line))) {
-		int n = sscanf(line, "%d %d %4095s %4095s %4095s port %4095s %d %d %d %d %x %"PRIx32" %4095s %4095s %d %hd %hd %hd %ld %ld", &code, &req, node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_union.raw, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change, &udp_ping_rtt);
+		int n = sscanf(line, "%d %d %4095s %4095s %4095s port %4095s %d %d %d %d %x %"PRIx32" %4095s %4095s %d %hd %hd %hd %ld %ld %lu %lu %lu %lu", &code, &req, node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_union.raw, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change, &udp_ping_rtt, &in_packets, &in_bytes, &out_packets, &out_bytes);
 
 		if(n == 2) {
 			break;
 		}
 
-		if(n != 20) {
+		if(n != 24) {
 			fprintf(stderr, "Unable to parse node dump from tincd.\n");
 			return 1;
 		}
@@ -187,6 +188,9 @@ static int info_node(int fd, const char *item) {
 	} else {
 		printf("none, forwarded via %s\n", nexthop);
 	}
+
+	printf("RX:          %lu packets  %lu bytes\n", in_packets, in_bytes);
+	printf("TX:          %lu packets  %lu bytes\n", out_packets, out_bytes);
 
 	// List edges
 	printf("Edges:       ");

--- a/src/info.c
+++ b/src/info.c
@@ -70,15 +70,16 @@ static int info_node(int fd, const char *item) {
 	} status_union;
 	node_status_t status;
 	long int last_state_change;
+	long int udp_ping_rtt;
 
 	while(recvline(fd, line, sizeof(line))) {
-		int n = sscanf(line, "%d %d %4095s %4095s %4095s port %4095s %d %d %d %d %x %"PRIx32" %4095s %4095s %d %hd %hd %hd %ld", &code, &req, node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_union.raw, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change);
+		int n = sscanf(line, "%d %d %4095s %4095s %4095s port %4095s %d %d %d %d %x %"PRIx32" %4095s %4095s %d %hd %hd %hd %ld %ld", &code, &req, node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_union.raw, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change, &udp_ping_rtt);
 
 		if(n == 2) {
 			break;
 		}
 
-		if(n != 19) {
+		if(n != 20) {
 			fprintf(stderr, "Unable to parse node dump from tincd.\n");
 			return 1;
 		}
@@ -143,6 +144,8 @@ static int info_node(int fd, const char *item) {
 
 	if(status.udp_confirmed) {
 		printf(" udp_confirmed");
+		if(udp_ping_rtt != -1)
+			printf(" (rtt %ld.%03ld)", udp_ping_rtt/1000, udp_ping_rtt%1000);
 	}
 
 	printf("\n");

--- a/src/info.c
+++ b/src/info.c
@@ -70,11 +70,11 @@ static int info_node(int fd, const char *item) {
 	} status_union;
 	node_status_t status;
 	long int last_state_change;
-	long int udp_ping_rtt;
+	int udp_ping_rtt;
 	uint64_t in_packets, in_bytes, out_packets, out_bytes;
 
 	while(recvline(fd, line, sizeof(line))) {
-		int n = sscanf(line, "%d %d %4095s %4095s %4095s port %4095s %d %d %d %d %x %"PRIx32" %4095s %4095s %d %hd %hd %hd %ld %ld %lu %lu %lu %lu", &code, &req, node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_union.raw, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change, &udp_ping_rtt, &in_packets, &in_bytes, &out_packets, &out_bytes);
+		int n = sscanf(line, "%d %d %4095s %4095s %4095s port %4095s %d %d %d %d %x %"PRIx32" %4095s %4095s %d %hd %hd %hd %ld %d %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64, &code, &req, node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_union.raw, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change, &udp_ping_rtt, &in_packets, &in_bytes, &out_packets, &out_bytes);
 
 		if(n == 2) {
 			break;
@@ -146,7 +146,7 @@ static int info_node(int fd, const char *item) {
 	if(status.udp_confirmed) {
 		printf(" udp_confirmed");
 		if(udp_ping_rtt != -1)
-			printf(" (rtt %ld.%03ld)", udp_ping_rtt/1000, udp_ping_rtt%1000);
+			printf(" (rtt %ld.%03ld)", udp_ping_rtt / 1000, udp_ping_rtt % 1000);
 	}
 
 	printf("\n");
@@ -189,8 +189,8 @@ static int info_node(int fd, const char *item) {
 		printf("none, forwarded via %s\n", nexthop);
 	}
 
-	printf("RX:          %lu packets  %lu bytes\n", in_packets, in_bytes);
-	printf("TX:          %lu packets  %lu bytes\n", out_packets, out_bytes);
+	printf("RX:           %"PRIu64" packets  %"PRIu64" bytes\n", in_packets, in_bytes);
+	printf("TX:           %"PRIu64" packets  %"PRIu64" bytes\n", out_packets, out_bytes);
 
 	// List edges
 	printf("Edges:       ");

--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -156,8 +156,8 @@ static void udp_probe_h(node_t *n, vpn_packet_t *packet, length_t len) {
 		gettimeofday(&now, NULL);
 		struct timeval rtt;
 		timersub(&now, &n->udp_ping_sent, &rtt);
-		n->udp_ping_rtt = rtt.tv_sec*1000000L + rtt.tv_usec;
-		logger(DEBUG_TRAFFIC, LOG_INFO, "Got type %d UDP probe reply %d from %s (%s) rtt=%ld.%03ld", DATA(packet)[0], len, n->name, n->hostname, n->udp_ping_rtt/1000, n->udp_ping_rtt%1000);
+		n->udp_ping_rtt = rtt.tv_sec*1000000 + rtt.tv_usec;
+		logger(DEBUG_TRAFFIC, LOG_INFO, "Got type %d UDP probe reply %d from %s (%s) rtt=%d.%03d", DATA(packet)[0], len, n->name, n->hostname, n->udp_ping_rtt / 1000, n->udp_ping_rtt % 1000);
 	} else {
 		logger(DEBUG_TRAFFIC, LOG_INFO, "Got type %d UDP probe reply %d from %s (%s)", DATA(packet)[0], len, n->name, n->hostname);
 	}

--- a/src/node.c
+++ b/src/node.c
@@ -212,7 +212,7 @@ bool dump_nodes(connection_t *c) {
 		}
 
 		id[sizeof(id) - 1] = 0;
-		send_request(c, "%d %d %s %s %s %d %d %d %d %x %x %s %s %d %d %d %d %ld %ld %lu %lu %lu %lu", CONTROL, REQ_DUMP_NODES,
+		send_request(c, "%d %d %s %s %s %d %d %d %d %x %x %s %s %d %d %d %d %ld %d %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64, CONTROL, REQ_DUMP_NODES,
 		             n->name, id, n->hostname ? : "unknown port unknown",
 #ifdef DISABLE_LEGACY
 		             0, 0, 0,
@@ -221,7 +221,7 @@ bool dump_nodes(connection_t *c) {
 #endif
 		             n->outcompression, n->options, bitfield_to_int(&n->status, sizeof(n->status)),
 		             n->nexthop ? n->nexthop->name : "-", n->via ? n->via->name ? : "-" : "-", n->distance,
-		             n->mtu, n->minmtu, n->maxmtu, (long)n->last_state_change, (long)n->udp_ping_rtt,
+		             n->mtu, n->minmtu, n->maxmtu, (long)n->last_state_change, n->udp_ping_rtt,
 		             n->in_packets, n->in_bytes, n->out_packets, n->out_bytes);
 	}
 

--- a/src/node.c
+++ b/src/node.c
@@ -212,7 +212,7 @@ bool dump_nodes(connection_t *c) {
 		}
 
 		id[sizeof(id) - 1] = 0;
-		send_request(c, "%d %d %s %s %s %d %d %d %d %x %x %s %s %d %d %d %d %ld %ld", CONTROL, REQ_DUMP_NODES,
+		send_request(c, "%d %d %s %s %s %d %d %d %d %x %x %s %s %d %d %d %d %ld %ld %lu %lu %lu %lu", CONTROL, REQ_DUMP_NODES,
 		             n->name, id, n->hostname ? : "unknown port unknown",
 #ifdef DISABLE_LEGACY
 		             0, 0, 0,
@@ -221,7 +221,8 @@ bool dump_nodes(connection_t *c) {
 #endif
 		             n->outcompression, n->options, bitfield_to_int(&n->status, sizeof(n->status)),
 		             n->nexthop ? n->nexthop->name : "-", n->via ? n->via->name ? : "-" : "-", n->distance,
-		             n->mtu, n->minmtu, n->maxmtu, (long)n->last_state_change, (long)n->udp_ping_rtt);
+		             n->mtu, n->minmtu, n->maxmtu, (long)n->last_state_change, (long)n->udp_ping_rtt,
+		             n->in_packets, n->in_bytes, n->out_packets, n->out_bytes);
 	}
 
 	return send_request(c, "%d %d", CONTROL, REQ_DUMP_NODES);

--- a/src/node.c
+++ b/src/node.c
@@ -80,6 +80,7 @@ node_t *new_node(void) {
 	n->edge_tree = new_edge_tree();
 	n->mtu = MTU;
 	n->maxmtu = MTU;
+	n->udp_ping_rtt = -1;
 
 	return n;
 }
@@ -211,7 +212,7 @@ bool dump_nodes(connection_t *c) {
 		}
 
 		id[sizeof(id) - 1] = 0;
-		send_request(c, "%d %d %s %s %s %d %d %d %d %x %x %s %s %d %d %d %d %ld", CONTROL, REQ_DUMP_NODES,
+		send_request(c, "%d %d %s %s %s %d %d %d %d %x %x %s %s %d %d %d %d %ld %ld", CONTROL, REQ_DUMP_NODES,
 		             n->name, id, n->hostname ? : "unknown port unknown",
 #ifdef DISABLE_LEGACY
 		             0, 0, 0,
@@ -220,7 +221,7 @@ bool dump_nodes(connection_t *c) {
 #endif
 		             n->outcompression, n->options, bitfield_to_int(&n->status, sizeof(n->status)),
 		             n->nexthop ? n->nexthop->name : "-", n->via ? n->via->name ? : "-" : "-", n->distance,
-		             n->mtu, n->minmtu, n->maxmtu, (long)n->last_state_change);
+		             n->mtu, n->minmtu, n->maxmtu, (long)n->last_state_change, (long)n->udp_ping_rtt);
 	}
 
 	return send_request(c, "%d %d", CONTROL, REQ_DUMP_NODES);

--- a/src/node.h
+++ b/src/node.h
@@ -92,6 +92,7 @@ typedef struct node_t {
 
 	struct timeval udp_reply_sent;          /* Last time a (gratuitous) UDP probe reply was sent */
 	struct timeval udp_ping_sent;           /* Last time a UDP probe was sent */
+	long int udp_ping_rtt;                  /* Round trip time of UDP ping (in microseconds) */
 	timeout_t udp_ping_timeout;             /* Ping timeout event */
 
 	struct timeval mtu_ping_sent;           /* Last time a MTU probe was sent */

--- a/src/node.h
+++ b/src/node.h
@@ -92,7 +92,7 @@ typedef struct node_t {
 
 	struct timeval udp_reply_sent;          /* Last time a (gratuitous) UDP probe reply was sent */
 	struct timeval udp_ping_sent;           /* Last time a UDP probe was sent */
-	long int udp_ping_rtt;                  /* Round trip time of UDP ping (in microseconds) */
+	int udp_ping_rtt;                       /* Round trip time of UDP ping (in microseconds; or -1 if !status.udp_confirmed) */
 	timeout_t udp_ping_timeout;             /* Ping timeout event */
 
 	struct timeval mtu_ping_sent;           /* Last time a MTU probe was sent */

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -1298,12 +1298,13 @@ static int cmd_dump(int argc, char *argv[]) {
 		unsigned int options, status_int;
 		node_status_t status;
 		long int last_state_change;
+		long int udp_ping_rtt;
 
 		switch(req) {
 		case REQ_DUMP_NODES: {
-			int n = sscanf(line, "%*d %*d %4095s %4095s %4095s port %4095s %d %d %d %d %x %x %4095s %4095s %d %hd %hd %hd %ld", node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_int, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change);
+			int n = sscanf(line, "%*d %*d %4095s %4095s %4095s port %4095s %d %d %d %d %x %x %4095s %4095s %d %hd %hd %hd %ld %ld", node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_int, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change, &udp_ping_rtt);
 
-			if(n != 17) {
+			if(n != 18) {
 				fprintf(stderr, "Unable to parse node dump from tincd: %s\n", line);
 				return 1;
 			}
@@ -1331,8 +1332,11 @@ static int cmd_dump(int argc, char *argv[]) {
 					continue;
 				}
 
-				printf("%s id %s at %s port %s cipher %d digest %d maclength %d compression %d options %x status %04x nexthop %s via %s distance %d pmtu %d (min %d max %d)\n",
+				printf("%s id %s at %s port %s cipher %d digest %d maclength %d compression %d options %x status %04x nexthop %s via %s distance %d pmtu %d (min %d max %d)",
 				       node, id, host, port, cipher, digest, maclength, compression, options, status_int, nexthop, via, distance, pmtu, minmtu, maxmtu);
+				if (udp_ping_rtt != -1)
+					printf(" rtt %ld.%03ld", udp_ping_rtt/1000, udp_ping_rtt%1000);
+				printf("\n");
 			}
 		}
 		break;

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -1298,12 +1298,12 @@ static int cmd_dump(int argc, char *argv[]) {
 		unsigned int options, status_int;
 		node_status_t status;
 		long int last_state_change;
-		long int udp_ping_rtt;
+		int udp_ping_rtt;
 		uint64_t in_packets, in_bytes, out_packets, out_bytes;
 
 		switch(req) {
 		case REQ_DUMP_NODES: {
-			int n = sscanf(line, "%*d %*d %4095s %4095s %4095s port %4095s %d %d %d %d %x %x %4095s %4095s %d %hd %hd %hd %ld %ld %lu %lu %lu %lu", node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_int, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change, &udp_ping_rtt, &in_packets, &in_bytes, &out_packets, &out_bytes);
+			int n = sscanf(line, "%*d %*d %4095s %4095s %4095s port %4095s %d %d %d %d %x %x %4095s %4095s %d %hd %hd %hd %ld %d %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64, node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_int, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change, &udp_ping_rtt, &in_packets, &in_bytes, &out_packets, &out_bytes);
 
 			if(n != 22) {
 				fprintf(stderr, "Unable to parse node dump from tincd: %s\n", line);
@@ -1333,10 +1333,10 @@ static int cmd_dump(int argc, char *argv[]) {
 					continue;
 				}
 
-				printf("%s id %s at %s port %s cipher %d digest %d maclength %d compression %d options %x status %04x nexthop %s via %s distance %d pmtu %d (min %d max %d) rx %lu %lu tx %lu %lu",
+				printf("%s id %s at %s port %s cipher %d digest %d maclength %d compression %d options %x status %04x nexthop %s via %s distance %d pmtu %d (min %d max %d) rx %"PRIu64" %"PRIu64" tx %"PRIu64" %"PRIu64,
 				       node, id, host, port, cipher, digest, maclength, compression, options, status_int, nexthop, via, distance, pmtu, minmtu, maxmtu, in_packets, in_bytes, out_packets, out_bytes);
 				if (udp_ping_rtt != -1)
-					printf(" rtt %ld.%03ld", udp_ping_rtt/1000, udp_ping_rtt%1000);
+					printf(" rtt %d.%03d", udp_ping_rtt / 1000, udp_ping_rtt % 1000);
 				printf("\n");
 			}
 		}

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -1299,12 +1299,13 @@ static int cmd_dump(int argc, char *argv[]) {
 		node_status_t status;
 		long int last_state_change;
 		long int udp_ping_rtt;
+		uint64_t in_packets, in_bytes, out_packets, out_bytes;
 
 		switch(req) {
 		case REQ_DUMP_NODES: {
-			int n = sscanf(line, "%*d %*d %4095s %4095s %4095s port %4095s %d %d %d %d %x %x %4095s %4095s %d %hd %hd %hd %ld %ld", node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_int, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change, &udp_ping_rtt);
+			int n = sscanf(line, "%*d %*d %4095s %4095s %4095s port %4095s %d %d %d %d %x %x %4095s %4095s %d %hd %hd %hd %ld %ld %lu %lu %lu %lu", node, id, host, port, &cipher, &digest, &maclength, &compression, &options, &status_int, nexthop, via, &distance, &pmtu, &minmtu, &maxmtu, &last_state_change, &udp_ping_rtt, &in_packets, &in_bytes, &out_packets, &out_bytes);
 
-			if(n != 18) {
+			if(n != 22) {
 				fprintf(stderr, "Unable to parse node dump from tincd: %s\n", line);
 				return 1;
 			}
@@ -1332,8 +1333,8 @@ static int cmd_dump(int argc, char *argv[]) {
 					continue;
 				}
 
-				printf("%s id %s at %s port %s cipher %d digest %d maclength %d compression %d options %x status %04x nexthop %s via %s distance %d pmtu %d (min %d max %d)",
-				       node, id, host, port, cipher, digest, maclength, compression, options, status_int, nexthop, via, distance, pmtu, minmtu, maxmtu);
+				printf("%s id %s at %s port %s cipher %d digest %d maclength %d compression %d options %x status %04x nexthop %s via %s distance %d pmtu %d (min %d max %d) rx %lu %lu tx %lu %lu",
+				       node, id, host, port, cipher, digest, maclength, compression, options, status_int, nexthop, via, distance, pmtu, minmtu, maxmtu, in_packets, in_bytes, out_packets, out_bytes);
 				if (udp_ping_rtt != -1)
 					printf(" rtt %ld.%03ld", udp_ping_rtt/1000, udp_ping_rtt%1000);
 				printf("\n");


### PR DESCRIPTION
Expose traffic stats (rx/tx packets and bytes) and UDP round-trip-times to external programs (including Tinc CLI).

Why:
1. Monitoring programs (```collectd```, ...) could collect the information, draw graphs, sends alerts

2. In the future, the nodes advertising the same subnet with the same weight could be sorted by UDP RTT (instead of alphanumerically as now) forming poor man anycast.
For example if all nodes running DNS server would advertise ```10.8.8.8``` in the Tinc network, the requests sent to ```10.8.8.8``` would be routed to the closer node instead of the first in the alphabet.

3. Keeping track of UDP RTT would allow to detect slow paths in underlying network.
It happens that ```A->B``` is 10ms and ```B->C``` is 10ms, but ```A->C``` is 200ms.
Currently there is no fix for that at the Tinc level but at least it would make the problem visible (and allows to solve it at least by sending support tickets to the ISP)
