### PR TITLE
Generate tinc-up.bat on windows

### DIFF
--- a/src/invitation.c
+++ b/src/invitation.c
@@ -987,7 +987,12 @@ ask_netname:
 
 	char filename2[PATH_MAX];
 	snprintf(filename, sizeof(filename), "%s" SLASH "tinc-up.invitation", confbase);
+
+#ifdef HAVE_MINGW
+	snprintf(filename2, sizeof(filename2), "%s" SLASH "tinc-up.bat", confbase);
+#else
 	snprintf(filename2, sizeof(filename2), "%s" SLASH "tinc-up", confbase);
+#endif
 
 	if(valid_tinc_up) {
 		if(tty) {


### PR DESCRIPTION
On windows a file called "tinc-up" won't be executed - it needs to be named tinc-up.bat. Since it is also documented like this, we should generate a bat file when using "tinc join" on windows.