### PR TITLE
Fix a strict aliasing violation in inet_checksum()

### DIFF
--- a/src/route.c
+++ b/src/route.c
@@ -59,7 +59,6 @@ static const size_t opt_size = sizeof(struct nd_opt_hdr);
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
-volatile int dummy;
 static timeout_t age_subnets_timeout;
 
 /* RFC 1071 */
@@ -79,11 +78,6 @@ static uint16_t inet_checksum(void *data, int len, uint16_t prevsum) {
 
 	while(checksum >> 16) {
 		checksum = (checksum & 0xFFFF) + (checksum >> 16);
-	}
-
-	// Work around a compiler optimization bug.
-	if(checksum) {
-		dummy = 1;
 	}
 
 	return ~checksum;

--- a/src/route.c
+++ b/src/route.c
@@ -64,16 +64,19 @@ static timeout_t age_subnets_timeout;
 /* RFC 1071 */
 
 static uint16_t inet_checksum(void *data, int len, uint16_t prevsum) {
-	uint16_t *p = data;
+	uint8_t *p = data;
+	uint16_t word;
 	uint32_t checksum = prevsum ^ 0xFFFF;
 
 	while(len >= 2) {
-		checksum += *p++;
+		memcpy(&word, p, sizeof(word));
+		checksum += word;
+		p += 2;
 		len -= 2;
 	}
 
 	if(len) {
-		checksum += *(uint8_t *)p;
+		checksum += *p;
 	}
 
 	while(checksum >> 16) {


### PR DESCRIPTION
inet_checksum() accesses packet data as an array of uint16_t, but the
packet data can be for example of "anonymous struct pseudo" type from
route_ipv6_unreachable().
This type isn't a compatible type with uint16_t so a strict aliasing
violation occurs and causes the checksum to be computed incorrectly.

This was previously worked around by commit 7c73cb3 that thought this was
a GCC bug, however it really isn't.

Fix this by using the memcpy() idiom to read the packet data as an array of
uint16_t in inet_checksum() (this should be understood by compilers and
optimized accordingly, so no actual copy occurs).