### PR TITLE
fd_device: allow fd to be passed through a unix socket

### DIFF
--- a/doc/tinc.conf.5.in
+++ b/doc/tinc.conf.5.in
@@ -235,7 +235,8 @@ Do NOT connect multiple
 daemons to the same multicast address, this will very likely cause routing loops.
 Also note that this can cause decrypted VPN packets to be sent out on a real network if misconfigured.
 .It fd
-Use a file descriptor.
+Use a file descriptor, given directly as an integer or passed through a unix domain socket.
+On Linux, an abstract socket address can be specified by using "@" as a prefix.
 All packets are read from this interface.
 Packets received for the local node are written to it.
 .It uml Pq not compiled in by default

--- a/doc/tinc.texi
+++ b/doc/tinc.texi
@@ -941,7 +941,8 @@ Also note that this can cause decrypted VPN packets to be sent out on a real net
 
 @cindex fd
 @item fd
-Use a file descriptor.
+Use a file descriptor, given directly as an integer or passed through a unix domain socket.
+On Linux, an abstract socket address can be specified by using "@" as a prefix.
 All packets are read from this interface.
 Packets received for the local node are written to it.
 


### PR DESCRIPTION
New restrictions on the Android OS forbid direct leaking of file descriptors.
This patch allows the tinc daemon to have an fd and the associated
permissions transferred to it through a Unix domain socket.