### PR TITLE
Use auto-clone device /dev/{tun,tap} as default on FreeBSD/DragonFly

### DIFF
--- a/src/bsd/device.c
+++ b/src/bsd/device.c
@@ -39,8 +39,13 @@
 #include <net/if_utun.h>
 #endif
 
+#if defined(HAVE_FREEBSD) || defined(HAVE_DRAGONFLY)
+#define DEFAULT_TUN_DEVICE "/dev/tun"  // Use the autoclone device
+#define DEFAULT_TAP_DEVICE "/dev/tap"
+#else
 #define DEFAULT_TUN_DEVICE "/dev/tun0"
 #define DEFAULT_TAP_DEVICE "/dev/tap0"
+#endif
 
 typedef enum device_type {
 	DEVICE_TYPE_TUN,


### PR DESCRIPTION
DragonFly BSD doesn't pre-create `/dev/tunX` or `/dev/tapX` devices
anymore since 2019-Jul-31 [0].  So it's better to use the auto-clone
device `/dev/tun` or `/dev/tap` as the default TUN or TAP device.
The TUN/TAP device has the same behavior on DragonFly BSD and FreeBSD.

See also pull request: https://github.com/DragonFlyBSD/DeltaPorts/pull/925

[0] https://github.com/DragonFlyBSD/DragonFlyBSD/commit/f1e9a4fff5aaac2be3a291dbfea94f94755991b8

See also PR #240 .  Please review.  Thanks.