### PR TITLE
[android] tincctl: restrict umask argument for FORTIFY

### DIFF
--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -237,7 +237,7 @@ static bool parse_options(int argc, char **argv) {
 FILE *fopenmask(const char *filename, const char *mode, mode_t perms) {
 	mode_t mask = umask(0);
 	perms &= ~mask;
-	umask(~perms);
+	umask(~perms & 0777);
 	FILE *f = fopen(filename, mode);
 
 	if(!f) {


### PR DESCRIPTION
`umask(mode)` calls that do not verify `(mode & 0777) == mode` are
rejected when the libc FORTIFY checks are enabled [1].

The unrestricted `~perms` was indeed making this assertion fail.

[1]: https://android.googlesource.com/platform/bionic/+/refs/tags/android-11.0.0_r3/libc/bionic/fortify.cpp#404

---

This is needed for tinc to correctly run when built with the latest Android NDK,
which enables the FORTIFY checks.