### PR TITLE
fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/src/openssl/crypto.c
+++ b/src/openssl/crypto.c
@@ -96,9 +96,10 @@ void crypto_init(void) {
 
 	ENGINE_load_builtin_engines();
 	ENGINE_register_all_complete();
-
+#if OPENSSL_API_COMPAT < 0x10100000L
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms();
+#endif
 
 	if(!RAND_status()) {
 		fprintf(stderr, "Not enough entropy for the PRNG!\n");
@@ -107,8 +108,10 @@ void crypto_init(void) {
 }
 
 void crypto_exit(void) {
+#if OPENSSL_API_COMPAT < 0x10100000L
 	EVP_cleanup();
 	ERR_free_strings();
 	ENGINE_cleanup();
+#endif
 	random_exit();
 }

--- a/src/openssl/rsa.c
+++ b/src/openssl/rsa.c
@@ -21,6 +21,7 @@
 
 #include <openssl/pem.h>
 #include <openssl/err.h>
+#include <openssl/rsa.h>
 
 #define TINC_RSA_INTERNAL
 typedef RSA rsa_t;


### PR DESCRIPTION
This was fixed for 1.0 but missing for 1.1.

Signed-off-by: Rosen Penev <rosenp@gmail.com>