### PR TITLE
Fix stack smash

### DIFF
--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -1082,12 +1082,12 @@ static void try_sptps(node_t *n) {
 
 static void send_udp_probe_packet(node_t *n, int len) {
 	vpn_packet_t packet;
-	packet.offset = DEFAULT_PACKET_OFFSET;
-	memset(DATA(&packet), 0, 14);
 	if(len > sizeof(packet.data)){	
 		logger(DEBUG_TRAFFIC, LOG_INFO, "Truncating probe length %d to %s (%s)", len, n->name, n->hostname);
 		len = sizeof(packet.data);
 	}
+	packet.offset = DEFAULT_PACKET_OFFSET;
+	memset(DATA(&packet), 0, 14);
 	randomize(DATA(&packet) + 14, len - 14);
 	packet.len = len;
 	packet.priority = 0;

--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -1084,6 +1084,10 @@ static void send_udp_probe_packet(node_t *n, int len) {
 	vpn_packet_t packet;
 	packet.offset = DEFAULT_PACKET_OFFSET;
 	memset(DATA(&packet), 0, 14);
+	if(len > sizeof(packet.data)){	
+		logger(DEBUG_TRAFFIC, LOG_INFO, "Truncating probe length %d to %s (%s)", len, n->name, n->hostname);
+		len = sizeof(packet.data);
+	}
 	randomize(DATA(&packet) + 14, len - 14);
 	packet.len = len;
 	packet.priority = 0;


### PR DESCRIPTION
Issue #252 proposed fix.

1. Prevent overrun of `send_udp_probe_packet`. It's low cost and helps make tinc safer for the future.
2. Prevent negative interval

In the case of negative interval minmtu will be used.