### PR TITLE
Add CI testing through GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,203 @@
+name: Build and test
+
+on:
+  push:
+    branches:
+      - master
+      - "1.1"
+    tags:
+      - "release-*"
+
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  test-linux:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+        compiler: [clang, gcc]
+        legacy_protocol: ["", --disable-legacy-protocol]
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+    env:
+      CC: ${{ matrix.compiler }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Artistic Style and build deps
+        run: >
+          sudo apt-get install -y --no-install-{recommends,suggests}
+          zlib1g-dev
+          liblzo2-dev
+          libncurses-dev
+          libreadline-dev
+          libminiupnpc-dev
+          libvdeplug-dev
+          astyle
+          socket
+
+      - name: Install OpenSSL
+        run: sudo apt-get install -y libssl-dev
+        if: ${{ matrix.legacy_protocol == '' }}
+
+      - name: Run autoreconf
+        run: autoreconf -fsi
+
+      - name: Run ./configure
+        run: >
+          ./configure 
+          --enable-{miniupnpc,uml,vde}
+          ${{ matrix.legacy_protocol }}
+
+      - name: Check code formatting
+        run: make check-style
+
+      - name: Compile project
+        run: make -j$(nproc)
+
+      - name: Run tests
+        # root is required for some tests
+        run: sudo make check-recursive
+        timeout-minutes: 20
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: tests_${{ matrix.os }}_${{ matrix.compiler }}
+          path: test/test-suite.log
+        if: failure()
+
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install msys2
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          # https://packages.msys2.org/package/
+          install: >-
+            base-devel
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-openssl
+            mingw-w64-x86_64-zlib
+            mingw-w64-x86_64-lzo2
+            mingw-w64-x86_64-ncurses
+            mingw-w64-x86_64-miniupnpc
+            git
+
+      - name: Build the project
+        shell: msys2 {0}
+        run: |
+          autoreconf -fsi
+          ./configure --with-curses-include=/mingw64/include/ncurses --disable-readline
+          make -j$(nproc)
+
+      - name: Check that tinc can be started
+        shell: msys2 {0}
+        run: ./src/tinc --version
+
+      - name: Check that tincd can be started
+        shell: msys2 {0}
+        run: ./src/tincd --version
+
+  release-deb:
+    if: startsWith(github.ref, 'refs/tags/release-')
+    needs: test-linux
+
+    strategy:
+      matrix:
+        os: ["ubuntu-18.04", ubuntu-20.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install build deps
+        run: >
+          sudo apt-get install -y --no-install-{recommends,suggests}
+          dh-make
+          texinfo
+          libssl-dev
+          zlib1g-dev
+          liblzo2-dev
+          libncurses-dev
+          libreadline-dev
+
+      - name: Run autoreconf
+        run: autoreconf -fsi
+
+      - name: Run ./configure
+        run: >
+          ./configure 
+          --prefix=/usr
+          --sbindir=/usr/sbin
+          --sysconfdir=/etc
+          --localstatedir=/var
+          --with-systemd=/usr/lib/systemd/system
+
+      - name: Prepare debian directory
+        run: >
+          dh_make
+          --yes
+          --single
+          --createorig
+          --copyright gpl2
+          --packagename "tinc_$(git describe --tags --always | sed 's/release-//')-${{ matrix.os }}"
+        env:
+          DEBFULLNAME: Automated Builds
+
+      - name: Build deb package
+        run: dpkg-buildpackage -d -us -uc
+
+      - name: Publish deb package
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ../*.deb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test-macos:
+    runs-on: macos-10.15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: brew install coreutils netcat automake lzo miniupnpc
+
+      - name: Run autoreconf
+        run: autoreconf -fsi
+
+      - name: Run ./configure
+        run: >
+          ./configure
+          --with-openssl=/usr/local/opt/openssl@1.1
+          --enable-{tunemu,miniupnpc}
+
+      - name: Compile application
+        run: make -j$(sysctl -n hw.ncpu)
+
+      - name: Run tests
+        run: make check-recursive
+        timeout-minutes: 20
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: tests_${{ runner.os }}
+          path: test/test-suite.log
+        if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.github/
 !.gitignore
 !.astylerc
 *.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,5 +36,8 @@ release:
 	/usr/bin/editor $(srcdir)/NEWS
 	$(MAKE) dist
 
+check-style:
+	astyle --options=.astylerc --dry-run -nQ src/*.[ch] src/*/*.[ch]
+
 astyle:
 	astyle --options=.astylerc -nQ src/*.[ch] src/*/*.[ch]

--- a/test/invite-offline.test
+++ b/test/invite-offline.test
@@ -15,7 +15,7 @@ EOF
 
 # Generate an invitation offline and let another node join the VPN
 
-invitation=`$tinc $c1 invite bar | sed 's/\r//'`
+invitation=`$tinc $c1 invite bar | tr -d '\r'`
 
 $tinc $c1 start $r1
 

--- a/test/legacy-protocol.test
+++ b/test/legacy-protocol.test
@@ -75,7 +75,7 @@ $tinc $c2 set ExperimentalProtocol no
 $tinc $c1 start $r1
 $tinc $c2 start $r2
 
-sleep 1
+sleep 5
 
 test `$tinc $c1 dump reachable nodes | wc -l` = 1
 test `$tinc $c2 dump reachable nodes | wc -l` = 1

--- a/test/scripts.test
+++ b/test/scripts.test
@@ -46,7 +46,7 @@ echo foo-started >>$OUT
 
 echo Inviting client node...
 
-url=`$tinc $c1 -n netname2 invite bar | sed 's/\r//'`
+url=`$tinc $c1 -n netname2 invite bar | tr -d '\r'`
 file=`cd $d1/invitations; ls | grep -v ed25519_key.priv`
 echo bar-invited >>$OUT
 
@@ -126,5 +126,6 @@ subnet-down netname,foo,dummy,,foo,,,fec0::/64,,,,5
 tinc-down netname,foo,dummy,,,,,,,,,5
 EOF
 
-sed -i 's/\r//' $OUT
-cmp $OUT $OUT.expected
+tr -d '\r' <$OUT >$OUT.actual
+
+cmp $OUT.actual $OUT.expected

--- a/test/security.test
+++ b/test/security.test
@@ -4,7 +4,12 @@
 
 # Skip this test if tools are missing
 
-which socket >/dev/null || exit 77
+which nc >/dev/null || exit 77
+
+if [ "$(uname)" = "Darwin" ]; then
+    alias timeout=gtimeout
+fi
+
 which timeout >/dev/null || exit 77
 
 # Initialize two nodes
@@ -37,29 +42,29 @@ $tinc $c2 start $r2
 
 # No ID sent by responding node if we don't send an ID first, before the timeout
 
-result=`(sleep 2; echo "0 bar 17.7") | timeout 3 socket localhost 32754` && exit 1
+result=`(sleep 2; echo "0 bar 17.7") | timeout 3 nc localhost 32754` && exit 1
 test $? = 124
 test -z "$result"
 
 # ID sent if initiator sends first, but still tarpitted
 
-result=`echo "0 bar 17.7" | timeout 3 socket localhost 32754` && exit 1
+result=`echo "0 bar 17.7" | timeout 3 nc localhost 32754` && exit 1
 test $? = 124
 test "`echo "$result" | head -c 10`" = "0 foo 17.7"
 
 # No invalid IDs allowed
 
-result=`echo "0 foo 17.7" | timeout 1 socket localhost 32754` && exit 1
+result=`echo "0 foo 17.7" | timeout 1 nc localhost 32754` && exit 1
 test $? = 124
 test -z "$result"
 
-result=`echo "0 baz 17.7" | timeout 1 socket localhost 32754` && exit 1
+result=`echo "0 baz 17.7" | timeout 1 nc localhost 32754` && exit 1
 test $? = 124
 test -z "$result"
 
 # No NULL METAKEYs allowed
 
-result=`printf "0 foo 17.0\n1 0 672 0 0 834188619F4D943FD0F4B1336F428BD4AC06171FEABA66BD2356BC9593F0ECD643F0E4B748C670D7750DFDE75DC9F1D8F65AB1026F5ED2A176466FBA4167CC567A2085ABD070C1545B180BDA86020E275EA9335F509C57786F4ED2378EFFF331869B856DDE1C05C461E4EECAF0E2FB97AF77B7BC2AD1B34C12992E45F5D1254BBF0C3FB224ABB3E8859594A83B6CA393ED81ECAC9221CE6BC71A727BCAD87DD80FC0834B87BADB5CB8FD3F08BEF90115A8DF1923D7CD9529729F27E1B8ABD83C4CF8818AE10257162E0057A658E265610B71F9BA4B365A20C70578FAC65B51B91100392171BA12A440A5E93C4AA62E0C9B6FC9B68F953514AAA7831B4B2C31C4\n" | timeout 3 socket localhost 32755` && exit 1
+result=`printf "0 foo 17.0\n1 0 672 0 0 834188619F4D943FD0F4B1336F428BD4AC06171FEABA66BD2356BC9593F0ECD643F0E4B748C670D7750DFDE75DC9F1D8F65AB1026F5ED2A176466FBA4167CC567A2085ABD070C1545B180BDA86020E275EA9335F509C57786F4ED2378EFFF331869B856DDE1C05C461E4EECAF0E2FB97AF77B7BC2AD1B34C12992E45F5D1254BBF0C3FB224ABB3E8859594A83B6CA393ED81ECAC9221CE6BC71A727BCAD87DD80FC0834B87BADB5CB8FD3F08BEF90115A8DF1923D7CD9529729F27E1B8ABD83C4CF8818AE10257162E0057A658E265610B71F9BA4B365A20C70578FAC65B51B91100392171BA12A440A5E93C4AA62E0C9B6FC9B68F953514AAA7831B4B2C31C4\n" | timeout 3 nc localhost 32755` && exit 1
 test $? = 124
 test -z "$result" # Not even the ID should be sent when the first packet contains illegal data
 

--- a/test/variables.test
+++ b/test/variables.test
@@ -5,18 +5,18 @@
 # Initialize one node
 
 $tinc $c1 init foo
-test "`$tinc $c1 get Name | sed 's/\r//'`" = "foo"
+test "`$tinc $c1 get Name | tr -d '\r'`" = "foo"
 
 # Test case sensitivity
 
 $tinc $c1 set Mode switch
-test "`$tinc $c1 get Mode | sed 's/\r//'`" = "switch"
-test "`$tinc $c1 get mode | sed 's/\r//'`" = "switch"
+test "`$tinc $c1 get Mode | tr -d '\r'`" = "switch"
+test "`$tinc $c1 get mode | tr -d '\r'`" = "switch"
 $tinc $c1 set mode router
-test "`$tinc $c1 get Mode | sed 's/\r//'`" = "router"
-test "`$tinc $c1 get mode | sed 's/\r//'`" = "router"
+test "`$tinc $c1 get Mode | tr -d '\r'`" = "router"
+test "`$tinc $c1 get mode | tr -d '\r'`" = "router"
 $tinc $c1 set Mode Switch
-test "`$tinc $c1 get Mode | sed 's/\r//'`" = "Switch"
+test "`$tinc $c1 get Mode | tr -d '\r'`" = "Switch"
 
 # Test deletion
 
@@ -28,7 +28,7 @@ test -z "`$tinc $c1 get Mode`"
 
 $tinc $c1 add Mode switch
 $tinc $c1 add Mode hub
-test "`$tinc $c1 get Mode | sed 's/\r//'`" = "hub"
+test "`$tinc $c1 get Mode | tr -d '\r'`" = "hub"
 
 # Test addition/deletion of multivalued variables
 
@@ -36,11 +36,11 @@ $tinc $c1 add Subnet 1
 $tinc $c1 add Subnet 2
 $tinc $c1 add Subnet 2
 $tinc $c1 add Subnet 3
-test "`$tinc $c1 get Subnet | sed 's/\r//'`" = "1
+test "`$tinc $c1 get Subnet | tr -d '\r'`" = "1
 2
 3"
 $tinc $c1 del Subnet 2
-test "`$tinc $c1 get Subnet | sed 's/\r//'`" = "1
+test "`$tinc $c1 get Subnet | tr -d '\r'`" = "1
 3"
 $tinc $c1 del Subnet
 test -z "`$tinc $c1 get Subnet`"
@@ -56,17 +56,17 @@ touch $d1/hosts/bar
 
 $tinc $c1 add bar.PMTU 1
 $tinc $c1 add bar.PMTU 2
-test "`$tinc $c1 get bar.PMTU | sed 's/\r//'`" = "2"
+test "`$tinc $c1 get bar.PMTU | tr -d '\r'`" = "2"
 
 $tinc $c1 add bar.Subnet 1
 $tinc $c1 add bar.Subnet 2
 $tinc $c1 add bar.Subnet 2
 $tinc $c1 add bar.Subnet 3
-test "`$tinc $c1 get bar.Subnet | sed 's/\r//'`" = "1
+test "`$tinc $c1 get bar.Subnet | tr -d '\r'`" = "1
 2
 3"
 $tinc $c1 del bar.Subnet 2
-test "`$tinc $c1 get bar.Subnet | sed 's/\r//'`" = "1
+test "`$tinc $c1 get bar.Subnet | tr -d '\r'`" = "1
 3"
 $tinc $c1 del bar.Subnet
 test -z "`$tinc $c1 get bar.Subnet`"
@@ -81,6 +81,6 @@ $tinc $c1 set qu-ux.Subnet 1 && exit 1 || true
 
 $tinc $c1 set PrivateKey 12345 && exit 1 || true
 $tinc $c1 --force set PrivateKey 12345
-test "`$tinc $c1 get PrivateKey | sed 's/\r//'`" = "12345"
+test "`$tinc $c1 get PrivateKey | tr -d '\r'`" = "12345"
 $tinc $c1 del PrivateKey
 test -z "`$tinc $c1 get PrivateKey`"


### PR DESCRIPTION
Hi,

This is a proposal to add CI to the project which will:

- build every incoming pull request (and pushes to main branches) on Linux/Windows/macOS, using different compilers and build flags
- check code formatting using existing astyle config
- run tests on every supported platform (Linux and macOS)
- when a release tag is pushed, build debs for Ubuntu 20.04 / 18.04 and attach them to the release

This will help with catching broken and badly formatted pull requests earlier without merging and manually testing everything.

The `.deb`s this thing produces are pretty far from what the Debian project recommends. As a user I would still like to see them though, possibly with a disclaimer ("auto builds, not supported, use at your own risk"). It's a pain to get tinc 1.1 binaries on my Ubuntu machines without relying on shady random PPAs.

## examples

- [push](https://github.com/hg/tinc/actions/runs/993794899)
- [PR](https://github.com/hg/tinc-old/pull/3/checks)
- [release tag](https://github.com/hg/tinc-old/actions/runs/991182690), [created release](https://github.com/hg/tinc-old/releases/tag/release-1.42)
- [broken test in PR](https://github.com/hg/tinc-old/pull/4/checks?check_run_id=2965357841) (logs at the bottom of the page [here](https://github.com/hg/tinc-old/actions/runs/991006586))

## tests

I had to change the tests a bit to make them run on macOS without switching everything to coreutils (this seems to be strongly advised against in their world.) They were mostly compatible, so why not? Please let me know if this should be dropped altogether, or moved to a separate PR.

Thank you for continuing to maintain this amazing project more more than two decades. It's miles ahead of everything released since then.