### PR TITLE
Add CI testing on FreeBSD/NetBSD/OpenBSD through sr.ht

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,0 +1,31 @@
+image: freebsd/13.x
+
+packages:
+  - gmake
+  - autotools
+  - openssl
+  - lzo2
+  - ncurses
+  - miniupnpc
+  - readline
+  - texinfo
+
+environment:
+  CFLAGS: -I/usr/local/include -L/usr/local/lib
+
+sources:
+  - https://github.com/gsliepen/tinc
+
+tasks:
+  - configure: |
+      cd tinc
+      autoreconf -fsi
+      ./configure --with-miniupnpc
+
+  - build: |
+      cd tinc
+      gmake -j$(sysctl -n hw.ncpu)
+
+  - test: |
+      cd tinc
+      gmake check-recursive VERBOSE=1

--- a/.builds/netbsd.yml
+++ b/.builds/netbsd.yml
@@ -1,0 +1,32 @@
+image: netbsd/9.x
+
+packages:
+  - gmake
+  - automake
+  - autoconf
+  - openssl
+  - lzo
+  - miniupnpc
+  - readline
+  - gtexinfo
+
+environment:
+  CFLAGS: -I/usr/pkg/include -L/usr/pkg/lib
+
+sources:
+  - https://github.com/gsliepen/tinc
+
+tasks:
+  - configure: |
+      cd tinc
+      autoreconf -fsi
+      ./configure --with-miniupnpc
+
+  - build: |
+      cd tinc
+      gmake -j$(sysctl -n hw.ncpu)
+
+  - test: |
+      cd tinc
+      export LD_LIBRARY_PATH=/usr/pkg/lib
+      gmake check-recursive VERBOSE=1

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,0 +1,33 @@
+image: openbsd/6.9
+
+packages:
+  - gmake
+  - automake-1.16.3
+  - autoconf-2.71
+  - openssl-1.1.1k
+  - lzo2
+  - miniupnpc
+  - readline
+  - texinfo
+
+environment:
+  AUTOCONF_VERSION: 2.71
+  AUTOMAKE_VERSION: 1.16
+  CFLAGS: -I/usr/local/include -L/usr/local/lib
+
+sources:
+  - https://github.com/gsliepen/tinc
+
+tasks:
+  - configure: |
+      cd tinc
+      autoreconf -fsi
+      ./configure --with-miniupnpc
+
+  - build: |
+      cd tinc
+      gmake -j$(sysctl -n hw.ncpu)
+
+  - test: |
+      cd tinc
+      gmake check-recursive VERBOSE=1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 !.github/
+!.builds/
 !.gitignore
 !.astylerc
 *.a


### PR DESCRIPTION
This was split off #277 to reduce its size a bit. It should only be merged after #277 because the current test suite does not run on BSDs (that's the reason they were bundled initially).

---

Historically there was some breakage on various BSDs due to lower amount of testing there. This should help with preventing it in the future.

The only decent service here is [sourcehut](https://builds.sr.ht). It's cheap and I'll be happy to cover at least the first two years. (Not affiliated, but very interested in more testing on less popular platforms).

Here are some of their users: [neovim](https://github.com/neovim/neovim/tree/master/.builds), [sway](https://github.com/swaywm/sway/tree/master/.builds), [wlroots](https://github.com/swaywm/wlroots/tree/master/.builds).

I'll post instructions on what to do next if this is merged.