### PR TITLE
Two bugfixes in MinGW build of tinc

### DIFF
--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -1107,7 +1107,7 @@ static int cmd_stop(int argc, char *argv[]) {
 	}
 
 #ifdef HAVE_MINGW
-	return remove_service();
+	return remove_service() ? EXIT_SUCCESS : EXIT_FAILURE;
 #else
 
 	if(!stop_tincd()) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -38,6 +38,7 @@ extern const char *winerror(int);
 #define sockinprogress(x) ((x) == WSAEINPROGRESS || (x) == WSAEWOULDBLOCK)
 #define sockinuse(x) ((x) == WSAEADDRINUSE)
 #define socknotconn(x) ((x) == WSAENOTCONN)
+#define sockshutdown(x) ((x) == WSAESHUTDOWN)
 #else
 #define sockerrno errno
 #define sockstrerror(x) strerror(x)


### PR DESCRIPTION
This was split off #277 to reduce its size. Sorry about that, won't happen again.

If you would like to see this properly tested, do not merge it before #277. Tests do not currently run on Windows. (Although this gives us the chicken-and-egg problem because most tests will fail without these bug fixes).

[This test run](https://github.com/hg/tinc/actions/runs/1017860304) (see also [the commit](https://github.com/hg/tinc/commit/f7890e11bb04585e15a1599fb51a4efe1cbf5383) that triggered it) includes changes from this PR and runs the fully compatible test suite from #277 on Windows.

---

# socket error checking in invitation.c

On Windows, `recv()` failures here

https://github.com/gsliepen/tinc/blob/2bc475274bd467532a1de0cf708072292d215474/src/invitation.c#L1325-L1331

were not handled properly and it printed "file already exists" (for a _socket_ error) in all `invite-*` tests: [before](https://github.com/gsliepen/tinc/files/6792199/invite-offline.before.log), [after](https://github.com/gsliepen/tinc/files/6792200/invite-offline.after.log).

It also did not detect socket shutdown after the initial exchange, which (after fixing the first thing) printed this:

```
Error reading data from 127.0.0.1 port 32759: (10058) A request to send or receive data was disallowed because the socket had already been shut down in that direction with aprevious shutdown call.
```

# src/tincctl.c: inverse exit code for 'tinc stop' on Windows

`tinc stop` on Windows returned the opposite of what it does on Unixen — 0 exit code for failure, 1 for success. See more [here](https://github.com/gsliepen/tinc/pull/277#discussion_r667323284).