### PR TITLE
Fix overrun in prf() if hmac size not divisible into key size

### DIFF
--- a/src/openssl/prf.c
+++ b/src/openssl/prf.c
@@ -67,11 +67,13 @@ static bool prf_xor(int nid, const char *secret, size_t secretlen, char *seed, s
 		}
 
 		/* XOR the results of the outer HMAC into the out buffer */
-		for(size_t i = 0; i < len && i < outlen; i++) {
+		size_t i;
+
+		for(i = 0; i < len && i < outlen; i++) {
 			*out++ ^= hash[i];
 		}
 
-		outlen -= len;
+		outlen -= i;
 	}
 
 	digest_close(digest);


### PR DESCRIPTION
Not seen only due to chacha having a 64byte key and a 64byte HMAC (SHA512) being used having a 64byte key and a 64byte HMAC (SHA512) being used

Found when exploring alternative crypto (AES).