### PR TITLE
src/getopt.h: add missing header guard

### DIFF
--- a/src/getopt.h
+++ b/src/getopt.h
@@ -133,3 +133,5 @@ extern int _getopt_internal();
 #endif
 
 #endif
+
+#endif /* TINC_GETOPT_H */


### PR DESCRIPTION
If the system is missing its own `getopt.h`, tinc uses the vendored copy.

If we simulate such a system by flipping the condition in `configure.ac`, [this is what we get](https://github.com/hg/tinc/runs/3045773719?check_suite_focus=true#step:8:54).

After applying this change it builds and [passes the test suite](https://github.com/hg/tinc/actions/runs/1022530587).