### PR TITLE
Allow running sptps_test on Windows

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -272,6 +272,10 @@ tincd_LDADD = $(MINIUPNPC_LIBS)
 tincd_LDFLAGS = -pthread
 endif
 
+if MINGW
+sptps_test_LDFLAGS = -pthread
+endif
+
 tinc_LDADD = $(READLINE_LIBS) $(CURSES_LIBS)
 sptps_speed_LDADD = -lrt
 


### PR DESCRIPTION
`sptps_test.c` was hanging on Windows and never sending any data because one is not supposed to call `select()` there on anything except proper BSD sockets.

After looking around the web for possible solutions I wasn't able to find anything less hackish than creating a separate thread which reads stdin and pushes data through a TCP socket to the main thread. The main thread can reuse the same `select()` loop that's used for every other operating system.

Here are the test results:
- [one](https://github.com/hg/tinc/runs/3087517825?check_suite_focus=true#step:6:56)
- [two](https://github.com/hg/tinc/runs/3087517790?check_suite_focus=true#step:6:57)
- [three](https://github.com/hg/tinc/runs/3091850792?check_suite_focus=true)
- [four](https://github.com/hg/tinc/runs/3091850806?check_suite_focus=true)
- [five](https://github.com/hg/tinc/runs/3091909047?check_suite_focus=true)
- [six](https://github.com/hg/tinc/runs/3091909055?check_suite_focus=true)
- [seven](https://github.com/hg/tinc/runs/3091952703?check_suite_focus=true)
- [eight](https://github.com/hg/tinc/runs/3091952707?check_suite_focus=true)
- [nine](https://github.com/hg/tinc/runs/3091983584?check_suite_focus=true)
- [ten](https://github.com/hg/tinc/runs/3091983594?check_suite_focus=true)

My C skills are very rusty. Apologies for the eye bleeds.

