### PR TITLE
Fix leaks triggered by integration test suite & enable ASAN in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         sanitizer:
+          - address
           - thread
           - undefined
     env:

--- a/src/conf.c
+++ b/src/conf.c
@@ -35,7 +35,7 @@
 #include "utils.h"              /* for cp */
 #include "xalloc.h"
 
-splay_tree_t *config_tree;
+splay_tree_t *config_tree = NULL;
 
 int pinginterval = 0;           /* seconds between pings */
 int pingtimeout = 0;            /* seconds to wait for response */

--- a/src/names.c
+++ b/src/names.c
@@ -50,6 +50,8 @@ void make_names(bool daemon) {
 		logger(DEBUG_ALWAYS, LOG_INFO, "Both netname and configuration directory given, using the latter...");
 	}
 
+	free(identname);
+
 	if(netname) {
 		xasprintf(&identname, "tinc.%s", netname);
 	} else {

--- a/src/sptps_keypair.c
+++ b/src/sptps_keypair.c
@@ -97,12 +97,14 @@ int main(int argc, char *argv[]) {
 	if(fp) {
 		if(!ecdsa_write_pem_private_key(key, fp)) {
 			fprintf(stderr, "Could not write ECDSA private key\n");
+			free(key);
 			return 1;
 		}
 
 		fclose(fp);
 	} else {
 		fprintf(stderr, "Could not open '%s' for writing: %s\n", argv[1], strerror(errno));
+		free(key);
 		return 1;
 	}
 
@@ -113,11 +115,12 @@ int main(int argc, char *argv[]) {
 			fprintf(stderr, "Could not write ECDSA public key\n");
 		}
 
+		free(key);
 		fclose(fp);
+		return 0;
 	} else {
 		fprintf(stderr, "Could not open '%s' for writing: %s\n", argv[2], strerror(errno));
+		free(key);
 		return 1;
 	}
-
-	return 0;
 }

--- a/test/commandline.test
+++ b/test/commandline.test
@@ -46,3 +46,19 @@ must_fail tinc foo -n foo get somethingreallyunknown
 must_fail tinc foo --net
 must_fail tinc foo --net get name
 must_fail tinc foo foo
+
+# Most of these should fail with ASAN. Some leaks are only detected by Valgrind.
+echo [STEP] Trigger previously known memory leaks
+
+tincd foo -c . -c . --help
+tincd foo -n net -n net --help
+tincd foo -n net -o FakeOpt=42 --help
+tincd foo --logfile=one --logfile=two --help
+tincd foo --pidfile=one --pidfile=two --help
+expect_code "$EXIT_FAILURE" tincd foo -n net -o Compression= --help
+expect_code "$EXIT_FAILURE" tincd foo -c fakedir -n 'n/e\t'
+
+tinc foo -c conf -c conf --help
+tinc foo -n net -n net --help
+tinc foo --pidfile=pid --pidfile=pid --help
+expect_code "$EXIT_FAILURE" tinc foo -c conf -n 'n/e\t'

--- a/test/testlib.sh.in
+++ b/test/testlib.sh.in
@@ -26,6 +26,8 @@ SPTPS_KEYPAIR=$(realdir "../src/sptps_keypair@EXEEXT@")
 
 # Exit status list
 # shellcheck disable=SC2034
+EXIT_FAILURE=1
+# shellcheck disable=SC2034
 EXIT_SKIP_TEST=77
 
 # The list of the environment variables that tinc injects into the scripts it calls.
@@ -95,6 +97,19 @@ rm_cr() {
 must_fail() {
   if "$@"; then
     bail "expected a non-zero exit code"
+  fi
+}
+
+# Executes whatever is passed to it, checking that the resulting exit code is equal to the first argument.
+expect_code() {
+  expected=$1
+  shift
+
+  code=0
+  "$@" || code=$?
+
+  if [ $code != "$expected" ]; then
+    bail "wrong exit code $code, expected $expected"
   fi
 }
 


### PR DESCRIPTION
This should fix all memory leaks that are triggered by running the integration test suite under ASAN.

Though these are definitely not all, fixing them lets us enable the ASAN job and spot new leaks right when they appear.

Tests:

- https://github.com/hg/tinc/actions/runs/1059688675
- https://github.com/hg/tinc/actions/runs/1059698688
