### PR TITLE
Fix known UndefinedBehaviorSanitizer warnings plus a few more leaks

### DIFF
--- a/.github/workflows/sanitizers/run.sh
+++ b/.github/workflows/sanitizers/run.sh
@@ -26,3 +26,12 @@ esac
 
 sudo --preserve-env=ASAN_OPTIONS,TSAN_OPTIONS,UBSAN_OPTIONS \
   make check VERBOSE=1
+
+# Check that the sanitizer has not created any log files.
+# If it has, fail the job to notify the developer.
+log_count=$(find "$logs" -type f -printf . | wc -c)
+
+if [ "$log_count" != 0 ]; then
+  echo "expected zero sanitizer logs, found $log_count"
+  exit 1
+fi

--- a/src/address_cache.c
+++ b/src/address_cache.c
@@ -67,6 +67,7 @@ static struct addrinfo *get_known_addresses(node_t *n) {
 static void free_known_addresses(struct addrinfo *ai) {
 	for(struct addrinfo *aip = ai, *next; aip; aip = next) {
 		next = aip->ai_next;
+		free(aip->ai_addr);
 		free(aip);
 	}
 }

--- a/src/connection.c
+++ b/src/connection.c
@@ -45,7 +45,10 @@ void init_connections(void) {
 
 void exit_connections(void) {
 	list_delete_list(connection_list);
+	connection_list = NULL;
+
 	free_connection(everyone);
+	everyone = NULL;
 }
 
 connection_t *new_connection(void) {

--- a/src/hash.c
+++ b/src/hash.c
@@ -29,11 +29,11 @@ static uint32_t hash_function(const void *p, size_t len) {
 	uint32_t hash = 0;
 
 	while(true) {
-		for(int i = len > 4 ? 4 : len; --i;) {
+		for(size_t i = len > 4 ? 4 : len; --i;) {
 			hash += (uint32_t)q[len - i] << (8 * i);
 		}
 
-		hash *= 0x9e370001UL; // Golden ratio prime.
+		hash = (uint32_t)(hash * 0x9e370001UL); // Golden ratio prime.
 
 		if(len <= 4) {
 			break;

--- a/src/invitation.c
+++ b/src/invitation.c
@@ -292,6 +292,7 @@ int cmd_invite(int argc, char *argv[]) {
 		return 1;
 	}
 
+	free(myname);
 	myname = get_my_name(true);
 
 	if(!myname) {

--- a/src/logger.c
+++ b/src/logger.c
@@ -94,7 +94,7 @@ static void real_logger(int level, int priority, const char *message) {
 		}
 	}
 
-	if(logcontrol) {
+	if(logcontrol && connection_list) {
 		suppress = true;
 		logcontrol = false;
 

--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -231,7 +231,7 @@ static bool read_ecdsa_private_key(void) {
 		return false;
 	}
 
-	if(s.st_mode & ~0100700) {
+	if(s.st_mode & ~0100700u) {
 		logger(DEBUG_ALWAYS, LOG_WARNING, "Warning: insecure file permissions for Ed25519 private key file `%s'!", fname);
 	}
 
@@ -323,7 +323,7 @@ static bool read_rsa_private_key(void) {
 		return false;
 	}
 
-	if(s.st_mode & ~0100700) {
+	if(s.st_mode & ~0100700u) {
 		logger(DEBUG_ALWAYS, LOG_WARNING, "Warning: insecure file permissions for RSA private key file `%s'!", fname);
 	}
 

--- a/src/net_socket.c
+++ b/src/net_socket.c
@@ -866,6 +866,8 @@ void try_outgoing_connections(void) {
 				node_add(n);
 			}
 
+			free(name);
+
 			outgoing->node = n;
 			list_insert_tail(outgoing_list, outgoing);
 			setup_outgoing_connection(outgoing, true);

--- a/src/protocol_auth.c
+++ b/src/protocol_auth.c
@@ -214,6 +214,9 @@ static bool finalize_invitation(connection_t *c, const char *data, uint16_t len)
 	environment_add(&env, "REMOTEADDRESS=%s", address);
 	environment_add(&env, "NAME=%s", myself->name);
 
+	free(address);
+	free(port);
+
 	execute_script("invitation-accepted", &env);
 
 	environment_exit(&env);

--- a/src/sptps.c
+++ b/src/sptps.c
@@ -92,7 +92,7 @@ static void warning(sptps_t *s, const char *format, ...) {
 
 // Send a record (datagram version, accepts all record types, handles encryption and authentication).
 static bool send_record_priv_datagram(sptps_t *s, uint8_t type, const void *data, uint16_t len) {
-	char buffer[len + 21UL];
+	uint8_t buffer[len + 21UL];
 
 	// Create header with sequence number, length and record type
 	uint32_t seqno = s->outseqno++;
@@ -117,7 +117,7 @@ static bool send_record_priv(sptps_t *s, uint8_t type, const void *data, uint16_
 		return send_record_priv_datagram(s, type, data, len);
 	}
 
-	char buffer[len + 19UL];
+	uint8_t buffer[len + 19UL];
 
 	// Create header with sequence number, length and record type
 	uint32_t seqno = s->outseqno++;
@@ -187,8 +187,8 @@ static bool send_sig(sptps_t *s) {
 	size_t siglen = ecdsa_size(s->mykey);
 
 	// Concatenate both KEX messages, plus tag indicating if it is from the connection originator, plus label
-	char msg[(1 + 32 + keylen) * 2 + 1 + s->labellen];
-	char sig[siglen];
+	uint8_t msg[(1 + 32 + keylen) * 2 + 1 + s->labellen];
+	uint8_t sig[siglen];
 
 	msg[0] = s->initiator;
 	memcpy(msg + 1, s->mykex, 1 + 32 + keylen);
@@ -253,7 +253,7 @@ static bool send_ack(sptps_t *s) {
 }
 
 // Receive an ACKnowledgement record.
-static bool receive_ack(sptps_t *s, const char *data, uint16_t len) {
+static bool receive_ack(sptps_t *s, const uint8_t *data, uint16_t len) {
 	(void)data;
 
 	if(len) {
@@ -278,7 +278,7 @@ static bool receive_ack(sptps_t *s, const char *data, uint16_t len) {
 }
 
 // Receive a Key EXchange record, respond by sending a SIG record.
-static bool receive_kex(sptps_t *s, const char *data, uint16_t len) {
+static bool receive_kex(sptps_t *s, const uint8_t *data, uint16_t len) {
 	// Verify length of the HELLO record
 	if(len != 1 + 32 + ECDH_SIZE) {
 		return error(s, EIO, "Invalid KEX record length");
@@ -307,7 +307,7 @@ static bool receive_kex(sptps_t *s, const char *data, uint16_t len) {
 }
 
 // Receive a SIGnature record, verify it, if it passed, compute the shared secret and calculate the session keys.
-static bool receive_sig(sptps_t *s, const char *data, uint16_t len) {
+static bool receive_sig(sptps_t *s, const uint8_t *data, uint16_t len) {
 	size_t keylen = ECDH_SIZE;
 	size_t siglen = ecdsa_size(s->hiskey);
 
@@ -317,7 +317,7 @@ static bool receive_sig(sptps_t *s, const char *data, uint16_t len) {
 	}
 
 	// Concatenate both KEX messages, plus tag indicating if it is from the connection originator
-	char msg[(1 + 32 + keylen) * 2 + 1 + s->labellen];
+	uint8_t msg[(1 + 32 + keylen) * 2 + 1 + s->labellen];
 
 	msg[0] = !s->initiator;
 	memcpy(msg + 1, s->hiskex, 1 + 32 + keylen);
@@ -383,7 +383,7 @@ bool sptps_force_kex(sptps_t *s) {
 }
 
 // Receive a handshake record.
-static bool receive_handshake(sptps_t *s, const char *data, uint16_t len) {
+static bool receive_handshake(sptps_t *s, const uint8_t *data, uint16_t len) {
 	// Only a few states to deal with handshaking.
 	switch(s->state) {
 	case SPTPS_SECONDARY_KEX:
@@ -528,7 +528,7 @@ bool sptps_verify_datagram(sptps_t *s, const void *vdata, size_t len) {
 }
 
 // Receive incoming data, datagram version.
-static bool sptps_receive_data_datagram(sptps_t *s, const char *data, size_t len) {
+static bool sptps_receive_data_datagram(sptps_t *s, const uint8_t *data, size_t len) {
 	if(len < (s->instate ? 21 : 5)) {
 		return error(s, EIO, "Received short packet");
 	}
@@ -558,7 +558,7 @@ static bool sptps_receive_data_datagram(sptps_t *s, const char *data, size_t len
 
 	// Decrypt
 
-	char buffer[len];
+	uint8_t buffer[len];
 	size_t outlen;
 
 	if(!chacha_poly1305_decrypt(s->incipher, seqno, data, len, buffer, &outlen)) {
@@ -599,7 +599,7 @@ static bool sptps_receive_data_datagram(sptps_t *s, const char *data, size_t len
 
 // Receive incoming data. Check if it contains a complete record, if so, handle it.
 size_t sptps_receive_data(sptps_t *s, const void *vdata, size_t len) {
-	const char *data = vdata;
+	const uint8_t *data = vdata;
 	size_t total_read = 0;
 
 	if(!s->state) {

--- a/src/sptps.h
+++ b/src/sptps.h
@@ -50,7 +50,7 @@ typedef struct sptps {
 	bool datagram;
 	int state;
 
-	char *inbuf;
+	uint8_t *inbuf;
 	size_t buflen;
 	uint16_t reclen;
 

--- a/src/subnet_parse.c
+++ b/src/subnet_parse.c
@@ -186,9 +186,7 @@ static int subnet_compare_ipv6(const subnet_t *a, const subnet_t *b) {
 }
 
 int subnet_compare(const subnet_t *a, const subnet_t *b) {
-	int result;
-
-	result = a->type - b->type;
+	int result = (int)a->type - (int)b->type;
 
 	if(result) {
 		return result;

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -1884,7 +1884,7 @@ static int cmd_config(int argc, char *argv[]) {
 	char *node = NULL;
 	char *variable;
 	char *value;
-	int len;
+	size_t len;
 
 	len = strcspn(line, "\t =");
 	value = line + len;

--- a/src/utils.c
+++ b/src/utils.c
@@ -54,7 +54,7 @@ static int charhex2bin(char c) {
 }
 
 size_t hex2bin(const char *src, void *vdst, size_t length) {
-	char *dst = vdst;
+	uint8_t *dst = vdst;
 	size_t i;
 
 	for(i = 0; i < length && isxdigit(src[i * 2]) && isxdigit(src[i * 2 + 1]); i++) {
@@ -67,7 +67,8 @@ size_t hex2bin(const char *src, void *vdst, size_t length) {
 size_t bin2hex(const void *vsrc, char *dst, size_t length) {
 	const char *src = vsrc;
 
-	for(size_t i = length; i-- > 0;) {
+	for(size_t i = length; i > 0;) {
+		--i;
 		dst[i * 2 + 1] = hexadecimals[(unsigned char) src[i] & 15];
 		dst[i * 2] = hexadecimals[(unsigned char) src[i] >> 4];
 	}

--- a/test/commandline.test
+++ b/test/commandline.test
@@ -28,9 +28,9 @@ tincd foo -D --net foo
 
 echo [STEP] Test tincd command line options that should not work
 
-must_fail tincd foo foo
-must_fail tincd foo --pidfile
-must_fail tincd foo --foo
+expect_code "$EXIT_FAILURE" tincd foo foo
+expect_code "$EXIT_FAILURE" tincd foo --pidfile
+expect_code "$EXIT_FAILURE" tincd foo --foo
 
 echo [STEP] Test tinc command line options that should work
 
@@ -42,10 +42,10 @@ tinc foo --net foo get name
 
 echo [STEP] Test tinc command line options that should not work
 
-must_fail tinc foo -n foo get somethingreallyunknown
-must_fail tinc foo --net
-must_fail tinc foo --net get name
-must_fail tinc foo foo
+expect_code "$EXIT_FAILURE" tinc foo -n foo get somethingreallyunknown
+expect_code "$EXIT_FAILURE" tinc foo --net
+expect_code "$EXIT_FAILURE" tinc foo --net get name
+expect_code "$EXIT_FAILURE" tinc foo foo
 
 # Most of these should fail with ASAN. Some leaks are only detected by Valgrind.
 echo [STEP] Trigger previously known memory leaks

--- a/test/compression.test
+++ b/test/compression.test
@@ -124,7 +124,7 @@ for level in $bogus_levels; do
   echo "[STEP] Testing bogus compression level $level"
   tinc foo set Compression "$level"
 
-  output=$(must_fail start_tinc foo 2>&1)
+  output=$(expect_code "$EXIT_FAILURE" start_tinc foo 2>&1)
 
   if ! echo "$output" | grep -q 'Bogus compression level'; then
     bail 'expected message about the wrong compression level'

--- a/test/splice.c
+++ b/test/splice.c
@@ -70,15 +70,16 @@ int main(int argc, char *argv[]) {
 	int sock[2];
 	char buf[1024];
 
-	struct addrinfo *ai, hint;
-	memset(&hint, 0, sizeof(hint));
-
-	hint.ai_family = AF_UNSPEC;
-	hint.ai_socktype = SOCK_STREAM;
-	hint.ai_protocol = IPPROTO_TCP;
-	hint.ai_flags = 0;
+	const struct addrinfo hint = {
+		.ai_family = AF_UNSPEC,
+		.ai_socktype = SOCK_STREAM,
+		.ai_protocol = IPPROTO_TCP,
+		.ai_flags = 0,
+	};
 
 	for(int i = 0; i < 2; i++) {
+		struct addrinfo *ai;
+
 		if(getaddrinfo(argv[2 + 3 * i], argv[3 + 3 * i], &hint, &ai) || !ai) {
 			fprintf(stderr, "getaddrinfo() failed: %s\n", sockstrerror(sockerrno));
 			return 1;
@@ -88,13 +89,17 @@ int main(int argc, char *argv[]) {
 
 		if(sock[i] == -1) {
 			fprintf(stderr, "Could not create socket: %s\n", sockstrerror(sockerrno));
+			freeaddrinfo(ai);
 			return 1;
 		}
 
 		if(connect(sock[i], ai->ai_addr, ai->ai_addrlen)) {
 			fprintf(stderr, "Could not connect to %s: %s\n", argv[i + 3 * i], sockstrerror(sockerrno));
+			freeaddrinfo(ai);
 			return 1;
 		}
+
+		freeaddrinfo(ai);
 
 		fprintf(stderr, "Connected to %s\n", argv[1 + 3 * i]);
 

--- a/test/variables.test
+++ b/test/variables.test
@@ -22,7 +22,7 @@ test "$(tinc foo get Mode)" = "Switch"
 
 echo [STEP] Test deletion
 
-must_fail tinc foo del Mode hub
+expect_code "$EXIT_FAILURE" tinc foo del Mode hub
 tinc foo del Mode switch
 test -z "$(tinc foo get Mode)"
 
@@ -52,7 +52,7 @@ test -z "$(tinc foo get Subnet)"
 echo [STEP] We should not be able to get/set server variables using node.variable syntax
 
 test -z "$(tinc foo get foo.Name)"
-must_fail tinc foo set foo.Name bar
+expect_code "$EXIT_FAILURE" tinc foo set foo.Name bar
 
 echo [STEP] Test getting/setting host variables for other nodes
 
@@ -80,11 +80,11 @@ test -z "$(tinc foo get bar.Subnet)"
 echo [STEP] We should not be able to get/set for nodes with invalid names
 
 touch "$DIR_FOO/hosts/qu-ux"
-must_fail tinc foo set qu-ux.Subnet 1
+expect_code "$EXIT_FAILURE" tinc foo set qu-ux.Subnet 1
 
 echo [STEP] We should not be able to set obsolete variables unless forced
 
-must_fail tinc foo set PrivateKey 12345
+expect_code "$EXIT_FAILURE" tinc foo set PrivateKey 12345
 tinc foo --force set PrivateKey 12345
 test "$(tinc foo get PrivateKey)" = "12345"
 


### PR DESCRIPTION
This fixes all UBSAN warnings triggered by the integration test suite, plus a bunch of leaks across the project.

`tinc fsck` has a couple more memory safety issues and some other errors (that are not currently detected by tests), but it's so complicated that I've been refactoring and testing it for a while.

It's a relatively large patch, so I'll send it separately (after this one, because it builds on top of this.)

Tests:

- https://github.com/hg/tinc/actions/runs/1064499905 (two separate successful runs that GitHub shows as a single one)
- https://builds.sr.ht/~reducer/job/551897
- https://builds.sr.ht/~reducer/job/551898
- https://builds.sr.ht/~reducer/job/551899

---

What are your thoughts on fixing *a lot* of clang-tidy warnings similar to:

- Narrowing conversion from 'unsigned long' to signed type 'int' is implementation-defined
  - these in particular often tend to trigger UBSAN at run time
- 'sscanf' used to convert a string to an integer value, but function will not report conversion errors; consider using 'strtol' instead
- 'atoi' used to convert a string to an integer value, but function will not report conversion errors; consider using 'strtol' instead
- Unused `header_name.h`
- Declaration shadows a local variable
- Declaration shadows a variable in the global scope
- …

and then adding clang-tidy with `-Werror` to CI?

I would like to reduce the number of these to zero.  However, it will produce a large diff which would be difficult to slice into pieces because fixing one warning often requires changing global functions or fields in widely used structs, which produces further warnings, and so on.

Will you accept patches to clean this up, seeing that this is not absolutely necessary and (as always) has a chance of breaking something?

