### PR TITLE
`tinc fsck`: refactor, implement TODOs, fix bugs, reuse code from tincd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,20 +107,21 @@ jobs:
     container:
       image: ${{ matrix.os }}
       options: --privileged
-
+      env:
+        CI: 1
     steps:
       - name: Install deps (Alpine)
         run: >
           apk add git binutils make autoconf automake gcc linux-headers libtool
           diffutils texinfo procps openssl-dev zlib-dev lzo-dev ncurses-dev
-          readline-dev musl-dev lz4-dev socat
+          readline-dev musl-dev lz4-dev socat shadow sudo
         if: startsWith(matrix.os, 'alpine')
 
       - name: Install deps (Debian and Ubuntu)
         shell: bash
         run: |
           apt-get update
-          apt-get install -y git binutils make autoconf automake gcc diffutils \
+          apt-get install -y git binutils make autoconf automake gcc diffutils sudo \
             texinfo netcat procps socat zlib1g-dev lib{ssl,lzo2,lz4,ncurses,readline}-dev
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -134,7 +135,7 @@ jobs:
             dnf config-manager --enable powertools
           fi
           yum install -y epel-release
-          yum install -y git binutils make autoconf automake gcc diffutils \
+          yum install -y git binutils make autoconf automake gcc diffutils sudo \
             texinfo netcat procps socat {lzo,zlib,lz4,ncurses,readline}-devel
           yum install -y openssl11-devel || yum install -y openssl-devel
         if: startsWith(matrix.os, 'centos') || startsWith(matrix.os, 'alma')
@@ -142,7 +143,7 @@ jobs:
       - name: Install deps (SUSE)
         shell: bash
         run: >
-          zypper install -y tar git binutils make autoconf automake gcc procps
+          zypper install -y tar git binutils make autoconf automake gcc procps sudo
           makeinfo diffutils gzip socat {openssl,zlib,lzo,liblz4,ncurses,readline}-devel
         if: startsWith(matrix.os, 'opensuse')
 
@@ -154,11 +155,17 @@ jobs:
       - name: Assign name for test results artifact
         run: echo TEST_ARTIFACT="$(echo '${{ matrix.os }}' | sed 's|[:/]|_|g')" >>"$GITHUB_ENV"
 
+      - name: Create a non-privileged user
+        run: |
+          useradd --user-group build
+          chown -R build:build .
+          echo 'build ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/build
+
       - name: Run tests with default settings
-        run: sh .github/workflows/test/run.sh default
+        run: sudo -u build CI=1 sh .github/workflows/test/run.sh default
 
       - name: Run tests without legacy protocol
-        run: sh .github/workflows/test/run.sh nolegacy
+        run: sudo -u build CI=1 sh .github/workflows/test/run.sh nolegacy
 
       - name: Upload test results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test/run.sh
+++ b/.github/workflows/test/run.sh
@@ -20,11 +20,12 @@ run_tests() {
   header "Cleaning up leftovers from previous runs"
 
   for name in tinc tincd; do
-    pkill -TERM -x "$name" || true
-    pkill -KILL -x "$name" || true
+    sudo pkill -TERM -x "$name" || true
+    sudo pkill -KILL -x "$name" || true
   done
 
-  git clean -dfx
+  sudo git clean -dfx
+  sudo chown -R build:build .
 
   header "Running test flavor $flavor"
 
@@ -44,7 +45,7 @@ run_tests() {
   code=0
   make check -j2 VERBOSE=1 || code=$?
 
-  tar -c -z -f "/tmp/tests.$flavor.tar.gz" test/
+  sudo tar -c -z -f "/tmp/tests.$flavor.tar.gz" test/
 
   return $code
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,6 +53,7 @@ tincd_SOURCES = \
 	buffer.c buffer.h \
 	cipher.h \
 	conf.c conf.h \
+	conf_net.c conf_net.h \
 	connection.c connection.h \
 	control.c control.h \
 	control_common.h \
@@ -70,6 +71,7 @@ tincd_SOURCES = \
 	fd_device.c \
 	graph.c graph.h \
 	hash.c hash.h \
+	keys.c keys.h \
 	have.h \
 	ipv4.h \
 	ipv6.h \
@@ -118,6 +120,9 @@ tinc_SOURCES = \
 	ifconfig.c ifconfig.h \
 	info.c info.h \
 	invitation.c invitation.h \
+	conf.c conf.h \
+	keys.c keys.h \
+	splay_tree.c splay_tree.h \
 	list.c list.h \
 	names.c names.h \
 	netutl.c netutl.h \

--- a/src/conf.c
+++ b/src/conf.c
@@ -193,29 +193,6 @@ bool get_config_address(const config_t *cfg, struct addrinfo **result) {
 	return false;
 }
 
-bool get_config_subnet(const config_t *cfg, subnet_t **result) {
-	subnet_t subnet = {0};
-
-	if(!cfg) {
-		return false;
-	}
-
-	if(!str2net(&subnet, cfg->value)) {
-		logger(DEBUG_ALWAYS, LOG_ERR, "Subnet expected for configuration variable %s in %s line %d",
-		       cfg->variable, cfg->file, cfg->line);
-		return false;
-	}
-
-	if(subnetcheck(subnet)) {
-		*(*result = new_subnet()) = subnet;
-		return true;
-	}
-
-	logger(DEBUG_ALWAYS, LOG_ERR, "Network address and prefix length do not match for configuration variable %s in %s line %d",
-	       cfg->variable, cfg->file, cfg->line);
-	return false;
-}
-
 /*
   Read exactly one line and strip the trailing newline if any.
 */
@@ -359,6 +336,10 @@ bool read_config_file(splay_tree_t *config_tree, const char *fname, bool verbose
 }
 
 void read_config_options(splay_tree_t *config_tree, const char *prefix) {
+	if(!cmdline_conf) {
+		return;
+	}
+
 	size_t prefix_len = prefix ? strlen(prefix) : 0;
 
 	for(const list_node_t *node = cmdline_conf->tail; node; node = node->prev) {
@@ -392,7 +373,7 @@ void read_config_options(splay_tree_t *config_tree, const char *prefix) {
 	}
 }
 
-bool read_server_config(void) {
+bool read_server_config(splay_tree_t *config_tree) {
 	char fname[PATH_MAX];
 	bool x;
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -52,12 +52,11 @@ extern bool get_config_bool(const config_t *config, bool *result);
 extern bool get_config_int(const config_t *config, int *result);
 extern bool get_config_string(const config_t *config, char **result);
 extern bool get_config_address(const config_t *config, struct addrinfo **result);
-extern bool get_config_subnet(const config_t *config, struct subnet_t **result);
 
 extern config_t *parse_config_line(char *line, const char *fname, int lineno);
 extern bool read_config_file(splay_tree_t *config_tree, const char *filename, bool verbose);
 extern void read_config_options(splay_tree_t *config_tree, const char *prefix);
-extern bool read_server_config(void);
+extern bool read_server_config(splay_tree_t *config_tree);
 extern bool read_host_config(splay_tree_t *config_tree, const char *name, bool verbose);
 extern bool append_config_file(const char *name, const char *key, const char *value);
 

--- a/src/conf_net.c
+++ b/src/conf_net.c
@@ -1,0 +1,26 @@
+#include "conf_net.h"
+#include "logger.h"
+
+bool get_config_subnet(const config_t *cfg, subnet_t **result) {
+	subnet_t subnet = {0};
+
+	if(!cfg) {
+		return false;
+	}
+
+	if(!str2net(&subnet, cfg->value)) {
+		logger(DEBUG_ALWAYS, LOG_ERR, "Subnet expected for configuration variable %s in %s line %d",
+		       cfg->variable, cfg->file, cfg->line);
+		return false;
+	}
+
+	if(subnetcheck(subnet)) {
+		*(*result = new_subnet()) = subnet;
+		return true;
+	}
+
+	logger(DEBUG_ALWAYS, LOG_ERR, "Network address and prefix length do not match for configuration variable %s in %s line %d",
+	       cfg->variable, cfg->file, cfg->line);
+	return false;
+}
+

--- a/src/conf_net.h
+++ b/src/conf_net.h
@@ -1,0 +1,10 @@
+#ifndef TINC_NET_CONF_H
+#define TINC_NET_CONF_H
+
+#include "system.h"
+#include "conf.h"
+#include "subnet.h"
+
+extern bool get_config_subnet(const config_t *config, struct subnet_t **result);
+
+#endif // TINC_NET_CONF_H

--- a/src/fsck.c
+++ b/src/fsck.c
@@ -18,7 +18,6 @@
 */
 
 #include "system.h"
-
 #include "crypto.h"
 #include "ecdsa.h"
 #include "ecdsagen.h"
@@ -30,6 +29,11 @@
 #endif
 #include "tincctl.h"
 #include "utils.h"
+#include "xalloc.h"
+#include "keys.h"
+#include "conf.h"
+
+static const char *exe_name = NULL;
 
 static bool ask_fix(void) {
 	if(force) {
@@ -60,13 +64,13 @@ again:
 	goto again;
 }
 
-static void print_tinc_cmd(const char *argv0, const char *format, ...) {
+static void print_tinc_cmd(const char *format, ...) {
 	if(confbasegiven) {
-		fprintf(stderr, "%s -c %s ", argv0, confbase);
+		fprintf(stderr, "%s -c %s ", exe_name, confbase);
 	} else if(netname) {
-		fprintf(stderr, "%s -n %s ", argv0, netname);
+		fprintf(stderr, "%s -n %s ", exe_name, netname);
 	} else {
-		fprintf(stderr, "%s ", argv0);
+		fprintf(stderr, "%s ", exe_name);
 	}
 
 	va_list va;
@@ -74,6 +78,33 @@ static void print_tinc_cmd(const char *argv0, const char *format, ...) {
 	vfprintf(stderr, format, va);
 	va_end(va);
 	fputc('\n', stderr);
+}
+
+typedef enum {
+	KEY_RSA,
+	KEY_ED25519,
+	KEY_BOTH,
+} key_type_t;
+
+static void print_new_keys_cmd(key_type_t key_type, const char *message) {
+	fprintf(stderr, "%s\n\n", message);
+
+	switch(key_type) {
+	case KEY_RSA:
+		fprintf(stderr, "You can generate a new RSA keypair with:\n\n");
+		print_tinc_cmd("generate-rsa-keys");
+		break;
+
+	case KEY_ED25519:
+		fprintf(stderr, "You can generate a new Ed25519 keypair with:\n\n");
+		print_tinc_cmd("generate-ed25519-keys");
+		break;
+
+	case KEY_BOTH:
+		fprintf(stderr, "You can generate new keys with:\n\n");
+		print_tinc_cmd("generate-keys");
+		break;
+	}
 }
 
 static int strtailcmp(const char *str, const char *tail) {
@@ -87,453 +118,336 @@ static int strtailcmp(const char *str, const char *tail) {
 	return memcmp(str + slen - tlen, tail, tlen);
 }
 
-static void check_conffile(const char *fname, bool server) {
-	(void)server;
+static void check_conffile(const char *nodename, bool server) {
+	splay_tree_t *config = NULL;
+	init_configuration(&config);
 
-	FILE *f = fopen(fname, "r");
+	bool read;
 
-	if(!f) {
-		fprintf(stderr, "ERROR: cannot read %s: %s\n", fname, strerror(errno));
+	if(server) {
+		read = read_server_config(config);
+	} else {
+		read = read_host_config(config, nodename, true);
+	}
+
+	if(!read) {
+		exit_configuration(&config);
 		return;
 	}
 
-	char line[2048];
-	int lineno = 0;
-	bool skip = false;
-	const int maxvariables = 50;
-	int count[maxvariables];
+	size_t total_vars = 0;
+
+	while(variables[total_vars].name) {
+		++total_vars;
+	}
+
+	int count[total_vars];
 	memset(count, 0, sizeof(count));
 
-	while(fgets(line, sizeof(line), f)) {
-		if(skip) {
-			if(!strncmp(line, "-----END", 8)) {
-				skip = false;
-			}
+	for splay_each(config_t, conf, config) {
+		int var_type = 0;
 
-			continue;
-		} else {
-			if(!strncmp(line, "-----BEGIN", 10)) {
-				skip = true;
-				continue;
-			}
-		}
-
-		int len;
-		char *variable, *value, *eol;
-		variable = value = line;
-
-		lineno++;
-
-		eol = line + strlen(line);
-
-		while(strchr("\t \r\n", *--eol)) {
-			*eol = '\0';
-		}
-
-		if(!line[0] || line[0] == '#') {
-			continue;
-		}
-
-		len = strcspn(value, "\t =");
-		value += len;
-		value += strspn(value, "\t ");
-
-		if(*value == '=') {
-			value++;
-			value += strspn(value, "\t ");
-		}
-
-		variable[len] = '\0';
-
-		bool found = false;
-
-		for(int i = 0; variables[i].name; i++) {
-			if(strcasecmp(variables[i].name, variable)) {
-				continue;
-			}
-
-			found = true;
-
-			if(variables[i].type & VAR_OBSOLETE) {
-				fprintf(stderr, "WARNING: obsolete variable %s in %s line %d\n", variable, fname, lineno);
-			}
-
-			if(i < maxvariables) {
+		for(size_t i = 0; variables[i].name; ++i) {
+			if(strcasecmp(variables[i].name, conf->variable) == 0) {
 				count[i]++;
+				var_type = variables[i].type;
 			}
 		}
 
-		if(!found) {
-			fprintf(stderr, "WARNING: unknown variable %s in %s line %d\n", variable, fname, lineno);
+		if(var_type == 0) {
+			continue;
 		}
 
-		if(!*value) {
-			fprintf(stderr, "ERROR: no value for variable %s in %s line %d\n", variable, fname, lineno);
+		if(var_type & VAR_OBSOLETE) {
+			fprintf(stderr, "WARNING: obsolete variable %s in %s line %d\n",
+			        conf->variable, conf->file, conf->line);
+		}
+
+		if(server && !(var_type & VAR_SERVER)) {
+			fprintf(stderr, "WARNING: host variable %s found in server config %s line %d \n",
+			        conf->variable, conf->file, conf->line);
+		}
+
+		if(!server && !(var_type & VAR_HOST)) {
+			fprintf(stderr, "WARNING: server variable %s found in host config %s line %d \n",
+			        conf->variable, conf->file, conf->line);
 		}
 	}
 
-	for(int i = 0; variables[i].name && i < maxvariables; i++) {
+	for(size_t i = 0; i < total_vars; ++i) {
 		if(count[i] > 1 && !(variables[i].type & VAR_MULTIPLE)) {
-			fprintf(stderr, "WARNING: multiple instances of variable %s in %s\n", variables[i].name, fname);
+			fprintf(stderr, "WARNING: multiple instances of variable %s in %s\n",
+			        variables[i].name, nodename ? nodename : "tinc.conf");
 		}
 	}
 
-	if(ferror(f)) {
-		fprintf(stderr, "ERROR: while reading %s: %s\n", fname, strerror(errno));
-	}
-
-	fclose(f);
+	exit_configuration(&config);
 }
 
-int fsck(const char *argv0) {
 #ifdef HAVE_MINGW
-	int uid = 0;
+typedef int uid_t;
+
+static uid_t getuid() {
+	return 0;
+}
+
+static void check_key_file_mode(const char *fname) {
+	(void)fname;
+}
 #else
-	uid_t uid = getuid();
-#endif
+static void check_key_file_mode(const char *fname) {
+	const uid_t uid = getuid();
+	struct stat st;
 
-	// Check that tinc.conf is readable.
-
-	if(access(tinc_conf, R_OK)) {
-		fprintf(stderr, "ERROR: cannot read %s: %s\n", tinc_conf, strerror(errno));
-
-		if(errno == ENOENT) {
-			fprintf(stderr, "No tinc configuration found. Create a new one with:\n\n");
-			print_tinc_cmd(argv0, "init");
-		} else if(errno == EACCES) {
-			if(uid != 0) {
-				fprintf(stderr, "You are currently not running tinc as root. Use sudo?\n");
-			} else {
-				fprintf(stderr, "Check the permissions of each component of the path %s.\n", tinc_conf);
-			}
-		}
-
-		return 1;
+	if(stat(fname, &st)) {
+		fprintf(stderr, "ERROR: could not stat private key file %s\n", fname);
+		return;
 	}
 
+	if(st.st_mode & 077) {
+		fprintf(stderr, "WARNING: unsafe file permissions on %s.\n", fname);
+
+		if(st.st_uid != uid) {
+			fprintf(stderr, "You are not running %s as the same uid as %s.\n", exe_name, fname);
+		} else if(ask_fix()) {
+			if(chmod(fname, st.st_mode & ~077u)) {
+				fprintf(stderr, "ERROR: could not change permissions of %s: %s\n", fname, strerror(errno));
+			} else {
+				fprintf(stderr, "Fixed permissions of %s.\n", fname);
+			}
+		}
+	}
+}
+#endif // HAVE_MINGW
+
+static char *read_node_name() {
+	if(access(tinc_conf, R_OK) == 0) {
+		return get_my_name(true);
+	}
+
+	fprintf(stderr, "ERROR: cannot read %s: %s\n", tinc_conf, strerror(errno));
+
+	if(errno == ENOENT) {
+		fprintf(stderr, "No tinc configuration found. Create a new one with:\n\n");
+		print_tinc_cmd("init");
+		return NULL;
+	}
+
+	if(errno == EACCES) {
+		uid_t uid = getuid();
+
+		if(uid != 0) {
+			fprintf(stderr, "You are currently not running tinc as root. Use sudo?\n");
+		} else {
+			fprintf(stderr, "Check the permissions of each component of the path %s.\n", tinc_conf);
+		}
+	}
+
+	return NULL;
+}
+
+static bool build_host_conf_path(char *fname, const size_t len) {
 	char *name = get_my_name(true);
 
 	if(!name) {
 		fprintf(stderr, "ERROR: tinc cannot run without a valid Name.\n");
-		return 1;
+		return false;
 	}
 
-	// Check for private keys.
-	// TODO: use RSAPrivateKeyFile and Ed25519PrivateKeyFile variables if present.
-
-	struct stat st;
-	char fname[PATH_MAX];
-	char dname[PATH_MAX];
-
-#ifndef DISABLE_LEGACY
-	rsa_t *rsa_priv = NULL;
-	snprintf(fname, sizeof(fname), "%s/rsa_key.priv", confbase);
-
-	if(stat(fname, &st)) {
-		if(errno != ENOENT) {
-			// Something is seriously wrong here. If we can access the directory with tinc.conf in it, we should certainly be able to stat() an existing file.
-			fprintf(stderr, "ERROR: cannot read %s: %s\n", fname, strerror(errno));
-			fprintf(stderr, "Please correct this error.\n");
-			free(name);
-			return 1;
-		}
-	} else {
-		FILE *f = fopen(fname, "r");
-
-		if(!f) {
-			fprintf(stderr, "ERROR: could not open %s: %s\n", fname, strerror(errno));
-			free(name);
-			return 1;
-		}
-
-		rsa_priv = rsa_read_pem_private_key(f);
-		fclose(f);
-
-		if(!rsa_priv) {
-			fprintf(stderr, "ERROR: No key or unusable key found in %s.\n", fname);
-			fprintf(stderr, "You can generate a new RSA key with:\n\n");
-			print_tinc_cmd(argv0, "generate-rsa-keys");
-			free(name);
-			return 1;
-		}
-
-#ifndef HAVE_MINGW
-
-		if(st.st_mode & 077) {
-			fprintf(stderr, "WARNING: unsafe file permissions on %s.\n", fname);
-
-			if(st.st_uid != uid) {
-				fprintf(stderr, "You are not running %s as the same uid as %s.\n", argv0, fname);
-			} else if(ask_fix()) {
-				if(chmod(fname, st.st_mode & ~077)) {
-					fprintf(stderr, "ERROR: could not change permissions of %s: %s\n", fname, strerror(errno));
-				} else {
-					fprintf(stderr, "Fixed permissions of %s.\n", fname);
-				}
-			}
-		}
-
-#endif
-	}
-
-#endif
-
-	ecdsa_t *ecdsa_priv = NULL;
-	snprintf(fname, sizeof(fname), "%s/ed25519_key.priv", confbase);
-
-	if(stat(fname, &st)) {
-		if(errno != ENOENT) {
-			// Something is seriously wrong here. If we can access the directory with tinc.conf in it, we should certainly be able to stat() an existing file.
-			fprintf(stderr, "ERROR: cannot read %s: %s\n", fname, strerror(errno));
-			fprintf(stderr, "Please correct this error.\n");
-			free(name);
-			return 1;
-		}
-	} else {
-		FILE *f = fopen(fname, "r");
-
-		if(!f) {
-			fprintf(stderr, "ERROR: could not open %s: %s\n", fname, strerror(errno));
-			free(name);
-			return 1;
-		}
-
-		ecdsa_priv = ecdsa_read_pem_private_key(f);
-		fclose(f);
-
-		if(!ecdsa_priv) {
-			fprintf(stderr, "ERROR: No key or unusable key found in %s.\n", fname);
-			fprintf(stderr, "You can generate a new Ed25519 key with:\n\n");
-			print_tinc_cmd(argv0, "generate-ed25519-keys");
-			free(name);
-			return 1;
-		}
-
-#ifndef HAVE_MINGW
-
-		if(st.st_mode & 077) {
-			fprintf(stderr, "WARNING: unsafe file permissions on %s.\n", fname);
-
-			if(st.st_uid != uid) {
-				fprintf(stderr, "You are not running %s as the same uid as %s.\n", argv0, fname);
-			} else if(ask_fix()) {
-				if(chmod(fname, st.st_mode & ~077)) {
-					fprintf(stderr, "ERROR: could not change permissions of %s: %s\n", fname, strerror(errno));
-				} else {
-					fprintf(stderr, "Fixed permissions of %s.\n", fname);
-				}
-			}
-		}
-
-#endif
-	}
-
-#ifdef DISABLE_LEGACY
-
-	if(!ecdsa_priv) {
-		fprintf(stderr, "ERROR: No Ed25519 private key found.\n");
-#else
-
-	if(!rsa_priv && !ecdsa_priv) {
-		fprintf(stderr, "ERROR: Neither RSA or Ed25519 private key found.\n");
-#endif
-		fprintf(stderr, "You can generate new keys with:\n\n");
-		print_tinc_cmd(argv0, "generate-keys");
-		free(name);
-		return 1;
-	}
-
-	// Check for public keys.
-	// TODO: use RSAPublicKeyFile variable if present.
-
-	snprintf(fname, sizeof(fname), "%s/hosts/%s", confbase, name);
-
+	snprintf(fname, len, "%s/hosts/%s", confbase, name);
 	free(name);
+	return true;
+}
 
-	if(access(fname, R_OK)) {
-		fprintf(stderr, "WARNING: cannot read %s\n", fname);
+static bool ask_fix_ec_public_key(const char *fname, ecdsa_t *ec_priv) {
+	if(!ask_fix()) {
+		return true;
 	}
 
-	FILE *f;
+	if(!disable_old_keys(fname, "public Ed25519 key")) {
+		return false;
+	}
+
+	FILE *f = fopen(fname, "a");
+
+	if(!f) {
+		fprintf(stderr, "ERROR: could not append to %s: %s\n", fname, strerror(errno));
+		return false;
+	}
+
+	bool success = ecdsa_write_pem_public_key(ec_priv, f);
+	fclose(f);
+
+	if(success) {
+		fprintf(stderr, "Wrote Ed25519 public key to %s.\n", fname);
+	} else {
+		fprintf(stderr, "ERROR: could not write Ed25519 public key to %s.\n", fname);
+	}
+
+	return success;
+}
 
 #ifndef DISABLE_LEGACY
-	rsa_t *rsa_pub = NULL;
-
-	f = fopen(fname, "r");
-
-	if(f) {
-		rsa_pub = rsa_read_pem_public_key(f);
-		fclose(f);
+static bool ask_fix_rsa_public_key(const char *fname, rsa_t *rsa_priv) {
+	if(!ask_fix()) {
+		return true;
 	}
 
-	if(rsa_priv) {
-		if(!rsa_pub) {
-			fprintf(stderr, "WARNING: No (usable) public RSA key found.\n");
+	if(!disable_old_keys(fname, "public RSA key")) {
+		return false;
+	}
 
-			if(ask_fix()) {
-				FILE *f = fopen(fname, "a");
+	FILE *f = fopen(fname, "a");
 
-				if(f) {
-					if(rsa_write_pem_public_key(rsa_priv, f)) {
-						fprintf(stderr, "Wrote RSA public key to %s.\n", fname);
-					} else {
-						fprintf(stderr, "ERROR: could not write RSA public key to %s.\n", fname);
-					}
+	if(!f) {
+		fprintf(stderr, "ERROR: could not append to %s: %s\n", fname, strerror(errno));
+		return false;
+	}
 
-					fclose(f);
-				} else {
-					fprintf(stderr, "ERROR: could not append to %s: %s\n", fname, strerror(errno));
-				}
-			}
-		} else {
-			// TODO: suggest remedies
-			size_t len = rsa_size(rsa_priv);
+	bool success = rsa_write_pem_public_key(rsa_priv, f);
+	fclose(f);
 
-			if(len != rsa_size(rsa_pub)) {
-				fprintf(stderr, "ERROR: public and private RSA keys do not match.\n");
-				rsa_free(rsa_pub);
-				rsa_free(rsa_priv);
-				free(ecdsa_priv);
-				return 1;
-			}
+	if(success) {
+		fprintf(stderr, "Wrote RSA public key to %s.\n", fname);
+	} else {
+		fprintf(stderr, "ERROR: could not write RSA public key to %s.\n", fname);
+	}
 
-			char *buf1 = malloc(len);
-			char *buf2 = malloc(len);
-			char *buf3 = malloc(len);
+	return success;
+}
 
-			randomize(buf1, len);
-			buf1[0] &= 0x7f;
-			memset(buf2, 0, len);
-			memset(buf3, 0, len);
-			bool result = false;
+static bool test_rsa_keypair(rsa_t *rsa_priv, rsa_t *rsa_pub, const char *host_file) {
+	size_t len = rsa_size(rsa_priv);
 
-			if(rsa_public_encrypt(rsa_pub, buf1, len, buf2)) {
-				if(rsa_private_decrypt(rsa_priv, buf2, len, buf3)) {
-					if(memcmp(buf1, buf3, len)) {
-						result = true;
-					} else {
-						fprintf(stderr, "ERROR: public and private RSA keys do not match.\n");
-					}
-				} else {
-					fprintf(stderr, "ERROR: private RSA key does not work.\n");
-				}
+	if(len != rsa_size(rsa_pub)) {
+		fprintf(stderr, "ERROR: public and private RSA key lengths do not match.\n");
+		return false;
+	}
+
+	bool success = false;
+	uint8_t *plaintext = xmalloc(len);
+	uint8_t *encrypted = xzalloc(len);
+	uint8_t *decrypted = xzalloc(len);
+
+	randomize(plaintext, len);
+	plaintext[0] &= 0x7f;
+
+	if(rsa_public_encrypt(rsa_pub, plaintext, len, encrypted)) {
+		if(rsa_private_decrypt(rsa_priv, encrypted, len, decrypted)) {
+			if(memcmp(plaintext, decrypted, len) == 0) {
+				success = true;
 			} else {
-				fprintf(stderr, "ERROR: public RSA key does not work.\n");
-			}
-
-
-			rsa_free(rsa_pub);
-			rsa_pub = NULL;
-
-			free(buf3);
-			free(buf2);
-			free(buf1);
-
-			if(!result) {
-				rsa_free(rsa_priv);
-				free(ecdsa_priv);
-				return 1;
-			}
-		}
-
-		rsa_free(rsa_priv);
-		rsa_priv = NULL;
-	} else {
-		if(rsa_pub) {
-			fprintf(stderr, "WARNING: A public RSA key was found but no private key is known.\n");
-			rsa_free(rsa_pub);
-			rsa_pub = NULL;
-		}
-	}
-
-#endif
-
-	ecdsa_t *ecdsa_pub = NULL;
-
-	f = fopen(fname, "r");
-
-	if(f) {
-		ecdsa_pub = get_pubkey(f);
-
-		if(!ecdsa_pub) {
-			rewind(f);
-			ecdsa_pub = ecdsa_read_pem_public_key(f);
-		}
-
-		fclose(f);
-	}
-
-	if(ecdsa_priv) {
-		if(!ecdsa_pub) {
-			fprintf(stderr, "WARNING: No (usable) public Ed25519 key found.\n");
-
-			if(ask_fix()) {
-				FILE *f = fopen(fname, "a");
-
-				if(f) {
-					if(ecdsa_write_pem_public_key(ecdsa_priv, f)) {
-						fprintf(stderr, "Wrote Ed25519 public key to %s.\n", fname);
-					} else {
-						fprintf(stderr, "ERROR: could not write Ed25519 public key to %s.\n", fname);
-					}
-
-					fclose(f);
-				} else {
-					fprintf(stderr, "ERROR: could not append to %s: %s\n", fname, strerror(errno));
-				}
+				fprintf(stderr, "ERROR: public and private RSA keys do not match.\n");
+				success = ask_fix_rsa_public_key(host_file, rsa_priv);
 			}
 		} else {
-			// TODO: suggest remedies
-			char *key1 = ecdsa_get_base64_public_key(ecdsa_pub);
+			print_new_keys_cmd(KEY_RSA, "ERROR: private RSA key does not work.");
+		}
+	} else {
+		fprintf(stderr, "ERROR: public RSA key does not work.\n");
+		success = ask_fix_rsa_public_key(host_file, rsa_priv);
+	}
 
-			free(ecdsa_pub);
-			ecdsa_pub = NULL;
+	free(decrypted);
+	free(encrypted);
+	free(plaintext);
 
-			if(!key1) {
-				fprintf(stderr, "ERROR: public Ed25519 key does not work.\n");
-				free(ecdsa_priv);
-				return 1;
-			}
+	return success;
+}
 
-			char *key2 = ecdsa_get_base64_public_key(ecdsa_priv);
+static bool check_rsa_pubkey(rsa_t *rsa_priv, rsa_t *rsa_pub, const char *host_file) {
+	if(!rsa_pub) {
+		fprintf(stderr, "WARNING: No (usable) public RSA key found.\n");
+		return ask_fix_rsa_public_key(host_file, rsa_priv);
+	}
 
-			if(!key2) {
-				fprintf(stderr, "ERROR: private Ed25519 key does not work.\n");
-				free(ecdsa_priv);
-				free(key1);
-				return 1;
-			}
+	if(!rsa_priv) {
+		fprintf(stderr, "WARNING: A public RSA key was found but no private key is known.\n");
+		return true;
+	}
 
-			int result = strcmp(key1, key2);
-			free(key1);
-			free(key2);
+	return test_rsa_keypair(rsa_priv, rsa_pub, host_file);
+}
+#endif // DISABLE_LEGACY
 
-			if(result) {
-				fprintf(stderr, "ERROR: public and private Ed25519 keys do not match.\n");
-				free(ecdsa_priv);
-				return 1;
-			}
+static bool test_ec_keypair(ecdsa_t *ec_priv, ecdsa_t *ec_pub, const char *host_file) {
+	// base64-encoded public key obtained from the PRIVATE key.
+	char *b64_priv_pub = ecdsa_get_base64_public_key(ec_priv);
+
+	if(!b64_priv_pub) {
+		print_new_keys_cmd(KEY_ED25519, "ERROR: private Ed25519 key does not work.");
+		return false;
+	}
+
+	// base64-encoded public key obtained from the PUBLIC key.
+	char *b64_pub_pub = ecdsa_get_base64_public_key(ec_pub);
+
+	if(!b64_pub_pub) {
+		fprintf(stderr, "ERROR: public Ed25519 key does not work.\n");
+		free(b64_priv_pub);
+		return ask_fix_ec_public_key(host_file, ec_priv);
+	}
+
+	bool match = strcmp(b64_pub_pub, b64_priv_pub) == 0;
+	free(b64_pub_pub);
+	free(b64_priv_pub);
+
+	if(match) {
+		return true;
+	}
+
+	fprintf(stderr, "ERROR: public and private Ed25519 keys do not match.\n");
+	return ask_fix_ec_public_key(host_file, ec_priv);
+}
+
+static bool check_ec_pubkey(ecdsa_t *ec_priv, ecdsa_t *ec_pub, const char *host_file) {
+	if(!ec_priv) {
+		if(ec_pub) {
+			print_new_keys_cmd(KEY_ED25519, "WARNING: A public Ed25519 key was found but no private key is known.");
 		}
 
-		free(ecdsa_priv);
-		ecdsa_priv = NULL;
-	} else {
-		if(ecdsa_pub) {
-			fprintf(stderr, "WARNING: A public Ed25519 key was found but no private key is known.\n");
-			free(ecdsa_pub);
-			ecdsa_pub = NULL;
+		return true;
+	}
+
+	if(ec_pub) {
+		return test_ec_keypair(ec_priv, ec_pub, host_file);
+	}
+
+	fprintf(stderr, "WARNING: No (usable) public Ed25519 key found.\n");
+	return ask_fix_ec_public_key(host_file, ec_priv);
+}
+
+static bool check_config_mode(const char *fname) {
+	if(access(fname, R_OK | X_OK) == 0) {
+		return true;
+	}
+
+	if(errno != EACCES) {
+		fprintf(stderr, "ERROR: cannot access %s: %s\n", fname, strerror(errno));
+		return false;
+	}
+
+	fprintf(stderr, "WARNING: cannot read and execute %s: %s\n", fname, strerror(errno));
+
+	if(ask_fix()) {
+		if(chmod(fname, 0755)) {
+			fprintf(stderr, "ERROR: cannot change permissions on %s: %s\n", fname, strerror(errno));
 		}
 	}
 
-	// Check whether scripts are executable
+	return true;
+}
 
-	struct dirent *ent;
+static bool check_script_confdir() {
+	char fname[PATH_MAX];
 	DIR *dir = opendir(confbase);
 
 	if(!dir) {
 		fprintf(stderr, "ERROR: cannot read directory %s: %s\n", confbase, strerror(errno));
-		return 1;
+		return false;
 	}
+
+	struct dirent *ent;
 
 	while((ent = readdir(dir))) {
 		if(strtailcmp(ent->d_name, "-up") && strtailcmp(ent->d_name, "-down")) {
@@ -563,32 +477,24 @@ int fsck(const char *argv0) {
 		}
 
 		snprintf(fname, sizeof(fname), "%s" SLASH "%s", confbase, ent->d_name);
-
-		if(access(fname, R_OK | X_OK)) {
-			if(errno != EACCES) {
-				fprintf(stderr, "ERROR: cannot access %s: %s\n", fname, strerror(errno));
-				continue;
-			}
-
-			fprintf(stderr, "WARNING: cannot read and execute %s: %s\n", fname, strerror(errno));
-
-			if(ask_fix()) {
-				if(chmod(fname, 0755)) {
-					fprintf(stderr, "ERROR: cannot change permissions on %s: %s\n", fname, strerror(errno));
-				}
-			}
-		}
+		check_config_mode(fname);
 	}
 
 	closedir(dir);
 
-	snprintf(dname, sizeof(dname), "%s" SLASH "hosts", confbase);
-	dir = opendir(dname);
+	return true;
+}
+
+static bool check_script_hostdir(const char *host_dir) {
+	char fname[PATH_MAX];
+	DIR *dir = opendir(host_dir);
 
 	if(!dir) {
-		fprintf(stderr, "ERROR: cannot read directory %s: %s\n", dname, strerror(errno));
-		return 1;
+		fprintf(stderr, "ERROR: cannot read directory %s: %s\n", host_dir, strerror(errno));
+		return false;
 	}
+
+	struct dirent *ent;
 
 	while((ent = readdir(dir))) {
 		if(strtailcmp(ent->d_name, "-up") && strtailcmp(ent->d_name, "-down")) {
@@ -605,44 +511,165 @@ int fsck(const char *argv0) {
 		*dash = 0;
 
 		snprintf(fname, sizeof(fname), "%s" SLASH "hosts" SLASH "%s", confbase, ent->d_name);
-
-		if(access(fname, R_OK | X_OK)) {
-			if(errno != EACCES) {
-				fprintf(stderr, "ERROR: cannot access %s: %s\n", fname, strerror(errno));
-				continue;
-			}
-
-			fprintf(stderr, "WARNING: cannot read and execute %s: %s\n", fname, strerror(errno));
-
-			if(ask_fix()) {
-				if(chmod(fname, 0755)) {
-					fprintf(stderr, "ERROR: cannot change permissions on %s: %s\n", fname, strerror(errno));
-				}
-			}
-		}
+		check_config_mode(fname);
 	}
 
 	closedir(dir);
 
-	// Check for obsolete / unsafe / unknown configuration variables.
+	return true;
+}
 
-	check_conffile(tinc_conf, true);
+#ifdef DISABLE_LEGACY
+static bool check_public_keys(splay_tree_t *config, const char *name, ecdsa_t *ec_priv) {
+#else
+static bool check_public_keys(splay_tree_t *config, const char *name, rsa_t *rsa_priv, ecdsa_t *ec_priv) {
+#endif
+	// Check public keys.
+	char host_file[PATH_MAX];
 
-	dir = opendir(dname);
+	if(!build_host_conf_path(host_file, sizeof(host_file))) {
+		return false;
+	}
+
+	if(access(host_file, R_OK)) {
+		fprintf(stderr, "WARNING: cannot read %s\n", host_file);
+	}
+
+	ecdsa_t *ec_pub = NULL;
+	read_ecdsa_public_key(&ec_pub, &config, name);
+
+	bool success = true;
+#ifndef DISABLE_LEGACY
+	rsa_t *rsa_pub = NULL;
+	read_rsa_public_key(&rsa_pub, config, name);
+
+	success = check_rsa_pubkey(rsa_priv, rsa_pub, host_file);
+	rsa_free(rsa_pub);
+#endif
+
+	if(!check_ec_pubkey(ec_priv, ec_pub, host_file)) {
+		success = false;
+	}
+
+	ecdsa_free(ec_pub);
+
+	return success;
+}
+
+static bool check_keypairs(splay_tree_t *config, const char *name) {
+	// Check private keys.
+	char *priv_keyfile = NULL;
+	ecdsa_t *ec_priv = read_ecdsa_private_key(config, &priv_keyfile);
+
+	if(priv_keyfile) {
+		check_key_file_mode(priv_keyfile);
+		free(priv_keyfile);
+		priv_keyfile = NULL;
+	}
+
+#ifdef DISABLE_LEGACY
+
+	if(!ec_priv) {
+		print_new_keys_cmd(KEY_ED25519, "ERROR: No Ed25519 private key found.");
+		return false;
+	}
+
+#else
+	rsa_t *rsa_priv = read_rsa_private_key(config, &priv_keyfile);
+
+	if(priv_keyfile) {
+		check_key_file_mode(priv_keyfile);
+		free(priv_keyfile);
+	}
+
+	if(!rsa_priv && !ec_priv) {
+		print_new_keys_cmd(KEY_BOTH, "ERROR: Neither RSA or Ed25519 private key found.");
+		return false;
+	}
+
+#endif
+
+#ifdef DISABLE_LEGACY
+	bool success = check_public_keys(config, name, ec_priv);
+#else
+	bool success = check_public_keys(config, name, rsa_priv, ec_priv);
+	rsa_free(rsa_priv);
+#endif
+	ecdsa_free(ec_priv);
+
+	return success;
+}
+
+static void check_config_variables(const char *host_dir) {
+	check_conffile(NULL, true);
+
+	DIR *dir = opendir(host_dir);
 
 	if(dir) {
-		while((ent = readdir(dir))) {
-			if(!check_id(ent->d_name)) {
-				continue;
+		for(struct dirent * ent; (ent = readdir(dir));) {
+			if(check_id(ent->d_name)) {
+				check_conffile(ent->d_name, false);
 			}
-
-			snprintf(fname, sizeof(fname), "%s" SLASH "hosts" SLASH "%s", confbase, ent->d_name);
-			check_conffile(fname, false);
 		}
 
 		closedir(dir);
 	}
-
-	return 0;
 }
 
+static bool check_scripts_and_configs() {
+	// Check whether scripts are executable.
+	if(!check_script_confdir()) {
+		return false;
+	}
+
+	char host_dir[PATH_MAX];
+	snprintf(host_dir, sizeof(host_dir), "%s" SLASH "hosts", confbase);
+
+	if(!check_script_hostdir(host_dir)) {
+		return false;
+	}
+
+	// Check for obsolete / unsafe / unknown configuration variables (and print warnings).
+	check_config_variables(host_dir);
+
+	return true;
+}
+
+int fsck(const char *argv0) {
+	exe_name = argv0;
+
+	// Check that tinc.conf is readable and read our name if it is.
+	char *name = read_node_name();
+
+	if(!name) {
+		fprintf(stderr, "ERROR: tinc cannot run without a valid Name.\n");
+		exe_name = NULL;
+		return EXIT_FAILURE;
+	}
+
+	// Avoid touching global configuration here. Read the config files into
+	// a temporary configuration tree, then throw it away after fsck is done.
+	splay_tree_t *config = NULL;
+	init_configuration(&config);
+
+	// Read the server configuration file and append host configuration for our node.
+	bool success = read_server_config(config) &&
+	               read_host_config(config, name, true);
+
+	// Check both RSA and EC key pairs.
+	// We need working configuration to run this check.
+	if(success) {
+		success = check_keypairs(config, name);
+	}
+
+	// Check that scripts are executable and check the config for invalid variables.
+	// This check does not require working configuration, so run it always.
+	// This way, we can diagnose more issues on the first run.
+	success = success & check_scripts_and_configs();
+
+	exit_configuration(&config);
+	free(name);
+	exe_name = NULL;
+
+	return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/keys.c
+++ b/src/keys.c
@@ -1,0 +1,336 @@
+#include "system.h"
+#include "keys.h"
+#include "conf.h"
+#include "logger.h"
+#include "names.h"
+#include "xalloc.h"
+#include "ecdsa.h"
+#include "utils.h"
+
+bool disable_old_keys(const char *filename, const char *what) {
+	char tmpfile[PATH_MAX] = "";
+	char buf[1024];
+	bool disabled = false;
+	bool block = false;
+	bool error = false;
+
+	FILE *r = fopen(filename, "r");
+	FILE *w = NULL;
+
+	if(!r) {
+		return false;
+	}
+
+	int result = snprintf(tmpfile, sizeof(tmpfile), "%s.tmp", filename);
+
+	if(result < sizeof(tmpfile)) {
+		struct stat st = {.st_mode = 0600};
+		fstat(fileno(r), &st);
+		w = fopenmask(tmpfile, "w", st.st_mode);
+	}
+
+	while(fgets(buf, sizeof(buf), r)) {
+		if(!block && !strncmp(buf, "-----BEGIN ", 11)) {
+			if((strstr(buf, " ED25519 ") && strstr(what, "Ed25519")) || (strstr(buf, " RSA ") && strstr(what, "RSA"))) {
+				disabled = true;
+				block = true;
+			}
+		}
+
+		bool ed25519pubkey = !strncasecmp(buf, "Ed25519PublicKey", 16) && strchr(" \t=", buf[16]) && strstr(what, "Ed25519");
+
+		if(ed25519pubkey) {
+			disabled = true;
+		}
+
+		if(w) {
+			if(block || ed25519pubkey) {
+				fputc('#', w);
+			}
+
+			if(fputs(buf, w) < 0) {
+				error = true;
+				break;
+			}
+		}
+
+		if(block && !strncmp(buf, "-----END ", 9)) {
+			block = false;
+		}
+	}
+
+	if(w)
+		if(fclose(w) < 0) {
+			error = true;
+		}
+
+	if(ferror(r) || fclose(r) < 0) {
+		error = true;
+	}
+
+	if(disabled) {
+		if(!w || error) {
+			fprintf(stderr, "Warning: old key(s) found, remove them by hand!\n");
+
+			if(w) {
+				unlink(tmpfile);
+			}
+
+			return false;
+		}
+
+#ifdef HAVE_MINGW
+		// We cannot atomically replace files on Windows.
+		char bakfile[PATH_MAX] = "";
+		snprintf(bakfile, sizeof(bakfile), "%s.bak", filename);
+
+		if(rename(filename, bakfile) || rename(tmpfile, filename)) {
+			rename(bakfile, filename);
+#else
+
+		if(rename(tmpfile, filename)) {
+#endif
+			fprintf(stderr, "Warning: old key(s) found, remove them by hand!\n");
+			unlink(tmpfile);
+			return false;
+		}
+
+#ifdef HAVE_MINGW
+		unlink(bakfile);
+#endif
+		fprintf(stderr, "Warning: old key(s) found and disabled.\n");
+	}
+
+	unlink(tmpfile);
+	return true;
+}
+
+ecdsa_t *read_ecdsa_private_key(splay_tree_t *config_tree, char **keyfile) {
+	FILE *fp;
+	char *fname;
+
+	/* Check for PrivateKeyFile statement and read it */
+
+	if(!get_config_string(lookup_config(config_tree, "Ed25519PrivateKeyFile"), &fname)) {
+		xasprintf(&fname, "%s" SLASH "ed25519_key.priv", confbase);
+	}
+
+	fp = fopen(fname, "r");
+
+	if(!fp) {
+		logger(DEBUG_ALWAYS, LOG_ERR, "Error reading Ed25519 private key file `%s': %s", fname, strerror(errno));
+
+		if(errno == ENOENT) {
+			logger(DEBUG_ALWAYS, LOG_INFO, "Create an Ed25519 key pair with `tinc -n %s generate-ed25519-keys'.", netname ? netname : ".");
+		}
+
+		free(fname);
+		return NULL;
+	}
+
+#ifndef HAVE_MINGW
+	struct stat s;
+
+	if(fstat(fileno(fp), &s)) {
+		logger(DEBUG_ALWAYS, LOG_ERR, "Could not stat Ed25519 private key file `%s': %s'", fname, strerror(errno));
+		free(fname);
+		return false;
+	}
+
+	if(s.st_mode & ~0100700u) {
+		logger(DEBUG_ALWAYS, LOG_WARNING, "Warning: insecure file permissions for Ed25519 private key file `%s'!", fname);
+	}
+
+#endif
+
+	ecdsa_t *key = ecdsa_read_pem_private_key(fp);
+	fclose(fp);
+
+	if(!key) {
+		logger(DEBUG_ALWAYS, LOG_ERR, "Reading Ed25519 private key file `%s' failed", fname);
+		free(fname);
+		return NULL;
+	}
+
+	if(keyfile) {
+		*keyfile = fname;
+	} else {
+		free(fname);
+	}
+
+	return key;
+}
+
+bool read_ecdsa_public_key(ecdsa_t **ecdsa, splay_tree_t **config_tree, const char *name) {
+	if(ecdsa_active(*ecdsa)) {
+		return true;
+	}
+
+	FILE *fp;
+	char *fname;
+	char *p;
+
+	if(!*config_tree) {
+		init_configuration(config_tree);
+
+		if(!read_host_config(*config_tree, name, true)) {
+			return false;
+		}
+	}
+
+	/* First, check for simple Ed25519PublicKey statement */
+
+	if(get_config_string(lookup_config(*config_tree, "Ed25519PublicKey"), &p)) {
+		*ecdsa = ecdsa_set_base64_public_key(p);
+		free(p);
+		return *ecdsa != NULL;
+	}
+
+	/* Else, check for Ed25519PublicKeyFile statement and read it */
+
+	if(!get_config_string(lookup_config(*config_tree, "Ed25519PublicKeyFile"), &fname)) {
+		xasprintf(&fname, "%s" SLASH "hosts" SLASH "%s", confbase, name);
+	}
+
+	fp = fopen(fname, "r");
+
+	if(!fp) {
+		logger(DEBUG_ALWAYS, LOG_ERR, "Error reading Ed25519 public key file `%s': %s",
+		       fname, strerror(errno));
+		free(fname);
+		return false;
+	}
+
+	*ecdsa = ecdsa_read_pem_public_key(fp);
+
+	if(!*ecdsa && errno != ENOENT) {
+		logger(DEBUG_ALWAYS, LOG_ERR, "Parsing Ed25519 public key file `%s' failed.", fname);
+	}
+
+	fclose(fp);
+	free(fname);
+
+	return *ecdsa != NULL;
+}
+
+#ifndef DISABLE_LEGACY
+rsa_t *read_rsa_private_key(splay_tree_t *config_tree, char **keyfile) {
+	FILE *fp;
+	char *fname;
+	char *n, *d;
+	rsa_t *key;
+
+	/* First, check for simple PrivateKey statement */
+
+	config_t *rsa_priv_conf = lookup_config(config_tree, "PrivateKey");
+
+	if(get_config_string(rsa_priv_conf, &d)) {
+		if(!get_config_string(lookup_config(config_tree, "PublicKey"), &n)) {
+			logger(DEBUG_ALWAYS, LOG_ERR, "PrivateKey used but no PublicKey found!");
+			free(d);
+			return NULL;
+		}
+
+		key = rsa_set_hex_private_key(n, "FFFF", d);
+		free(n);
+		free(d);
+
+		if(key && keyfile && rsa_priv_conf->file) {
+			*keyfile = xstrdup(rsa_priv_conf->file);
+		}
+
+		return key;
+	}
+
+	/* Else, check for PrivateKeyFile statement and read it */
+
+	if(!get_config_string(lookup_config(config_tree, "PrivateKeyFile"), &fname)) {
+		xasprintf(&fname, "%s" SLASH "rsa_key.priv", confbase);
+	}
+
+	fp = fopen(fname, "r");
+
+	if(!fp) {
+		logger(DEBUG_ALWAYS, LOG_ERR, "Error reading RSA private key file `%s': %s",
+		       fname, strerror(errno));
+
+		if(errno == ENOENT) {
+			logger(DEBUG_ALWAYS, LOG_INFO, "Create an RSA key pair with `tinc -n %s generate-rsa-keys'.", netname ? netname : ".");
+		}
+
+		free(fname);
+		return NULL;
+	}
+
+#ifndef HAVE_MINGW
+	struct stat s;
+
+	if(fstat(fileno(fp), &s)) {
+		logger(DEBUG_ALWAYS, LOG_ERR, "Could not stat RSA private key file `%s': %s'", fname, strerror(errno));
+		free(fname);
+		return NULL;
+	}
+
+	if(s.st_mode & ~0100700u) {
+		logger(DEBUG_ALWAYS, LOG_WARNING, "Warning: insecure file permissions for RSA private key file `%s'!", fname);
+	}
+
+#endif
+
+	key = rsa_read_pem_private_key(fp);
+	fclose(fp);
+
+	if(!key) {
+		logger(DEBUG_ALWAYS, LOG_ERR, "Reading RSA private key file `%s' failed: %s", fname, strerror(errno));
+		free(fname);
+		return NULL;
+	}
+
+	if(keyfile) {
+		*keyfile = fname;
+	} else {
+		free(fname);
+	}
+
+	return key;
+}
+
+bool read_rsa_public_key(rsa_t **rsa, splay_tree_t *config_tree, const char *name) {
+	FILE *fp;
+	char *fname;
+	char *n;
+
+	/* First, check for simple PublicKey statement */
+
+	if(get_config_string(lookup_config(config_tree, "PublicKey"), &n)) {
+		*rsa = rsa_set_hex_public_key(n, "FFFF");
+		free(n);
+		return *rsa != NULL;
+	}
+
+	/* Else, check for PublicKeyFile statement and read it */
+
+	if(!get_config_string(lookup_config(config_tree, "PublicKeyFile"), &fname)) {
+		xasprintf(&fname, "%s" SLASH "hosts" SLASH "%s", confbase, name);
+	}
+
+	fp = fopen(fname, "r");
+
+	if(!fp) {
+		logger(DEBUG_ALWAYS, LOG_ERR, "Error reading RSA public key file `%s': %s", fname, strerror(errno));
+		free(fname);
+		return false;
+	}
+
+	*rsa = rsa_read_pem_public_key(fp);
+	fclose(fp);
+
+	if(!*rsa) {
+		logger(DEBUG_ALWAYS, LOG_ERR, "Reading RSA public key file `%s' failed: %s", fname, strerror(errno));
+	}
+
+	free(fname);
+
+	return *rsa != NULL;
+}
+#endif

--- a/src/keys.h
+++ b/src/keys.h
@@ -1,0 +1,18 @@
+#ifndef TINC_KEYS_H
+#define TINC_KEYS_H
+
+#include "rsa.h"
+#include "ecdsa.h"
+#include "splay_tree.h"
+
+extern bool disable_old_keys(const char *filename, const char *what);
+
+extern ecdsa_t *read_ecdsa_private_key(splay_tree_t *config_tree, char **keyfile);
+extern bool read_ecdsa_public_key(ecdsa_t **ecdsa, splay_tree_t **config_tree, const char *name);
+
+#ifndef DISABLE_LEGACY
+extern rsa_t *read_rsa_private_key(splay_tree_t *config, char **keyfile);
+extern bool read_rsa_public_key(rsa_t **rsa, splay_tree_t *config_tree, const char *name);
+#endif
+
+#endif // TINC_KEYS_H

--- a/src/net.c
+++ b/src/net.c
@@ -23,6 +23,7 @@
 #include "system.h"
 
 #include "autoconnect.h"
+#include "conf_net.h"
 #include "conf.h"
 #include "connection.h"
 #include "device.h"
@@ -340,7 +341,7 @@ int reload_configuration(void) {
 	exit_configuration(&config_tree);
 	init_configuration(&config_tree);
 
-	if(!read_server_config()) {
+	if(!read_server_config(config_tree)) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Unable to reread configuration file.");
 		return EINVAL;
 	}

--- a/src/net.h
+++ b/src/net.h
@@ -205,8 +205,6 @@ extern void close_network_connections(void);
 extern int main_loop(void);
 extern void terminate_connection(struct connection_t *c, bool report);
 extern bool node_read_ecdsa_public_key(struct node_t *n);
-extern bool read_ecdsa_public_key(struct connection_t *c);
-extern bool read_rsa_public_key(struct connection_t *c);
 extern void handle_device_data(void *data, int flags);
 extern void handle_meta_connection_data(struct connection_t *c);
 extern void regenerate_key(void);

--- a/src/openssl/rsa.c
+++ b/src/openssl/rsa.c
@@ -102,7 +102,7 @@ rsa_t *rsa_read_pem_private_key(FILE *fp) {
 	return rsa;
 }
 
-size_t rsa_size(rsa_t *rsa) {
+size_t rsa_size(const rsa_t *rsa) {
 	return RSA_size(rsa);
 }
 

--- a/src/rsa.h
+++ b/src/rsa.h
@@ -29,7 +29,7 @@ extern rsa_t *rsa_set_hex_public_key(char *n, char *e) __attribute__((__malloc__
 extern rsa_t *rsa_set_hex_private_key(char *n, char *e, char *d) __attribute__((__malloc__));
 extern rsa_t *rsa_read_pem_public_key(FILE *fp) __attribute__((__malloc__));
 extern rsa_t *rsa_read_pem_private_key(FILE *fp) __attribute__((__malloc__));
-extern size_t rsa_size(rsa_t *rsa);
+extern size_t rsa_size(const rsa_t *rsa);
 extern bool rsa_public_encrypt(rsa_t *rsa, void *in, size_t len, void *out) __attribute__((__warn_unused_result__));
 extern bool rsa_private_decrypt(rsa_t *rsa, void *in, size_t len, void *out) __attribute__((__warn_unused_result__));
 

--- a/src/tincd.c
+++ b/src/tincd.c
@@ -297,7 +297,7 @@ static bool parse_options(int argc, char **argv) {
 
 exit_fail:
 	free_names();
-	free(cmdline_conf);
+	list_delete_list(cmdline_conf);
 	cmdline_conf = NULL;
 	return false;
 }
@@ -387,7 +387,7 @@ static void cleanup() {
 		exit_configuration(&config_tree);
 	}
 
-	free(cmdline_conf);
+	list_delete_list(cmdline_conf);
 	free_names();
 }
 
@@ -504,7 +504,7 @@ int main(int argc, char **argv) {
 	srand(now.tv_sec + now.tv_usec);
 	crypto_init();
 
-	if(!read_server_config()) {
+	if(!read_server_config(config_tree)) {
 		return 1;
 	}
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -55,4 +55,6 @@ extern bool check_id(const char *id);
 extern bool check_netname(const char *netname, bool strict);
 char *replace_name(const char *name);
 
+extern FILE *fopenmask(const char *filename, const char *mode, mode_t perms);
+
 #endif

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,7 +2,7 @@ TESTS = \
 	basic.test \
 	executables.test \
 	commandline.test \
-	compression.test \
+	command-fsck.test \
 	import-export.test \
 	invite-join.test \
 	invite-offline.test \
@@ -14,12 +14,14 @@ TESTS = \
 
 if WITH_LEGACY_PROTOCOL
 TESTS += \
-	 legacy-protocol.test \
-	 algorithms.test
+	legacy-protocol.test \
+	algorithms.test
 endif
 
 if LINUX
-TESTS += ns-ping.test
+TESTS += \
+	ns-ping.test \
+	compression.test
 endif
 
 dist_check_SCRIPTS = $(TESTS)

--- a/test/command-fsck.test
+++ b/test/command-fsck.test
@@ -1,0 +1,290 @@
+#!/bin/sh
+
+. ./testlib.sh
+
+foo_dir=$(peer_directory foo)
+foo_host=$foo_dir/hosts/foo
+foo_conf=$foo_dir/tinc.conf
+foo_rsa_priv=$foo_dir/rsa_key.priv
+foo_ec_priv=$foo_dir/ed25519_key.priv
+foo_tinc_up=$foo_dir/tinc-up
+foo_host_up=$foo_dir/host-up
+
+if is_windows; then
+  foo_tinc_up=$foo_tinc_up.cmd
+  foo_host_up=$foo_host_up.cmd
+fi
+
+# Sample RSA key pair (old format). Uses e = 0xFFFF.
+rsa_n=BB82C3A9B906E98ABF2D99FF9B320B229F5C1E58EC784762DA1F4D3509FFF78ECA7FFF19BA170736CDE458EC8E732DDE2C02009632DF731B4A6BD6C504E50B7B875484506AC1E49FD0DF624F6612F564C562BD20F870592A49195023D744963229C35081C8AE48BE2EBB5CC9A0D64924022DC0EB782A3A8F3EABCA04AA42B24B2A6BD2353A6893A73AE01FA54891DD24BF36CA032F19F7E78C01273334BAA2ECF36B6998754CB012BC985C975503D945E4D925F6F719ACC8FBA7B18C810FF850C3CCACD60565D4FCFE02A98FE793E2D45D481A34D1F90584D096561FF3184C462C606535F3F9BB260541DF0D1FEB16938FFDEC2FF96ACCC6BD5BFBC19471F6AB
+rsa_d=8CEC9A4316FE45E07900197D8FBB52D3AF01A51C4F8BD08A1E21A662E3CFCF7792AD7680673817B70AC1888A08B49E8C5835357016D9BF56A0EBDE8B5DF214EC422809BC8D88177F273419116EF2EC7951453F129768DE9BC31D963515CC7481559E4C0E65C549169F2B94AE68DB944171189DD654DC6970F2F5843FB7C8E9D057E2B5716752F1F5686811AC075ED3D3CBD06B5D35AE33D01260D9E0560AF545D0C9D89A31D5EAF96D5422F6567FE8A90E23906B840545805644DFD656E526A686D3B978DD271578CA3DA0F7D23FC1252A702A5D597CAE9D4A5BBF6398A75AF72582C7538A7937FB71A2610DCBC39625B77103FA3B7D0A55177FD98C39CD4A27
+
+# Extracts the PEM key from a config file, leaving the file unchanged.
+# usage: extract_pem_key_from_config path_to_file
+extract_pem_key_from_config() {
+  sed -n '/-----BEGIN /,/-----END /p' "$1"
+}
+
+# Removes the PEM key from a config file.
+# usage: rm_pem_key_from_config path_to_file
+rm_pem_key_from_config() {
+  sed_cmd '/-----BEGIN /,/-----END /d' "$1"
+}
+
+reinit_configs() {
+  if [ -d "$foo_dir" ]; then
+    chmod -f 755 "$foo_dir"
+    rm -rf "$foo_dir"
+  fi
+
+  tinc foo <<EOF
+init foo
+set DeviceType dummy
+EOF
+}
+
+fsck_test() {
+  echo >&2 "[STEP] $*"
+  reinit_configs
+}
+
+run_access_checks() {
+  ! is_root && ! is_windows
+}
+
+test_private_keys() {
+  keyfile=$1
+
+  fsck_test "Must fail on broken $keyfile"
+  printf '' >"$foo_dir/$keyfile"
+  if with_legacy; then
+    expect_msg 'no private key is known' tinc foo fsck
+  else
+    must_fail_with_msg 'no Ed25519 private key found' tinc foo fsck
+  fi
+
+  if run_access_checks; then
+    fsck_test "Must fail on inaccessible $keyfile"
+    chmod 000 "$foo_dir/$keyfile"
+    if with_legacy; then
+      expect_msg 'error reading' tinc foo fsck
+    else
+      must_fail_with_msg 'error reading' tinc foo fsck
+    fi
+  fi
+
+  if ! is_windows; then
+    fsck_test "Must warn about unsafe permissions on $keyfile"
+    chmod 666 "$foo_dir/$keyfile"
+    expect_msg 'unsafe file permissions' tinc foo fsck
+  fi
+
+  if with_legacy; then
+    fsck_test "Must pass on missing $keyfile when the other key is present"
+    rm -f "$foo_dir/$keyfile"
+    tinc foo fsck
+  fi
+}
+
+test_private_key_var() {
+  var=$1
+  keyfile=$2
+
+  fsck_test "Must find private key at $var"
+  mv "$foo_dir/$keyfile" "$foo_dir/renamed_private_key"
+  echo "$var = $(normalize_path "$foo_dir/renamed_private_key")" >>"$foo_conf"
+  fail_on_msg 'key was found but no private key' tinc foo fsck
+}
+
+test_ec_public_key_file_var() {
+  conf=$1
+  fsck_test "EC public key in Ed25519PublicKeyFile in $conf must work"
+  cat >"$foo_dir/ec_pubkey" <<EOF
+-----BEGIN ED25519 PUBLIC KEY-----
+$(awk '/^Ed25519PublicKey/ { printf $NF }' "$foo_host")
+-----END ED25519 PUBLIC KEY-----
+EOF
+  sed_cmd '/Ed25519PublicKey/d' "$foo_host"
+  echo "Ed25519PublicKeyFile = $(normalize_path "$foo_dir/ec_pubkey")" >>"$foo_dir/$conf"
+  fail_on_msg 'no (usable) public Ed25519' tinc foo fsck
+}
+
+test_rsa_public_key_file_var() {
+  conf=$1
+  fsck_test "RSA public key in PublicKeyFile in $conf must work"
+  extract_pem_key_from_config "$foo_host" >"$foo_dir/rsa_pubkey"
+  rm_pem_key_from_config "$foo_host"
+  echo "PublicKeyFile = $(normalize_path "$foo_dir/rsa_pubkey")" >>"$foo_dir/$conf"
+  fail_on_msg 'error reading RSA public key' tinc foo fsck
+}
+
+fsck_test 'Newly created configuration should pass'
+tinc foo fsck
+
+fsck_test 'Must fail on missing tinc.conf'
+rm -f "$foo_conf"
+must_fail_with_msg 'no tinc configuration found' tinc foo fsck
+
+if run_access_checks; then
+  fsck_test 'Must fail on inaccessible tinc.conf'
+  chmod 000 "$foo_dir"
+  must_fail_with_msg 'not running tinc as root' tinc foo fsck
+fi
+
+if ! is_windows; then
+  fsck_test 'Non-executable tinc-up MUST be fixed by tinc --force'
+  chmod a-x "$foo_tinc_up"
+  expect_msg 'cannot read and execute' tinc foo --force fsck
+  test -x "$foo_tinc_up"
+
+  fsck_test 'Non-executable tinc-up MUST NOT be fixed by tinc without --force'
+  chmod a-x "$foo_tinc_up"
+  expect_msg 'cannot read and execute' tinc foo fsck
+  must_fail test -x "$foo_tinc_up"
+fi
+
+fsck_test 'Unknown -up script warning'
+touch "$foo_dir/fake-up"
+expect_msg 'unknown script' tinc foo fsck
+
+fsck_test 'Unknown -down script warning'
+touch "$foo_dir/fake-down"
+expect_msg 'unknown script' tinc foo fsck
+
+if ! is_windows; then
+  fsck_test 'Non-executable foo-up MUST be fixed by tinc --force'
+  touch "$foo_host_up"
+  chmod a-x "$foo_host_up"
+  expect_msg 'cannot read and execute' tinc foo --force fsck
+  test -x "$foo_tinc_up"
+
+  fsck_test 'Non-executable bar-up MUST NOT be fixed by tinc'
+  touch "$foo_dir/hosts/bar-up"
+  chmod a-x "$foo_dir/hosts/bar-up"
+  expect_msg 'cannot read and execute' tinc foo fsck
+  must_fail test -x "$foo_dir/bar-up"
+fi
+
+if run_access_checks; then
+  fsck_test 'Inaccessible hosts/foo must fail'
+  chmod 000 "$foo_host"
+  must_fail_with_msg 'cannot open config file' tinc foo fsck
+fi
+
+fsck_test 'Must fail when all private keys are missing'
+rm -f "$foo_ec_priv" "$foo_rsa_priv"
+if with_legacy; then
+  must_fail_with_msg 'neither RSA or Ed25519 private key' tinc foo fsck
+else
+  must_fail_with_msg 'no Ed25519 private key' tinc foo fsck
+fi
+
+if with_legacy; then
+  test_private_keys rsa_key.priv
+
+  if ! is_windows; then
+    fsck_test 'Must warn about unsafe permissions on tinc.conf with PrivateKey'
+    rm -f "$foo_rsa_priv"
+    echo "PrivateKey = $rsa_d" >>"$foo_conf"
+    echo "PublicKey = $rsa_n" >>"$foo_host"
+    chmod 666 "$foo_conf"
+    expect_msg 'unsafe file permissions' tinc foo fsck
+  fi
+
+  fsck_test 'Must warn about missing RSA private key if public key is present'
+  rm -f "$foo_rsa_priv"
+  expect_msg 'public RSA key was found but no private key' tinc foo fsck
+
+  fsck_test 'Must warn about missing RSA public key'
+  rm_pem_key_from_config "$foo_host"
+  expect_msg 'no (usable) public RSA' tinc foo fsck
+  must_fail grep -q 'BEGIN RSA PUBLIC KEY' "$foo_host"
+
+  fsck_test 'Must fix missing RSA public key on --force'
+  rm_pem_key_from_config "$foo_host"
+  expect_msg 'wrote RSA public key' tinc foo --force fsck
+  grep -q 'BEGIN RSA PUBLIC KEY' "$foo_host"
+
+  test_private_key_var PrivateKeyFile rsa_key.priv
+
+  test_rsa_public_key_file_var tinc.conf
+  test_rsa_public_key_file_var hosts/foo
+
+  fsck_test 'RSA PublicKey + PrivateKey must work'
+  rm -f "$foo_rsa_priv"
+  rm_pem_key_from_config "$foo_host"
+  echo "PrivateKey = $rsa_d" >>"$foo_conf"
+  echo "PublicKey = $rsa_n" >>"$foo_host"
+  fail_on_msg 'no (usable) public RSA' tinc foo fsck
+
+  fsck_test 'RSA PrivateKey without PublicKey must warn'
+  rm -f "$foo_rsa_priv"
+  rm_pem_key_from_config "$foo_host"
+  echo "PrivateKey = $rsa_d" >>"$foo_conf"
+  expect_msg 'PrivateKey used but no PublicKey found' tinc foo fsck
+
+  fsck_test 'Must warn about missing EC private key if public key is present'
+  rm -f "$foo_ec_priv"
+  expect_msg 'public Ed25519 key was found but no private key' tinc foo fsck
+
+  fsck_test 'Must fix broken RSA public key with --force'
+  sed_cmd 2d "$foo_host"
+  expect_msg 'old key(s) found and disabled' tinc foo --force fsck
+  tinc foo fsck
+
+  fsck_test 'Must fix missing RSA public key with --force'
+  rm_pem_key_from_config "$foo_host"
+  expect_msg 'no (usable) public RSA key found' tinc foo --force fsck
+  tinc foo fsck
+fi
+
+fsck_test 'Must fix broken Ed25519 public key with --force'
+sed_cmd 's/Ed25519PublicKey.*/Ed25519PublicKey = foobar/' "$foo_host"
+expect_msg 'no (usable) public Ed25519 key' tinc foo --force fsck
+tinc foo fsck
+
+fsck_test 'Must fix missing Ed25519 public key with --force'
+sed_cmd '/Ed25519PublicKey/d' "$foo_host"
+expect_msg 'no (usable) public Ed25519 key' tinc foo --force fsck
+tinc foo fsck
+
+test_private_keys ed25519_key.priv
+test_private_key_var Ed25519PrivateKeyFile ed25519_key.priv
+
+test_ec_public_key_file_var tinc.conf
+test_ec_public_key_file_var hosts/foo
+
+fsck_test 'Must warn about missing EC public key and NOT fix without --force'
+sed_cmd '/Ed25519PublicKey/d' "$foo_host"
+expect_msg 'no (usable) public Ed25519' tinc foo fsck
+must_fail grep -q 'ED25519 PUBLIC KEY' "$foo_host"
+
+fsck_test 'Must fix missing EC public key on --force'
+sed_cmd '/Ed25519PublicKey/d' "$foo_host"
+expect_msg 'wrote Ed25519 public key' tinc foo --force fsck
+grep -q 'ED25519 PUBLIC KEY' "$foo_host"
+
+fsck_test 'Must warn about obsolete variables'
+echo 'GraphDumpFile = /dev/null' >>"$foo_host"
+expect_msg 'obsolete variable GraphDumpFile' tinc foo fsck
+
+fsck_test 'Must warn about missing values'
+echo 'Weight = ' >>"$foo_host"
+must_fail_with_msg 'no value for variable `Weight' tinc foo fsck
+
+fsck_test 'Must warn about duplicate variables'
+echo 'Weight = 0' >>"$foo_host"
+echo 'Weight = 1' >>"$foo_host"
+expect_msg 'multiple instances of variable Weight' tinc foo fsck
+
+fsck_test 'Must warn about server variables in host config'
+echo 'Interface = fake0' >>"$foo_host"
+expect_msg 'server variable Interface found' tinc foo fsck
+
+fsck_test 'Must warn about host variables in server config'
+echo 'Port = 1337' >>"$foo_conf"
+expect_msg 'host variable Port found' tinc foo fsck
+
+fsck_test 'Must warn about missing Name'
+sed_cmd '/^Name =/d' "$foo_conf"
+must_fail_with_msg 'without a valid Name' tinc foo fsck

--- a/test/compression.test
+++ b/test/compression.test
@@ -2,7 +2,7 @@
 
 . ./testlib.sh
 
-test "$(id -u)" = "0" || exit $EXIT_SKIP_TEST
+require_root "$0" "$@"
 test -e /dev/net/tun || exit $EXIT_SKIP_TEST
 ip netns list || exit $EXIT_SKIP_TEST
 command -v socat || exit $EXIT_SKIP_TEST
@@ -110,8 +110,9 @@ for level in $levels; do
     socat -u TCP4-LISTEN:$recv_port_foo,reuseaddr OPEN:"$tmp_file",creat &
 
   ip netns exec bar \
-    socat -u OPEN:"$ref_file" TCP4:$ip_foo:$recv_port_foo,retry=30
+    socat -u OPEN:"$ref_file" TCP4:$ip_foo:$recv_port_foo,retry=30 &
 
+  wait
   diff -w "$ref_file" "$tmp_file"
 
   tinc foo stop

--- a/test/ns-ping.test
+++ b/test/ns-ping.test
@@ -2,9 +2,7 @@
 
 . ./testlib.sh
 
-echo "[STEP] Skip this test if we aren't root or if 'ip netns' does not exist"
-
-test "$(id -u)" = "0" || exit $EXIT_SKIP_TEST
+require_root "$0" "$@"
 test -e /dev/net/tun || exit $EXIT_SKIP_TEST
 ip netns list || exit $EXIT_SKIP_TEST
 

--- a/test/testlib.sh.in
+++ b/test/testlib.sh.in
@@ -58,6 +58,12 @@ if type gtimeout >/dev/null; then
   timeout() { gtimeout "$@"; }
 fi
 
+# As usual, BSD tools require special handling, as they do not support -i without a suffix.
+# Note that there must be no space after -i, or it won't work on GNU sed.
+sed_cmd() {
+  sed -i.orig "$@"
+}
+
 # Are the shell tools provided by busybox?
 is_busybox() {
   timeout --help 2>&1 | grep -q -i busybox
@@ -93,11 +99,74 @@ rm_cr() {
   tr -d '\r'
 }
 
+if is_windows; then
+  normalize_path() { cygpath --mixed -- "$@"; }
+else
+  normalize_path() { echo "$@"; }
+fi
+
 # Executes whatever is passed to it, checking that the resulting exit code is non-zero.
 must_fail() {
   if "$@"; then
     bail "expected a non-zero exit code"
   fi
+}
+
+# Executes the passed command and checks two conditions:
+#   1. it must exit successfully (with code 0)
+#   2. its output (stdout + stderr) must include the substring from the first argument (ignoring case)
+# usage: expect_msg 'expected message' command --with --args
+expect_msg() {
+  message=$1
+  shift
+
+  if ! output=$("$@" 2>&1); then
+    bail 'expected 0 exit code'
+  fi
+
+  if ! echo "$output" | grep -q -i "$message"; then
+    bail "expected message '$message'"
+  fi
+}
+
+# The reverse of expect_msg. We cannot simply wrap expect_msg with must_fail
+# because there should be a separate check for tinc exit code.
+fail_on_msg() {
+  message=$1
+  shift
+
+  if ! output=$("$@" 2>&1); then
+    bail 'expected 0 exit code'
+  fi
+
+  if echo "$output" | grep -q -i "$message"; then
+    bail "unexpected message '$message'"
+  fi
+}
+
+# Like expect_msg, but the command must fail with a non-zero exit code.
+# usage: must_fail_with_msg 'expected message' command --with --args
+must_fail_with_msg() {
+  message=$1
+  shift
+
+  if output=$("$@" 2>&1); then
+    bail "expected a non-zero exit code"
+  fi
+
+  if ! echo "$output" | grep -i -q "$message"; then
+    bail "expected message '$message'"
+  fi
+}
+
+# Is the legacy protocol enabled?
+with_legacy() {
+  tincd foo --version | grep -q legacy_protocol
+}
+
+# Are we running with EUID 0?
+is_root() {
+  test "$(id -u)" = 0
 }
 
 # Executes whatever is passed to it, checking that the resulting exit code is equal to the first argument.
@@ -215,6 +284,7 @@ require_nodes() {
 }
 
 peer_directory() {
+  peer=$1
   case "$peer" in
   foo) echo "$DIR_FOO" ;;
   bar) echo "$DIR_BAR" ;;
@@ -370,9 +440,32 @@ cleanup() {
   ) || true
 }
 
+# If we're on a CI server, the test requires superuser privileges to run, and we're not
+# currently a superuser, try running the test as one and fail if it doesn't work (the
+# system must be configured to provide passwordless sudo for our user).
+require_root() {
+  if is_root; then
+    return
+  fi
+  if is_ci; then
+    echo "root is required for test $SCRIPTNAME, but we're a regular user; elevating privileges..."
+    if ! command -v sudo 2>/dev/null; then
+      bail "please install sudo and configure passwordless auth for user $USER"
+    fi
+    if ! sudo --preserve-env --non-interactive true; then
+      bail "sudo is not allowed or requires a password for user $USER"
+    fi
+    exec sudo --preserve-env "$@"
+  else
+    # Avoid these kinds of surprises outside CI. Just skip the test.
+    echo "root is required for test $SCRIPTNAME, but we're a regular user; skipping"
+    exit $EXIT_SKIP_TEST
+  fi
+}
+
 # Generate path to current shell which can be used from Windows applications.
 if is_windows; then
-  MINGW_SHELL=$(cygpath --mixed -- "$SHELL")
+  MINGW_SHELL=$(normalize_path "$SHELL")
 fi
 
 # This was called from a tincd script. Skip executing commands with side effects.
@@ -383,10 +476,9 @@ echo [STEP] Check for leftover tinc daemons and test directories
 # Cleanup leftovers from previous runs.
 stop_all_tincs
 
-# On Windows this can actually fail. We don't want to suppress possible failure with -f.
-if [ -d "$DIR_FOO" ]; then rm -r "$DIR_FOO"; fi
-if [ -d "$DIR_BAR" ]; then rm -r "$DIR_BAR"; fi
-if [ -d "$DIR_BAZ" ]; then rm -r "$DIR_BAZ"; fi
+if [ -d "$DIR_FOO" ]; then rm -rf "$DIR_FOO"; fi
+if [ -d "$DIR_BAR" ]; then rm -rf "$DIR_BAR"; fi
+if [ -d "$DIR_BAZ" ]; then rm -rf "$DIR_BAZ"; fi
 
 # Register cleanup function so we don't have to call it everywhere
 # (and failed scripts do not leave stray tincd running).


### PR DESCRIPTION
This started as an attempt to fix the remaining memory leaks and bugs in `tinc fsck`. However, it was obvious that the command could use some attention, so I refactored it into smaller pieces and added missing functionality:

- implement TODOs
- fix invalid warning: `WARNING: public and private RSA keys do not match` (on freshly `tinc init`'ed key pair)
- use the same configuration reading & parsing logic as in `tincd`
- read keys from all supported variables (`PrivateKey` + `PrivateKeyFile` + inline, same for Ed25519)
- auto fix a few more broken key configurations
- fix a couple of rare memory leaks
- add warnings for host variables in server config and vice versa
- check duplicates for all configuration variables (not the first 50)
- `check_conffile` had a stack-buffer-underflow with going before the start of the line

I know it's a big ask to review this, but the new tests should ease this a bit as they cover every check performed by `fsck` (except for some error conditions that are impossible to produce without hooking into tinc's code).

Most of 17ba469e11601209fee54a73425fa21a739a99af is shuffling existing functions around (to unbreak linkage with `tinc`). I had to change a few arguments to make them applicable to more situations.

Tests cannot be split off from this PR because they won't run on current `fsck` due to bugs and missing functionality.

- https://github.com/hg/tinc/actions/runs/1075674524
- https://github.com/hg/tinc/actions/runs/1075747412
- https://builds.sr.ht/~reducer/job/554502
- https://builds.sr.ht/~reducer/job/554503
- https://builds.sr.ht/~reducer/job/554504

Windows jobs are hanging due to this: e050753d1fc4d4465032919746c2a4db78f19932
