### PR TITLE
Improve invite-join.test reliability on Alpine Linux.

### DIFF
--- a/test/invite-join.test
+++ b/test/invite-join.test
@@ -17,7 +17,8 @@ start_tinc foo
 
 echo [STEP] Generate an invitation and let another node join the VPN
 
-tinc foo invite bar | tinc bar join
+invitation=$(tinc foo invite bar)
+tinc bar join "$invitation"
 
 echo [STEP] Test equivalence of host config files
 


### PR DESCRIPTION
When joining one tinc to another on Alpine, it seems to be more reliable to receive invitation from one tinc instance and then pass it to another one instead of starting both at the same time and connecting them via a pipe (`tinc foo ... | tinc bar ...`)

Every time we've seen Alpine fail, it happened here

https://github.com/hg/tinc/blob/317ac584352db2b446e09a10ffb19d0d9f49acff/src/tincctl.c#L465-L473

with this message

```
Connected to localhost port 30010...
recvline failed: Connection reset by peer
Cannot read greeting from peer
Could not connect to ::1 port 30010: Address not available
```

This will be improved in due time (I added an item to my todo list and we can probably open a separate issue). In the meantime, we can at least make a failing Alpine job signal something important, before everyone starts ignoring it.

Here's 1200 successful test runs on six different version of Alpine:

- https://github.com/hg/tinc/actions/runs/1087334406
- https://github.com/hg/tinc/actions/runs/1087337931

Plus the usual:

- https://github.com/hg/tinc/actions/runs/1087391861
- https://github.com/hg/tinc/actions/runs/1087917968