### PR TITLE
Use libvdeplug.h instead of libvdeplug_dyn.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,8 +90,12 @@ AC_ARG_ENABLE(uml,
 AC_ARG_ENABLE(vde,
   AS_HELP_STRING([--enable-vde], [enable support for Virtual Distributed Ethernet]),
   [ AS_IF([test "x$enable_vde" = "xyes"],
-      [ AC_CHECK_HEADERS(libvdeplug_dyn.h, [], [AC_MSG_ERROR([VDE plug header files not found.]); break])
-        AC_CHECK_LIB(dl, dlopen, [LIBS="$LIBS -ldl"], [AC_MSG_ERROR([VDE plug depends on libdl.]); break])
+      [ AC_CHECK_HEADERS(libvdeplug.h,
+        [AC_CHECK_LIB(vdeplug, vde_close,
+                      [LIBS="$LIBS -lvdeplug"],
+                      [AC_MSG_ERROR("VDE plug library files not found.")]
+        )],
+        [AC_MSG_ERROR([VDE plug header files not found.]); break])
         AC_DEFINE(ENABLE_VDE, 1, [Support for VDE])
         vde=true
       ],

--- a/src/vde_device.c
+++ b/src/vde_device.c
@@ -19,7 +19,7 @@
 
 #include "system.h"
 
-#include <libvdeplug_dyn.h>
+#include <libvdeplug.h>
 
 #include "conf.h"
 #include "device.h"
@@ -29,20 +29,12 @@
 #include "route.h"
 #include "xalloc.h"
 
-static struct vdepluglib plug;
 static struct vdeconn *conn = NULL;
 static int port = 0;
 static char *group = NULL;
 static const char *device_info = "VDE socket";
 
 static bool setup_device(void) {
-	libvdeplug_dynopen(plug);
-
-	if(!plug.dl_handle) {
-		logger(DEBUG_ALWAYS, LOG_ERR, "Could not open libvdeplug library!");
-		return false;
-	}
-
 	if(!get_config_string(lookup_config(config_tree, "Device"), &device)) {
 		xasprintf(&device, RUNSTATEDIR "/vde.ctl");
 	}
@@ -59,14 +51,14 @@ static bool setup_device(void) {
 		.mode = 0700,
 	};
 
-	conn = plug.vde_open(device, identname, &args);
+	conn = vde_open(device, identname, &args);
 
 	if(!conn) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Could not open VDE socket %s", device);
 		return false;
 	}
 
-	device_fd = plug.vde_datafd(conn);
+	device_fd = vde_datafd(conn);
 
 #ifdef FD_CLOEXEC
 	fcntl(device_fd, F_SETFD, FD_CLOEXEC);
@@ -83,12 +75,8 @@ static bool setup_device(void) {
 
 static void close_device(void) {
 	if(conn) {
-		plug.vde_close(conn);
+		vde_close(conn);
 		conn = NULL;
-	}
-
-	if(plug.dl_handle) {
-		libvdeplug_dynclose(plug);
 	}
 
 	free(device);
@@ -101,11 +89,23 @@ static void close_device(void) {
 }
 
 static bool read_packet(vpn_packet_t *packet) {
-	ssize_t lenin = (ssize_t) plug.vde_recv(conn, DATA(packet), MTU, 0);
+	ssize_t lenin = vde_recv(conn, DATA(packet), MTU, 0);
 
 	if(lenin <= 0) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Error while reading from %s %s: %s", device_info, device, strerror(errno));
 		event_exit();
+		return false;
+	}
+
+	if(lenin == 1) {
+		logger(DEBUG_TRAFFIC, LOG_DEBUG,
+		       "Dropped a packet received from %s - the sender was not allowed to send that packet.", device_info);
+		return false;
+	}
+
+	if(lenin < 14) {
+		logger(DEBUG_TRAFFIC, LOG_DEBUG,
+		       "Received an invalid packet from %s - packet shorter than an ethernet header).", device_info);
 		return false;
 	}
 
@@ -117,7 +117,7 @@ static bool read_packet(vpn_packet_t *packet) {
 }
 
 static bool write_packet(vpn_packet_t *packet) {
-	if((ssize_t)plug.vde_send(conn, DATA(packet), packet->len, 0) < 0) {
+	if(vde_send(conn, DATA(packet), packet->len, 0) < 0) {
 		if(errno != EINTR && errno != EAGAIN) {
 			logger(DEBUG_ALWAYS, LOG_ERR, "Can't write to %s %s: %s", device_info, device, strerror(errno));
 			event_exit();


### PR DESCRIPTION
This is my attempt to address issue https://github.com/gsliepen/tinc/issues/300. I changed include from ``libvdeplug_dyn.h`` rather than ``libvdeplug.h``. 

The ``libvdeplug.h`` from Debian Unstable is almost identical to the one from Debian Buster. ~~I think using the statically linked version of ``libvdeplug`` might be the quickest and easiest fix.~~ (This is still dynamic linking, please refer to https://github.com/gsliepen/tinc/pull/302#issuecomment-894950250)