### PR TITLE
Fix -Wsign-compare error in keys.c

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -21,7 +21,7 @@ bool disable_old_keys(const char *filename, const char *what) {
 		return false;
 	}
 
-	int result = snprintf(tmpfile, sizeof(tmpfile), "%s.tmp", filename);
+	size_t result = snprintf(tmpfile, sizeof(tmpfile), "%s.tmp", filename);
 
 	if(result < sizeof(tmpfile)) {
 		struct stat st = {.st_mode = 0600};


### PR DESCRIPTION
When compiling with ``-Wall -Wextra`` under Debian Buster, I get the following error message:
```
keys.c: In function ‘disable_old_keys’:
keys.c:26:12: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  if(result < sizeof(tmpfile)) {
```

``snprintf`` returns a negative value on output error. In the current implementation, there is no error handling for negative return
values. Therefore in this context, it is acceptable to convert ``int`` to ``size_t``.