### PR TITLE
Make apt stop asking questions when building deb package.

### DIFF
--- a/.ci/package/deb/build.sh
+++ b/.ci/package/deb/build.sh
@@ -13,6 +13,8 @@ find_tag() {
   git describe --always --tags --match='release-*' "$@"
 }
 
+export DEBIAN_FRONTEND=noninteractive
+
 apt-get install -y devscripts git-buildpackage dh-make
 
 export USER=${USER:-$(whoami)}


### PR DESCRIPTION
I don't know what changed in the last couple of days, but it didn't ask anything before.

Tests:

- https://github.com/hg/tinc/actions/runs/1118758437
- https://github.com/hg/tinc/actions/runs/1118769237

Packages:

- https://github.com/hg/tinc/releases/tag/latest
- https://github.com/hg/tinc/releases/tag/release-1.420

I wonder why apt doesn't detect if it's on a tty or not, and acts accordingly.

Thanks @fangfufu for reporting it (#311).