### PR TITLE
RFC7539-related changes to ChaCha20

### DIFF
--- a/src/chacha-poly1305/chacha.c
+++ b/src/chacha-poly1305/chacha.c
@@ -74,9 +74,9 @@ void chacha_keysetup(chacha_ctx *x, const uint8_t *k, uint32_t kbits) {
 
 void chacha_ivsetup(chacha_ctx *x, const uint8_t *iv, const uint8_t *counter) {
 	x->input[12] = counter == NULL ? 0 : U8TO32_LITTLE(counter + 0);
-	x->input[13] = counter == NULL ? 0 : U8TO32_LITTLE(counter + 4);
-	x->input[14] = U8TO32_LITTLE(iv + 0);
-	x->input[15] = U8TO32_LITTLE(iv + 4);
+	x->input[13] = U8TO32_LITTLE(iv + 0);
+	x->input[14] = U8TO32_LITTLE(iv + 4);
+	x->input[15] = U8TO32_LITTLE(iv + 8);
 }
 
 void

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -25,7 +25,7 @@
 
 /* Protocol version. Different major versions are incompatible. */
 
-#define PROT_MAJOR 17
+#define PROT_MAJOR 18
 #define PROT_MINOR 7 /* Should not exceed 255! */
 
 /* Silly Windows */


### PR DESCRIPTION
This is an attempt to align the ChaCha20 implementation with RFC7539 (related to #301).

It seems to be the right thing to do to increment the major protocol version. I don't think we can reset the minor version, though? It's compared with magic values 1 and 2 all over the place.

A large part of RFC7539 is the [AEAD construction](https://datatracker.ietf.org/doc/html/rfc7539#section-2.8), which doesn't seem to be used in tinc. Instead we simply encrypt the plaintext and append the MAC to it. Were you planning to modify the protocol to add AEAD?

---

Because we don't have unit testing yet, I threw together a small program to check the algorithm against [RFC test vectors](https://datatracker.ietf.org/doc/html/rfc7539#section-2.3.2):

    $ cd src/chacha-poly1305/
    $ cat >test.c
    $ gcc poly1305.c chacha.c test.c
    $ ./a.out

```c
#include <stdint.h>
#include <string.h>
#include <stdlib.h>
#include <stdio.h>
#include "chacha.h"
#include "poly1305.h"

#define U8C(v) (v##U)
#define U32C(v) (v##U)

#define U8V(v) ((uint8_t)(v)&U8C(0xFF))
#define U32V(v) ((uint32_t)(v)&U32C(0xFFFFFFFF))

#define ROTL32(v, n) \
	(U32V((v) << (n)) | ((v) >> (32 - (n))))

#define U8TO32_LITTLE(p)              \
	(((uint32_t)((p)[0])) |       \
	 ((uint32_t)((p)[1]) << 8) |  \
	 ((uint32_t)((p)[2]) << 16) | \
	 ((uint32_t)((p)[3]) << 24))

#define U32TO8_LITTLE(p, v)              \
	do {                             \
		(p)[0] = U8V((v));       \
		(p)[1] = U8V((v) >> 8);  \
		(p)[2] = U8V((v) >> 16); \
		(p)[3] = U8V((v) >> 24); \
	} while(0)

#define ROTATE(v, c) (ROTL32(v, c))
#define XOR(v, w) ((v) ^ (w))
#define PLUS(v, w) (U32V((v) + (w)))
#define PLUSONE(v) (PLUS((v), 1))

#define QUARTERROUND(a, b, c, d)   \
	a = PLUS(a, b);            \
	d = ROTATE(XOR(d, a), 16); \
	c = PLUS(c, d);            \
	b = ROTATE(XOR(b, c), 12); \
	a = PLUS(a, b);            \
	d = ROTATE(XOR(d, a), 8);  \
	c = PLUS(c, d);            \
	b = ROTATE(XOR(b, c), 7);

static const uint8_t key[] = {
	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
	0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
};

static const uint8_t one[8] = {1, 0, 0, 0, 0, 0, 0, 0};

static const uint32_t expected_initial_state[] = {
	0x61707865, 0x3320646e, 0x79622d32, 0x6b206574,
	0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c,
	0x13121110, 0x17161514, 0x1b1a1918, 0x1f1e1d1c,
	0x00000001, 0x09000000, 0x4a000000, 0x00000000,
};

static const uint32_t expected_after_20_rounds[] = {
	0x837778ab, 0xe238d763, 0xa67ae21e, 0x5950bb2f,
	0xc4f2d0c7, 0xfc62bb2f, 0x8fa018fc, 0x3f5ec7b7,
	0x335271c2, 0xf29489f3, 0xeabda8fc, 0x82e46ebd,
	0xd19c12b4, 0xb04e16de, 0x9e83d0cb, 0x4e3c50a2,
};

static void check_state(const void *expected, const void *real, const char *kind) {
	if(memcmp(expected, real, sizeof(struct chacha_ctx))) {
		fprintf(stderr, "invalid %s state\n", kind);
		exit(1);
	}
}

// copy-pasted from chacha.c
static void run_20_rounds(struct chacha_ctx *ctx) {
	uint32_t x0 = ctx->input[0];
	uint32_t x1 = ctx->input[1];
	uint32_t x2 = ctx->input[2];
	uint32_t x3 = ctx->input[3];
	uint32_t x4 = ctx->input[4];
	uint32_t x5 = ctx->input[5];
	uint32_t x6 = ctx->input[6];
	uint32_t x7 = ctx->input[7];
	uint32_t x8 = ctx->input[8];
	uint32_t x9 = ctx->input[9];
	uint32_t x10 = ctx->input[10];
	uint32_t x11 = ctx->input[11];
	uint32_t x12 = ctx->input[12];
	uint32_t x13 = ctx->input[13];
	uint32_t x14 = ctx->input[14];
	uint32_t x15 = ctx->input[15];

	for(size_t i = 20; i > 0; i -= 2) {
		QUARTERROUND(x0, x4, x8, x12)
		QUARTERROUND(x1, x5, x9, x13)
		QUARTERROUND(x2, x6, x10, x14)
		QUARTERROUND(x3, x7, x11, x15)
		QUARTERROUND(x0, x5, x10, x15)
		QUARTERROUND(x1, x6, x11, x12)
		QUARTERROUND(x2, x7, x8, x13)
		QUARTERROUND(x3, x4, x9, x14)
	}

	U32TO8_LITTLE((uint8_t *) ctx + 0, x0);
	U32TO8_LITTLE((uint8_t *) ctx + 4, x1);
	U32TO8_LITTLE((uint8_t *) ctx + 8, x2);
	U32TO8_LITTLE((uint8_t *) ctx + 12, x3);
	U32TO8_LITTLE((uint8_t *) ctx + 16, x4);
	U32TO8_LITTLE((uint8_t *) ctx + 20, x5);
	U32TO8_LITTLE((uint8_t *) ctx + 24, x6);
	U32TO8_LITTLE((uint8_t *) ctx + 28, x7);
	U32TO8_LITTLE((uint8_t *) ctx + 32, x8);
	U32TO8_LITTLE((uint8_t *) ctx + 36, x9);
	U32TO8_LITTLE((uint8_t *) ctx + 40, x10);
	U32TO8_LITTLE((uint8_t *) ctx + 44, x11);
	U32TO8_LITTLE((uint8_t *) ctx + 48, x12);
	U32TO8_LITTLE((uint8_t *) ctx + 52, x13);
	U32TO8_LITTLE((uint8_t *) ctx + 56, x14);
	U32TO8_LITTLE((uint8_t *) ctx + 60, x15);
}

static void test_initialization() {
	static const uint8_t nonce[] = {
		0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x4a, 0x00, 0x00, 0x00, 0x00,
	};

	struct chacha_ctx ctx = {0};

	chacha_keysetup(&ctx, key, 256);
	chacha_ivsetup(&ctx, nonce, one);
	check_state(&expected_initial_state, &ctx, "initial");

	run_20_rounds(&ctx);
	check_state(&expected_after_20_rounds, &ctx, "20 rounds");
}

static void test_entryption() {
	const uint8_t plaintext[] = {
		0x4c, 0x61, 0x64, 0x69, 0x65, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x47, 0x65, 0x6e, 0x74, 0x6c,
		0x65, 0x6d, 0x65, 0x6e, 0x20, 0x6f, 0x66, 0x20, 0x74, 0x68, 0x65, 0x20, 0x63, 0x6c, 0x61, 0x73,
		0x73, 0x20, 0x6f, 0x66, 0x20, 0x27, 0x39, 0x39, 0x3a, 0x20, 0x49, 0x66, 0x20, 0x49, 0x20, 0x63,
		0x6f, 0x75, 0x6c, 0x64, 0x20, 0x6f, 0x66, 0x66, 0x65, 0x72, 0x20, 0x79, 0x6f, 0x75, 0x20, 0x6f,
		0x6e, 0x6c, 0x79, 0x20, 0x6f, 0x6e, 0x65, 0x20, 0x74, 0x69, 0x70, 0x20, 0x66, 0x6f, 0x72, 0x20,
		0x74, 0x68, 0x65, 0x20, 0x66, 0x75, 0x74, 0x75, 0x72, 0x65, 0x2c, 0x20, 0x73, 0x75, 0x6e, 0x73,
		0x63, 0x72, 0x65, 0x65, 0x6e, 0x20, 0x77, 0x6f, 0x75, 0x6c, 0x64, 0x20, 0x62, 0x65, 0x20, 0x69,
		0x74, 0x2e,
	};

	const uint8_t expected_ciphertext[] = {
		0x6e, 0x2e, 0x35, 0x9a, 0x25, 0x68, 0xf9, 0x80, 0x41, 0xba, 0x07, 0x28, 0xdd, 0x0d, 0x69, 0x81,
		0xe9, 0x7e, 0x7a, 0xec, 0x1d, 0x43, 0x60, 0xc2, 0x0a, 0x27, 0xaf, 0xcc, 0xfd, 0x9f, 0xae, 0x0b,
		0xf9, 0x1b, 0x65, 0xc5, 0x52, 0x47, 0x33, 0xab, 0x8f, 0x59, 0x3d, 0xab, 0xcd, 0x62, 0xb3, 0x57,
		0x16, 0x39, 0xd6, 0x24, 0xe6, 0x51, 0x52, 0xab, 0x8f, 0x53, 0x0c, 0x35, 0x9f, 0x08, 0x61, 0xd8,
		0x07, 0xca, 0x0d, 0xbf, 0x50, 0x0d, 0x6a, 0x61, 0x56, 0xa3, 0x8e, 0x08, 0x8a, 0x22, 0xb6, 0x5e,
		0x52, 0xbc, 0x51, 0x4d, 0x16, 0xcc, 0xf8, 0x06, 0x81, 0x8c, 0xe9, 0x1a, 0xb7, 0x79, 0x37, 0x36,
		0x5a, 0xf9, 0x0b, 0xbf, 0x74, 0xa3, 0x5b, 0xe6, 0xb4, 0x0b, 0x8e, 0xed, 0xf2, 0x78, 0x5e, 0x42,
		0x87, 0x4d,
	};

	static const uint8_t enc_nonce[] = {
		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4a, 0x00, 0x00, 0x00, 0x00,
	};

	uint8_t ciphertext[sizeof(expected_ciphertext)];

	struct chacha_ctx ctx = {0};
	chacha_keysetup(&ctx, key, 256);
	chacha_ivsetup(&ctx, enc_nonce, one);

	chacha_encrypt_bytes(&ctx, (uint8_t *) plaintext, ciphertext, sizeof(ciphertext));

	if(memcmp(expected_ciphertext, ciphertext, sizeof(ciphertext))) {
		fprintf(stderr, "invalid ciphertext\n");
		exit(2);
	}
}

static void test_auth() {
	const uint8_t key[] = {
		0x85, 0xd6, 0xbe, 0x78, 0x57, 0x55, 0x6d, 0x33, 0x7f, 0x44, 0x52, 0xfe, 0x42, 0xd5, 0x06, 0xa8,
		0x01, 0x03, 0x80, 0x8a, 0xfb, 0x0d, 0xb2, 0xfd, 0x4a, 0xbf, 0xf6, 0xaf, 0x41, 0x49, 0xf5, 0x1b,
	};

	const uint8_t msg[] = {
		0x43, 0x72, 0x79, 0x70, 0x74, 0x6f, 0x67, 0x72, 0x61, 0x70, 0x68, 0x69, 0x63, 0x20, 0x46, 0x6f,
		0x72, 0x75, 0x6d, 0x20, 0x52, 0x65, 0x73, 0x65, 0x61, 0x72, 0x63, 0x68, 0x20, 0x47, 0x72, 0x6f,
		0x75, 0x70,
	};

	const uint8_t  expected_tag[] = {
		0xa8, 0x06, 0x1d, 0xc1, 0x30, 0x51, 0x36, 0xc6, 0xc2, 0x2b, 0x8b, 0xaf, 0x0c, 0x01, 0x27, 0xa9,
	};

	uint8_t tag[POLY1305_TAGLEN];
	poly1305_auth(tag, msg, sizeof(msg), key);

	if(memcmp(expected_tag, tag, sizeof(tag))) {
		fprintf(stderr, "invalid MAC\n");
		exit(3);
	}
}

int main() {
	test_initialization();
	test_entryption();
	test_auth();
}
```

