### PR TITLE
hash table fix

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -43,21 +43,21 @@ uint32_t modulo(uint32_t hash, size_t n);
 	void hash_insert_ ## t (hash_ ##t *hash, const t *key, const void *value) { \
 		uint32_t i = hash_modulo_ ## t(hash_function_ ## t(key)); \
 		for(uint8_t f=0; f< (HASH_SEARCH_ITERATIONS - 1); f++){ \
-			if(hash->values[i] == NULL || !memcmp(key, &hash->keys[i], sizeof(#t))) { \
-				memcpy(&hash->keys[i], key, sizeof(#t)); \
+			if(hash->values[i] == NULL || !memcmp(key, &hash->keys[i], sizeof(t))) { \
+				memcpy(&hash->keys[i], key, sizeof(t)); \
 				hash->values[i] = value; \
 				return; \
 			} \
 			if(++i == n) i = 0; \
 		} \
 		/* We always pick the last slot. It's unfair. But thats life */ \
-		memcpy(&hash->keys[i], key, sizeof(#t)); \
+		memcpy(&hash->keys[i], key, sizeof(t)); \
 		hash->values[i] = value; \
 	} \
 	void *hash_search_ ## t (const hash_ ##t *hash, const t *key) { \
 		uint32_t i = hash_modulo_ ## t(hash_function_ ## t(key)); \
 		for(uint8_t f=0; f<HASH_SEARCH_ITERATIONS; f++){ \
-			if(!memcmp(key, &hash->keys[i], sizeof(#t))) { \
+			if(!memcmp(key, &hash->keys[i], sizeof(t))) { \
 				return (void *)hash->values[i]; \
 			} \
 			if(++i == n) i = 0; \
@@ -67,7 +67,7 @@ uint32_t modulo(uint32_t hash, size_t n);
 	void hash_delete_ ## t (hash_ ##t *hash, const t *key) { \
 		uint32_t i = hash_modulo_ ## t(hash_function_ ## t(key)); \
 		for(uint8_t f=0; f<HASH_SEARCH_ITERATIONS; f++){ \
-			if(!memcmp(key, &hash->keys[i], sizeof(#t))) { \
+			if(!memcmp(key, &hash->keys[i], sizeof(t))) { \
 				hash->values[i] = NULL; \
 				return; \
 			} \
@@ -76,6 +76,7 @@ uint32_t modulo(uint32_t hash, size_t n);
 	} \
 	void hash_clear_ ## t(hash_ ##t *hash) { \
 		memset(hash->values, 0, n * sizeof(*hash->values)); \
+		memset(hash->keys, 0, n * sizeof(*hash->keys)); \
 	}
 
 

--- a/src/subnet.c
+++ b/src/subnet.c
@@ -129,6 +129,9 @@ void subnet_cache_flush_table(subnet_type_t stype) {
 
 void init_subnets(void) {
 	hash_seed = (uint32_t)rand();
+
+	// tables need to be cleared on startup
+	subnet_cache_flush_tables();
 }
 
 void exit_subnets(void) {


### PR DESCRIPTION
1. Clears keys during hash_clear
2. Explicitly clears memory during subnet init (bug introduced during merge)
3. Fixes memcmp read past bounds (read size 8, not 4/6/8)