### PR TITLE
Improve failure detection in the test suite.

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,6 +1,7 @@
 image: freebsd/13.x
 
 packages:
+  - coreutils
   - autotools
   - openssl
   - lzo2

--- a/.ci/tidy/run.sh
+++ b/.ci/tidy/run.sh
@@ -27,9 +27,7 @@ for path in $paths; do
 done
 
 if ! [ -f compile_commands.json ]; then
-  # Running compiledb directly on this doesn't work on FreeBSD for some reason.
-  make -j2 all extra
-  compiledb -n make check
+  compiledb make all extra
 fi
 
 echo >&2 "Running clang-tidy without $paths"

--- a/test/compression.test
+++ b/test/compression.test
@@ -106,13 +106,13 @@ for level in $levels; do
   wait_script foo hosts/bar-up
   wait_script bar hosts/foo-up
 
-  ip netns exec foo \
-    socat -u TCP4-LISTEN:$recv_port_foo,reuseaddr OPEN:"$tmp_file",creat &
+  try_limit_time 60 sh <<EOF
+    set -eu
+    ip netns exec foo socat -u TCP4-LISTEN:$recv_port_foo,reuseaddr OPEN:"$tmp_file",creat &
+    ip netns exec bar socat -u OPEN:"$ref_file" TCP4:$ip_foo:$recv_port_foo,retry=30 &
+    wait
+EOF
 
-  ip netns exec bar \
-    socat -u OPEN:"$ref_file" TCP4:$ip_foo:$recv_port_foo,retry=30 &
-
-  wait
   diff -w "$ref_file" "$tmp_file"
 
   tinc foo stop

--- a/test/testlib.sh.in
+++ b/test/testlib.sh.in
@@ -185,21 +185,11 @@ expect_code() {
 # Runs its arguments with timeout(1) or gtimeout(1) if either are installed.
 # Usage: try_limit_time 10 command --with --args
 if type timeout >/dev/null; then
-  if is_busybox; then
-    # busybox does not support --foreground
-    try_limit_time() {
-      time=$1
-      shift
-      timeout "$time" "$@"
-    }
-  else
-    # BSD and GNU timeout do not require special handling
-    try_limit_time() {
-      time=$1
-      shift
-      timeout --foreground "$time" "$@"
-    }
-  fi
+  try_limit_time() {
+    time=$1
+    shift
+    timeout "$time" "$@"
+  }
 else
   try_limit_time() {
     echo >&2 "timeout was not found, running without time limits!"


### PR DESCRIPTION
Improve detection of tinc failures in the test suite — it should now report failures as failures instead of hanging indefinitely.

Prompted by #315.

The reason behind `--foreground` was to put the time limit only on the, em, foreground process, ignoring anything that it might start and leave running in the background (like tinc). After rewriting the test library so many times I don't believe it's actually needed anymore, any it's best to throw it away in any case because it's not supported by most `timeout`s.

Things that should have failed (and did):

- https://github.com/hg/tinc/runs/3329650122
- https://github.com/hg/tinc/runs/3329650316

---

A bit of a rant: it's way too late for that, but after bashing my head against so many pointless differences in Unix utilities I am of the opinion that the test suite for cross-platform projects should be written in something like Python, or maybe even C. Diversity is good when there is actual diversity, but not when you have ten sets of utilities that are pretty much the same, except for tiny little differences like: this `tail` does X on SIGPIPE, that `tail` doesn't; this `wc` prints whitespace around the number, that one doesn't, this shell waits for all child jobs to finish, that one doesn't, and so on and so forth.

Autotools developers deserve a monument for their efforts.

