### PR TITLE
Reinit pseudo-random state in tincd service on Windows

### DIFF
--- a/src/tincd.c
+++ b/src/tincd.c
@@ -491,8 +491,6 @@ int main(int argc, char **argv) {
 
 	/* Slllluuuuuuurrrrp! */
 
-	gettimeofday(&now, NULL);
-	srand(now.tv_sec + now.tv_usec);
 	crypto_init();
 
 	if(!read_server_config(&config_tree)) {
@@ -545,6 +543,9 @@ int main2(int argc, char **argv) {
 	(void)argv;
 #endif
 	char *priority = NULL;
+
+	gettimeofday(&now, NULL);
+	srand(now.tv_sec + now.tv_usec);
 
 	if(!detach()) {
 		return 1;


### PR DESCRIPTION
https://github.com/hg/tinc/runs/3333383171

This should fix #306. Here's what I believe was happening:

0. tincd service on Windows is always initialized to the same pseudo-random sequence
1. bar connects to foo, sends its subnet information (using "random" numbers in meta commands)
2. foo configures bar's edges, subnets, etc, and remembers the commands it received
3. bar disconnects from foo and restarts
4. bar connects again (repeat step 1)
5. foo sees the exact same commands and rejects them outright
6. bar gets ignored and there's no connection anymore

Sometimes a timer would go off somewhere, `rand()` would be called before it's used in `send_add_edge`, and the job would pass successfully.

---

Considering how bad MS's pseudo-random number generator is (`RAND_MAX` is 0xFFFF and collisions are relatively likely), maybe it's best to throw it away and use one of:

- call it twice and build a proper 32-bit integer out of both results
- set the first result to `getpid()`
- roll our own algorithm
- or maybe even `CryptGenRandom()`, at least for anything that goes through the network to other nodes

---

By the way, CI breakage is caused by the new Debian release. We'll have to wait until container images are updated, probably another day or two. We can hardcode version numbers instead of tags like `stable`, but then you'll have to update them every couple of years.