### PR TITLE
Fix UBSAN warnings about conversions and overflows.

### DIFF
--- a/src/route.c
+++ b/src/route.c
@@ -485,7 +485,7 @@ static void clamp_mss(const node_t *source, const node_t *via, vpn_packet_t *pac
 		csum += csum >> 16;
 		csum ^= 0xffff;
 		DATA(packet)[start + 16] = csum >> 8;
-		DATA(packet)[start + 17] = csum;
+		DATA(packet)[start + 17] = csum & 0xff;
 		break;
 	}
 }

--- a/src/subnet.c
+++ b/src/subnet.c
@@ -83,7 +83,7 @@ static uint32_t hash_function_ipv6_t(const ipv6_t *p) {
 	uint32_t hash = hash_seed;
 
 	for(int i = 0; i < 4; i++) {
-		hash += fullwidth[i];
+		hash = wrapping_add32(hash, fullwidth[i]);
 		hash = wrapping_mul32(hash, 0x9e370001U);
 	}
 
@@ -95,7 +95,7 @@ static uint32_t hash_function_mac_t(const mac_t *p) {
 	uint32_t hash = hash_seed;
 
 	for(int i = 0; i < 3; i++) {
-		hash += halfwidth[i];
+		hash = wrapping_add32(hash, halfwidth[i]);
 		hash = wrapping_mul32(hash, 0x9e370001U);
 	}
 


### PR DESCRIPTION
A couple of fixes for yet another batch of UBSAN warnings.

before:

- https://github.com/hg/tinc/runs/3334263546
- plus local testing

after:

- https://github.com/hg/tinc/actions/runs/1133163095
- https://github.com/hg/tinc/actions/runs/1133164880

```
route.c:488:30: runtime error: implicit conversion from type 'uint32_t' (aka 'unsigned int') of value 62357 (32-bit, unsigned) to type 'uint8_t' (aka 'unsigned char') changed the value to 149 (8-bit, unsigned)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior route.c:488:30 in
```

```
subnet.c:86:8: runtime error: unsigned integer overflow: 4273296874 + 33554432 cannot be represented in type 'unsigned int'
    #0 0x55d3879f6337 in hash_function_ipv6_t src/subnet.c:86:8
    #1 0x55d3879f6388 in hash_search_ipv6_t src/subnet.c:106:1
    #2 0x55d3879f8e16 in lookup_subnet_ipv6 src/subnet.c:293:10
    #3 0x55d3879cb4fb in route_ipv6 src/route.c:722:11
    #4 0x55d3879c7b19 in route src/route.c:1160:4
    #5 0x55d38797db2e in handle_device_data src/net_packet.c:1910:3
    #6 0x55d387950780 in event_loop src/event.c:355:5
    #7 0x55d387968c02 in main_loop src/net.c:505:6
    #8 0x55d3879ff471 in main src/tincd.c:614:11
    #9 0x7efd65c8f0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #10 0x55d387919dcd in _start (src/tincd+0x9adcd)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior subnet.c:86:8 in
```
