### PR TITLE
Replace pointers to cipher_t/digest_t in connection_t with structs.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           - mips
 
     container:
-      image: debian:bullseye
+      image: debian:buster
       options: --privileged
 
     steps:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -216,13 +216,13 @@ endif
 
 if OPENSSL
 tincd_SOURCES += \
-	openssl/cipher.c \
+	openssl/cipher.c openssl/cipher.h \
 	openssl/crypto.c \
 	openssl/digest.c openssl/digest.h \
 	openssl/prf.c \
 	openssl/rsa.c
 tinc_SOURCES += \
-	openssl/cipher.c \
+	openssl/cipher.c openssl/cipher.h \
 	openssl/crypto.c \
 	openssl/digest.c openssl/digest.h \
 	openssl/prf.c \
@@ -280,6 +280,13 @@ sptps_speed_SOURCES += \
 	nolegacy/crypto.c \
 	nolegacy/prf.c
 endif
+endif
+
+if WITH_LEGACY_PROTOCOL
+tinc_SOURCES        += digest.c
+tincd_SOURCES       += digest.c cipher.c
+sptps_test_SOURCES  += digest.c
+sptps_speed_SOURCES += digest.c
 endif
 
 if MINIUPNPC

--- a/src/cipher.c
+++ b/src/cipher.c
@@ -1,0 +1,18 @@
+#include "cipher.h"
+#include "xalloc.h"
+
+#ifndef DISABLE_LEGACY
+
+cipher_t *cipher_alloc() {
+	return xzalloc(sizeof(cipher_t));
+}
+
+void cipher_free(cipher_t **cipher) {
+	if(cipher && *cipher) {
+		cipher_close(*cipher);
+		free(*cipher);
+		*cipher = NULL;
+	}
+}
+
+#endif // DISABLE_LEGACY

--- a/src/cipher.h
+++ b/src/cipher.h
@@ -28,10 +28,20 @@
 
 #ifndef DISABLE_LEGACY
 
+#ifdef HAVE_OPENSSL
+#include "openssl/cipher.h"
+#elif HAVE_LIBGCRYPT
+#include "gcrypt/cipher.h"
+#else
+#error Incorrect cryptographic library, please reconfigure.
+#endif
+
 typedef struct cipher cipher_t;
 
-extern cipher_t *cipher_open_by_name(const char *name) __attribute__((__malloc__));
-extern cipher_t *cipher_open_by_nid(int nid) __attribute__((__malloc__));
+extern cipher_t *cipher_alloc() __attribute__((__malloc__));
+extern void cipher_free(cipher_t **cipher);
+extern bool cipher_open_by_name(cipher_t *cipher, const char *name);
+extern bool cipher_open_by_nid(cipher_t *cipher, int nid);
 extern void cipher_close(cipher_t *cipher);
 extern size_t cipher_keylength(const cipher_t *cipher);
 extern size_t cipher_blocksize(const cipher_t *cipher);
@@ -43,6 +53,6 @@ extern bool cipher_decrypt(cipher_t *cipher, const void *indata, size_t inlen, v
 extern int cipher_get_nid(const cipher_t *cipher);
 extern bool cipher_active(const cipher_t *cipher);
 
-#endif
+#endif // DISABLE_LEGACY
 
-#endif
+#endif // TINC_CIPHER_H

--- a/src/connection.c
+++ b/src/connection.c
@@ -63,10 +63,10 @@ void free_connection(connection_t *c) {
 	}
 
 #ifndef DISABLE_LEGACY
-	cipher_close(c->incipher);
-	digest_close(c->indigest);
-	cipher_close(c->outcipher);
-	digest_close(c->outdigest);
+	cipher_close(&c->incipher);
+	digest_close(&c->indigest);
+	cipher_close(&c->outcipher);
+	digest_close(&c->outdigest);
 	rsa_free(c->rsa);
 #endif
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -78,10 +78,10 @@ typedef struct connection_t {
 
 #ifndef DISABLE_LEGACY
 	rsa_t *rsa;                     /* his public RSA key */
-	cipher_t *incipher;             /* Cipher he will use to send data to us */
-	cipher_t *outcipher;            /* Cipher we will use to send data to him */
-	digest_t *indigest;
-	digest_t *outdigest;
+	cipher_t incipher;              /* Cipher he will use to send data to us */
+	cipher_t outcipher;             /* Cipher we will use to send data to him */
+	digest_t indigest;
+	digest_t outdigest;
 	uint64_t inbudget;
 	uint64_t outbudget;
 #endif

--- a/src/digest.c
+++ b/src/digest.c
@@ -1,0 +1,18 @@
+#include "digest.h"
+#include "xalloc.h"
+
+#ifndef DISABLE_LEGACY
+
+digest_t *digest_alloc() {
+	return xzalloc(sizeof(digest_t));
+}
+
+void digest_free(digest_t **digest) {
+	if(digest && *digest) {
+		digest_close(*digest);
+		free(*digest);
+		*digest = NULL;
+	}
+}
+
+#endif // DISABLE_LEGACY

--- a/src/digest.h
+++ b/src/digest.h
@@ -27,10 +27,20 @@
 
 #ifndef DISABLE_LEGACY
 
+#ifdef HAVE_OPENSSL
+#include "openssl/digest.h"
+#elif HAVE_LIBGCRYPT
+#include "gcrypt/digest.h"
+#else
+#error Incorrect cryptographic library, please reconfigure.
+#endif
+
 typedef struct digest digest_t;
 
-extern digest_t *digest_open_by_name(const char *name, size_t maclength) __attribute__((__malloc__));
-extern digest_t *digest_open_by_nid(int nid, size_t maclength) __attribute__((__malloc__));
+extern bool digest_open_by_name(digest_t *digest, const char *name, size_t maclength);
+extern bool digest_open_by_nid(digest_t *digest, int nid, size_t maclength);
+extern digest_t *digest_alloc() __attribute__((__malloc__));
+extern void digest_free(digest_t **digest);
 extern void digest_close(digest_t *digest);
 extern bool digest_create(digest_t *digest, const void *indata, size_t inlen, void *outdata) __attribute__((__warn_unused_result__));
 extern bool digest_verify(digest_t *digest, const void *indata, size_t inlen, const void *digestdata) __attribute__((__warn_unused_result__));

--- a/src/gcrypt/cipher.c
+++ b/src/gcrypt/cipher.c
@@ -147,7 +147,8 @@ void cipher_close(cipher_t *cipher) {
 	}
 
 	free(cipher->key);
-	cipher->key = NULL;
+
+	memset(cipher, 0, sizeof(*cipher));
 }
 
 size_t cipher_keylength(const cipher_t *cipher) {

--- a/src/gcrypt/digest.c
+++ b/src/gcrypt/digest.c
@@ -120,7 +120,7 @@ void digest_close(digest_t *digest) {
 		gcry_md_close(digest->hmac);
 	}
 
-	digest->hmac = NULL;
+	memset(digest, 0, sizeof(*digest));
 }
 
 bool digest_set_key(digest_t *digest, const void *key, size_t len) {

--- a/src/meta.c
+++ b/src/meta.c
@@ -78,7 +78,7 @@ bool send_meta(connection_t *c, const void *buffer, size_t length) {
 
 		size_t outlen = length;
 
-		if(!cipher_encrypt(c->outcipher, buffer, length, buffer_prepare(&c->outbuf, length), &outlen, false) || outlen != length) {
+		if(!cipher_encrypt(&c->outcipher, buffer, length, buffer_prepare(&c->outbuf, length), &outlen, false) || outlen != length) {
 			logger(DEBUG_ALWAYS, LOG_ERR, "Error while encrypting metadata to %s (%s)",
 			       c->name, c->hostname);
 			return false;
@@ -258,7 +258,7 @@ bool receive_meta(connection_t *c) {
 
 			size_t outlen = inlen;
 
-			if(!cipher_decrypt(c->incipher, bufp, inlen, buffer_prepare(&c->inbuf, inlen), &outlen, false) || (size_t)inlen != outlen) {
+			if(!cipher_decrypt(&c->incipher, bufp, inlen, buffer_prepare(&c->inbuf, inlen), &outlen, false) || (size_t)inlen != outlen) {
 				logger(DEBUG_ALWAYS, LOG_ERR, "Error while decrypting metadata from %s (%s)",
 				       c->name, c->hostname);
 				return false;

--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -820,10 +820,15 @@ static bool setup_myself(void) {
 
 	if(!strcasecmp(cipher, "none")) {
 		myself->incipher = NULL;
-	} else if(!(myself->incipher = cipher_open_by_name(cipher))) {
-		logger(DEBUG_ALWAYS, LOG_ERR, "Unrecognized cipher type!");
-		free(cipher);
-		return false;
+	} else {
+		myself->incipher = cipher_alloc();
+
+		if(!cipher_open_by_name(myself->incipher, cipher)) {
+			logger(DEBUG_ALWAYS, LOG_ERR, "Unrecognized cipher type!");
+			cipher_free(&myself->incipher);
+			free(cipher);
+			return false;
+		}
 	}
 
 	free(cipher);
@@ -850,10 +855,15 @@ static bool setup_myself(void) {
 
 	if(!strcasecmp(digest, "none")) {
 		myself->indigest = NULL;
-	} else if(!(myself->indigest = digest_open_by_name(digest, maclength))) {
-		logger(DEBUG_ALWAYS, LOG_ERR, "Unrecognized digest type!");
-		free(digest);
-		return false;
+	} else {
+		myself->indigest = digest_alloc();
+
+		if(!digest_open_by_name(myself->indigest, digest, maclength)) {
+			logger(DEBUG_ALWAYS, LOG_ERR, "Unrecognized digest type!");
+			digest_free(&myself->indigest);
+			free(digest);
+			return false;
+		}
 	}
 
 	free(digest);

--- a/src/node.c
+++ b/src/node.c
@@ -95,10 +95,10 @@ void free_node(node_t *n) {
 	sockaddrfree(&n->address);
 
 #ifndef DISABLE_LEGACY
-	cipher_close(n->incipher);
-	digest_close(n->indigest);
-	cipher_close(n->outcipher);
-	digest_close(n->outdigest);
+	cipher_free(&n->incipher);
+	digest_free(&n->indigest);
+	cipher_free(&n->outcipher);
+	digest_free(&n->outdigest);
 #endif
 
 	ecdsa_free(n->ecdsa);

--- a/src/openssl/cipher.h
+++ b/src/openssl/cipher.h
@@ -1,0 +1,11 @@
+#ifndef TINC_OPENSSL_CIPHER_H
+#define TINC_OPENSSL_CIPHER_H
+
+#include <openssl/evp.h>
+
+struct cipher {
+	EVP_CIPHER_CTX *ctx;
+	const EVP_CIPHER *cipher;
+};
+
+#endif

--- a/src/openssl/prf.c
+++ b/src/openssl/prf.c
@@ -30,18 +30,19 @@
  */
 
 static bool prf_xor(int nid, const uint8_t *secret, size_t secretlen, uint8_t *seed, size_t seedlen, uint8_t *out, size_t outlen) {
-	digest_t *digest = digest_open_by_nid(nid, DIGEST_ALGO_SIZE);
+	digest_t digest = {0};
 
-	if(!digest) {
+	if(!digest_open_by_nid(&digest, nid, DIGEST_ALGO_SIZE)) {
+		digest_close(&digest);
 		return false;
 	}
 
-	if(!digest_set_key(digest, secret, secretlen)) {
-		digest_close(digest);
+	if(!digest_set_key(&digest, secret, secretlen)) {
+		digest_close(&digest);
 		return false;
 	}
 
-	size_t len = digest_length(digest);
+	size_t len = digest_length(&digest);
 
 	/* Data is what the "inner" HMAC function processes.
 	   It consists of the previous HMAC result plus the seed.
@@ -55,14 +56,14 @@ static bool prf_xor(int nid, const uint8_t *secret, size_t secretlen, uint8_t *s
 
 	while(outlen > 0) {
 		/* Inner HMAC */
-		if(!digest_create(digest, data, len + seedlen, data)) {
-			digest_close(digest);
+		if(!digest_create(&digest, data, len + seedlen, data)) {
+			digest_close(&digest);
 			return false;
 		}
 
 		/* Outer HMAC */
-		if(!digest_create(digest, data, len + seedlen, hash)) {
-			digest_close(digest);
+		if(!digest_create(&digest, data, len + seedlen, hash)) {
+			digest_close(&digest);
 			return false;
 		}
 
@@ -76,7 +77,7 @@ static bool prf_xor(int nid, const uint8_t *secret, size_t secretlen, uint8_t *s
 		outlen -= i;
 	}
 
-	digest_close(digest);
+	digest_close(&digest);
 	return true;
 }
 


### PR DESCRIPTION
This is a part of #294 (replacing pointers to `cipher_t` and `digest_t` inside `connection_t` with structs themselves).

CI for this PR will fail until #321 is merged and this rebased on top.

I am not sure about changes to gcrypt. It is impossible to test because it hasn't been working for quite a while. I'll look into fixing it next.
