### PR TITLE
Leaks in `invitation.c` + minor Solaris fixes

### DIFF
--- a/src/linux/device.c
+++ b/src/linux/device.c
@@ -142,7 +142,7 @@ static void close_device(void) {
 }
 
 static bool read_packet(vpn_packet_t *packet) {
-	size_t inlen;
+	ssize_t inlen;
 
 	switch(device_type) {
 	case DEVICE_TYPE_TUN:

--- a/src/solaris/device.c
+++ b/src/solaris/device.c
@@ -359,7 +359,7 @@ static bool read_packet(vpn_packet_t *packet) {
 		sbuf.buf = (char *)DATA(packet);
 
 		if((result = getmsg(device_fd, NULL, &sbuf, &f)) < 0) {
-			logger(LOG_ERR, "Error while reading from %s %s: %s", device_info, device, strerror(errno));
+			logger(DEBUG_TRAFFIC, LOG_ERR, "Error while reading from %s %s: %s", device_info, device, strerror(errno));
 			return false;
 		}
 
@@ -386,7 +386,7 @@ static bool write_packet(vpn_packet_t *packet) {
 		sbuf.buf = (char *)DATA(packet) + 14;
 
 		if(putmsg(device_fd, NULL, &sbuf, 0) < 0) {
-			logger(LOG_ERR, "Can't write to %s %s: %s", device_info, device, strerror(errno));
+			logger(DEBUG_TRAFFIC, LOG_ERR, "Can't write to %s %s: %s", device_info, device, strerror(errno));
 			return false;
 		}
 
@@ -397,7 +397,7 @@ static bool write_packet(vpn_packet_t *packet) {
 		sbuf.buf = (char *)DATA(packet);
 
 		if(putmsg(device_fd, NULL, &sbuf, 0) < 0) {
-			logger(LOG_ERR, "Can't write to %s %s: %s", device_info, device, strerror(errno));
+			logger(DEBUG_TRAFFIC, LOG_ERR, "Can't write to %s %s: %s", device_info, device, strerror(errno));
 			return false;
 		}
 


### PR DESCRIPTION
- https://github.com/hg/tinc/actions/runs/1138466183
- https://github.com/hg/tinc/actions/runs/1138456174

Found in the process of making libgcrypt work. Cryptographic library failures were pushing `invitation.c` into previously untested error handling paths.

Fuzz testing could help with that, probably. I am not sure how to implement it, though: tincd networking code seems to require a lot of state being set up to function properly, so there has to be a network connection of some sort.

Running two separate tincd processes and sending fuzz data between them won't work — fuzzers monitor the very same process they're writing data into and expect it to fail.

I'm thinking of trying to create a separate thread, `connect()` to the same process, send data there, and see what happens.

---

For Solaris CI we could try this:

https://github.com/vmactions/solaris-vm

I'm getting the idea that if the code is not being regularly tested, then it quickly bitrots and probably does not work. Does it make sense to spend time on a pretty much dead OS?