### PR TITLE
Wait for the network to be online before starting tinc. (1.1)

### DIFF
--- a/systemd/tinc@.service.in
+++ b/systemd/tinc@.service.in
@@ -4,6 +4,9 @@ Documentation=info:tinc
 Documentation=man:tinc(8) man:tinc.conf(5)
 Documentation=http://tinc-vpn.org/docs/
 PartOf=tinc.service
+Before=systemd-user-sessions.service
+After=network-online.target
+Wants=network-online.target
 ReloadPropagatedFrom=tinc.service
 
 [Service]
@@ -17,4 +20,4 @@ RestartSec=5
 TimeoutStopSec=5
 
 [Install]
-WantedBy=tinc.service
+WantedBy=multi-user.target


### PR DESCRIPTION
I found it super annoying that tinc starts before any of my other network interfaces come online. I made this change locally, so tinc starts up after the network comes online. OpenVPN has similar behaviour. I think it might be useful for others.

Note that the behaviour of tinc not waiting until the network comes online is mentioned in issue https://github.com/gsliepen/tinc/issues/133.

There is also a similar pull request for tinc 1.0. (pull request https://github.com/gsliepen/tinc/pull/325)