### PR TITLE
remove full subnet cache clear on graph update

### DIFF
--- a/src/graph.c
+++ b/src/graph.c
@@ -196,6 +196,8 @@ static void sssp_bfs(void) {
 				update_node_udp(e->to, &e->address);
 			}
 
+			subnet_cache_clear_node(e->to);
+
 			list_insert_tail(todo_list, e->to);
 		}
 
@@ -278,6 +280,7 @@ static void check_reachability(void) {
 			free(port);
 			environment_exit(&env);
 
+			subnet_cache_clear_node(n);
 			subnet_update(n, NULL, n->status.reachable);
 
 			if(!n->status.reachable) {
@@ -307,7 +310,6 @@ static void check_reachability(void) {
 }
 
 void graph(void) {
-	subnet_cache_flush_tables();
 	sssp_bfs();
 	check_reachability();
 	mst_kruskal();

--- a/src/graph.c
+++ b/src/graph.c
@@ -28,11 +28,11 @@
 
    For the MST algorithm we can choose from Prim's or Kruskal's. I personally
    favour Kruskal's, because we make an extra AVL tree of edges sorted on
-   weights (metric). That tree only has to be updated when an edge is added or
-   removed, and during the MST algorithm we just have go linearly through that
-   tree, adding safe edges until #edges = #nodes - 1. The implementation here
-   however is not so fast, because I tried to avoid having to make a forest and
-   merge trees.
+   weights (metric). With the lowest weight beings most optimal. That tree only
+   has to be updated when an edge is added or removed, and during the MST algorithm
+   we just have go linearly through that tree, adding safe edges until #edges = #nodes - 1.
+   The implementation here however is not so fast, because I tried to avoid having to
+   make a forest and merge trees.
 
    For the SSSP algorithm Dijkstra's seems to be a nice choice. Currently a
    simple breadth-first search is presented here.
@@ -196,7 +196,6 @@ static void sssp_bfs(void) {
 				update_node_udp(e->to, &e->address);
 			}
 
-			subnet_cache_clear_node(e->to);
 
 			list_insert_tail(todo_list, e->to);
 		}
@@ -280,7 +279,6 @@ static void check_reachability(void) {
 			free(port);
 			environment_exit(&env);
 
-			subnet_cache_clear_node(n);
 			subnet_update(n, NULL, n->status.reachable);
 
 			if(!n->status.reachable) {

--- a/src/hash.h
+++ b/src/hash.h
@@ -30,6 +30,7 @@ uint32_t modulo(uint32_t hash, size_t n);
 #define hash_insert(t, ...) hash_insert_ ## t (__VA_ARGS__)
 #define hash_delete(t, ...) hash_delete_ ## t (__VA_ARGS__)
 #define hash_search(t, ...) hash_search_ ## t (__VA_ARGS__)
+#define hash_search_idx(t, ...) hash_search_ ## t (__VA_ARGS__)
 #define hash_clear(t, n) hash_clear_ ## t ((n))
 
 #define hash_define(t, n) \
@@ -54,15 +55,20 @@ uint32_t modulo(uint32_t hash, size_t n);
 		memcpy(&hash->keys[i], key, sizeof(t)); \
 		hash->values[i] = value; \
 	} \
-	void *hash_search_ ## t (const hash_ ##t *hash, const t *key) { \
+	int hash_search_ ## t ## _idx (const hash_ ##t *hash, const t *key) { \
 		uint32_t i = hash_modulo_ ## t(hash_function_ ## t(key)); \
 		for(uint8_t f=0; f<HASH_SEARCH_ITERATIONS; f++){ \
 			if(!memcmp(key, &hash->keys[i], sizeof(t))) { \
-				return (void *)hash->values[i]; \
+				return i; \
 			} \
 			if(++i == n) i = 0; \
 		} \
-		return NULL; \
+		return -1; \
+	} \
+	void *hash_search_ ## t (const hash_ ##t *hash, const t *key) { \
+		uint32_t idx= hash_search_ ## t ## _idx(hash, key); \
+		if(idx < 0) return NULL; \
+		return (void*)hash->values[idx]; \
 	} \
 	void hash_delete_ ## t (hash_ ##t *hash, const t *key) { \
 		uint32_t i = hash_modulo_ ## t(hash_function_ ## t(key)); \

--- a/src/hash.h
+++ b/src/hash.h
@@ -30,7 +30,7 @@ uint32_t modulo(uint32_t hash, size_t n);
 #define hash_insert(t, ...) hash_insert_ ## t (__VA_ARGS__)
 #define hash_delete(t, ...) hash_delete_ ## t (__VA_ARGS__)
 #define hash_search(t, ...) hash_search_ ## t (__VA_ARGS__)
-#define hash_search_idx(t, ...) hash_search_ ## t (__VA_ARGS__)
+#define hash_search_idx (t, ...) hash_search_ ## t (__VA_ARGS__)
 #define hash_clear(t, n) hash_clear_ ## t ((n))
 
 #define hash_define(t, n) \

--- a/src/subnet.c
+++ b/src/subnet.c
@@ -319,6 +319,12 @@ subnet_t *lookup_subnet_ipv6(const ipv6_t *address) {
 	return r;
 }
 
+void subnet_cache_clear_node(node_t *owner) {
+	for splay_each(subnet_t, subnet, &owner->subnet_tree) {
+		subnet_cache_flush(subnet);
+	}
+}
+
 void subnet_update(node_t *owner, subnet_t *subnet, bool up) {
 	char netstr[MAXNETSTR];
 	char *name, *address, *port;

--- a/src/subnet.h
+++ b/src/subnet.h
@@ -87,5 +87,6 @@ extern subnet_t *lookup_subnet_ipv6(const ipv6_t *address);
 extern bool dump_subnets(struct connection_t *c);
 extern void subnet_cache_flush_tables(void);
 extern void subnet_cache_flush_table(subnet_type_t ipver);
+void subnet_cache_clear_node(node_t *owner);
 
 #endif


### PR DESCRIPTION
I wrote this, seemed like it would be a good idea. Thought I would add weight checks next, but I seem to have got my head in a loop in this graph code.

So I'm taking a break grom the graph code.

Effectively the goal would be to only clear from the hash cache if the incoming subnets have a lower weight than the currently cached item

This current version over clears, it doesnt do weight comparisons.