### PR TITLE
CI: fix archive name for sanitizer results.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Upload test results
         uses: actions/upload-artifact@v2
         with:
-          name: tests_${{ env.ARTIFACT }}
+          name: tests_sanitizer_${{ matrix.sanitizer }}
           path: /tmp/logs/tests.*.tar.gz
         if: always()
 


### PR DESCRIPTION
#333 

All sanitizer jobs were writing to the same name and overwriting each other.

---

Success:

https://github.com/hg/tinc/actions/runs/1157587095

---

The same fix with xoshiro changes applied on top:

https://github.com/hg/tinc/actions/runs/1157593127

UBSAN results (or see the link above):

https://github.com/hg/tinc/suites/3566773997/artifacts/85630898
