### PR TITLE
Fix `make distcheck`

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -6,8 +6,8 @@ deps_linux_alpine() {
   apk upgrade
 
   apk add \
-    git binutils make autoconf automake gcc linux-headers diffutils texinfo \
-    procps socat shadow sudo libgcrypt-dev \
+    git binutils make autoconf automake gcc linux-headers diffutils \
+    procps socat shadow sudo libgcrypt-dev texinfo texlive gzip \
     openssl-dev zlib-dev lzo-dev ncurses-dev readline-dev musl-dev lz4-dev vde2-dev
 }
 
@@ -24,7 +24,7 @@ deps_linux_debian() {
   apt-get upgrade -y
 
   apt-get install -y \
-    git binutils make autoconf automake gcc diffutils sudo texinfo netcat-openbsd procps socat \
+    git binutils make autoconf automake gcc diffutils sudo texinfo texlive netcat-openbsd procps socat \
     zlib1g-dev:"$HOST" \
     libssl-dev:"$HOST" \
     liblzo2-dev:"$HOST" \
@@ -54,7 +54,7 @@ deps_linux_rhel() {
   yum upgrade -y
 
   yum install -y \
-    git binutils make autoconf automake gcc diffutils sudo texinfo netcat procps systemd \
+    git binutils make autoconf automake gcc diffutils sudo texinfo-tex netcat procps systemd \
     findutils socat lzo-devel zlib-devel lz4-devel ncurses-devel readline-devel libgcrypt-devel "$@"
 
   if yum info openssl11-devel; then

--- a/.ci/sanitizers/ignore.txt
+++ b/.ci/sanitizers/ignore.txt
@@ -1,3 +1,9 @@
+# plain make
 src:ed25519/*
 src:chacha-poly1305/*
 src:xoshiro.c
+
+# make distcheck
+src:../../../src/ed25519/*
+src:../../../src/chacha-poly1305/*
+src:../../../src/xoshiro.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,12 @@ README: configure-version README.md
 
 CLEANFILES = README
 
+# If we're running on a CI server, we may not be able to remove some test
+# artifacts without using sudo because they are created by tincd running
+# with root privileges.
+clean-local:
+	if test -n "${CI}"; then sudo rm -rf test/*.test.*/; fi
+
 ChangeLog:
 	(cd $(srcdir) && git log) > ChangeLog
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -244,22 +244,22 @@ sptps_speed_SOURCES += \
 else
 if GCRYPT
 tincd_SOURCES += \
-	gcrypt/cipher.c \
+	gcrypt/cipher.c gcrypt/cipher.h \
 	gcrypt/crypto.c \
 	gcrypt/digest.c gcrypt/digest.h \
 	gcrypt/pem.c gcrypt/pem.h \
 	gcrypt/prf.c \
-	gcrypt/rsa.c
+	gcrypt/rsa.c gcrypt/rsa.h
 tinc_SOURCES += \
-	gcrypt/cipher.c \
+	gcrypt/cipher.c gcrypt/cipher.h \
 	gcrypt/crypto.c \
 	gcrypt/digest.c gcrypt/digest.h \
 	gcrypt/pem.c gcrypt/pem.h \
 	gcrypt/prf.c \
-	gcrypt/rsa.c \
+	gcrypt/rsa.c gcrypt/rsa.h \
 	gcrypt/rsagen.c
 sptps_test_SOURCES += \
-	gcrypt/cipher.c \
+	gcrypt/cipher.c gcrypt/cipher.h \
 	gcrypt/crypto.c \
 	gcrypt/digest.c gcrypt/digest.h \
 	gcrypt/prf.c

--- a/src/bsd/device.c
+++ b/src/bsd/device.c
@@ -28,7 +28,7 @@
 #include "../xalloc.h"
 
 #ifdef ENABLE_TUNEMU
-#include "bsd/tunemu.h"
+#include "tunemu.h"
 #endif
 
 #ifdef HAVE_NET_IF_UTUN_H

--- a/src/openssl/rsagen.c
+++ b/src/openssl/rsagen.c
@@ -17,7 +17,7 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include "system.h"
+#include "../system.h"
 
 #include <openssl/pem.h>
 #include <openssl/err.h>

--- a/src/tincd.c
+++ b/src/tincd.c
@@ -143,7 +143,7 @@ static void usage(bool status) {
 		        "\n"
 		        "Report bugs to tinc@tinc-vpn.org.\n";
 
-		fprintf(stderr, message, program_name);
+		printf(message, program_name);
 	}
 }
 


### PR DESCRIPTION
Here's what automake is doing:

```
bad=0; pid=$$; list="tincd tinc"; for p in $list; do \
  case '  ' in \
   *" $p "* | *" ../../../src/$p "*) continue;; \
  esac; \
  f=`echo "$p" | \
     sed 's,^.*/,,;s/$//;s,x,x,;s/$//'`; \
  for opt in --help --version; do \
    if "/home/neko/src/pub/tinc/tinc-1.1pre18-116-ge856b04f/_inst/sbin/$f" $opt >c${pid}_.out \
         2>c${pid}_.err </dev/null \
	&& test -n "`cat c${pid}_.out`" \
	&& test -z "`cat c${pid}_.err`"; then :; \
    else echo "$f does not support $opt" 1>&2; bad=1; fi; \
  done; \
done; rm -f c${pid}_.???; exit $bad
tincd does not support --help
make[2]: *** [Makefile:807: installcheck-sbinPROGRAMS] Error 1
make[2]: Leaving directory '/home/neko/src/pub/tinc/tinc-1.1pre18-116-ge856b04f/_build/sub/src'
make[1]: *** [Makefile:392: installcheck-recursive] Error 1
make[1]: Leaving directory '/home/neko/src/pub/tinc/tinc-1.1pre18-116-ge856b04f/_build/sub'
make: *** [Makefile:609: distcheck] Error 1
```

Since 28b7a53b6 tincd is printing its usage information to `stderr`, and automake scripts are not happy about this.

This reverts to previous behavior. Or we can disable this check for tincd by using [this](https://www.gnu.org/software/automake/manual/html_node/List-of-Automake-options.html#index-Options_002c-std_002doptions) (tinc should still work fine).

---

I also added `distcheck` to CI so this won't happen again (Linux only, because installing a full TeX suite in other jobs takes a lot of time).