### PR TITLE
Silence remaining 'bugprone-narrowing-conversions'

### DIFF
--- a/.ci/tidy/run.sh
+++ b/.ci/tidy/run.sh
@@ -27,6 +27,7 @@ for path in $paths; do
 done
 
 if ! [ -f compile_commands.json ]; then
+  make clean
   compiledb make all extra
 fi
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -34,22 +34,25 @@
 #define OPTION_CLAMP_MSS        0x0008
 #define OPTION_VERSION(x) ((x) >> 24) /* Top 8 bits are for protocol minor version */
 
-typedef struct connection_status_t {
-	uint32_t pinged: 1;                 /* sent ping */
-	uint32_t unused_active: 1;
-	uint32_t connecting: 1;             /* 1 if we are waiting for a non-blocking connect() to finish */
-	uint32_t unused_termreq: 1;         /* the termination of this connection was requested */
-	uint32_t remove_unused: 1;          /* Set to 1 if you want this connection removed */
-	uint32_t timeout_unused: 1;         /* 1 if gotten timeout */
-	uint32_t encryptout: 1;             /* 1 if we can encrypt outgoing traffic */
-	uint32_t decryptin: 1;              /* 1 if we have to decrypt incoming traffic */
-	uint32_t mst: 1;                    /* 1 if this connection is part of a minimum spanning tree */
-	uint32_t control: 1;                /* 1 if this is a control connection */
-	uint32_t pcap: 1;                   /* 1 if this is a control connection requesting packet capture */
-	uint32_t log: 1;                    /* 1 if this is a control connection requesting log dump */
-	uint32_t invitation: 1;             /* 1 if this is an invitation */
-	uint32_t invitation_used: 1;        /* 1 if the invitation has been consumed */
-	uint32_t tarpit: 1;                 /* 1 if the connection should be added to the tarpit */
+typedef union connection_status_t {
+	struct {
+		bool pinged: 1;                 /* sent ping */
+		bool unused_active: 1;
+		bool connecting: 1;             /* 1 if we are waiting for a non-blocking connect() to finish */
+		bool unused_termreq: 1;         /* the termination of this connection was requested */
+		bool remove_unused: 1;          /* Set to 1 if you want this connection removed */
+		bool timeout_unused: 1;         /* 1 if gotten timeout */
+		bool encryptout: 1;             /* 1 if we can encrypt outgoing traffic */
+		bool decryptin: 1;              /* 1 if we have to decrypt incoming traffic */
+		bool mst: 1;                    /* 1 if this connection is part of a minimum spanning tree */
+		bool control: 1;                /* 1 if this is a control connection */
+		bool pcap: 1;                   /* 1 if this is a control connection requesting packet capture */
+		bool log: 1;                    /* 1 if this is a control connection requesting log dump */
+		bool invitation: 1;             /* 1 if this is an invitation */
+		bool invitation_used: 1;        /* 1 if the invitation has been consumed */
+		bool tarpit: 1;                 /* 1 if the connection should be added to the tarpit */
+	};
+	uint32_t value;
 } connection_status_t;
 
 #include "ecdsa.h"

--- a/src/node.h
+++ b/src/node.h
@@ -28,20 +28,23 @@
 #include "event.h"
 #include "subnet.h"
 
-typedef struct node_status_t {
-	uint32_t unused_active: 1;          /* 1 if active (not used for nodes) */
-	uint32_t validkey: 1;               /* 1 if we currently have a valid key for him */
-	uint32_t waitingforkey: 1;          /* 1 if we already sent out a request */
-	uint32_t visited: 1;                /* 1 if this node has been visited by one of the graph algorithms */
-	uint32_t reachable: 1;              /* 1 if this node is reachable in the graph */
-	uint32_t indirect: 1;               /* 1 if this node is not directly reachable by us */
-	uint32_t sptps: 1;                  /* 1 if this node supports SPTPS */
-	uint32_t udp_confirmed: 1;          /* 1 if the address is one that we received UDP traffic on */
-	uint32_t send_locally: 1;           /* 1 if the next UDP packet should be sent on the local network */
-	uint32_t udppacket: 1;              /* 1 if the most recently received packet was UDP */
-	uint32_t validkey_in: 1;            /* 1 if we have sent a valid key to him */
-	uint32_t has_address: 1;            /* 1 if we know an external address for this node */
-	uint32_t ping_sent: 1;              /* 1 if we sent a UDP probe but haven't received the reply yet */
+typedef union node_status_t {
+	struct {
+		bool unused_active: 1;          /* 1 if active (not used for nodes) */
+		bool validkey: 1;               /* 1 if we currently have a valid key for him */
+		bool waitingforkey: 1;          /* 1 if we already sent out a request */
+		bool visited: 1;                /* 1 if this node has been visited by one of the graph algorithms */
+		bool reachable: 1;              /* 1 if this node is reachable in the graph */
+		bool indirect: 1;               /* 1 if this node is not directly reachable by us */
+		bool sptps: 1;                  /* 1 if this node supports SPTPS */
+		bool udp_confirmed: 1;          /* 1 if the address is one that we received UDP traffic on */
+		bool send_locally: 1;           /* 1 if the next UDP packet should be sent on the local network */
+		bool udppacket: 1;              /* 1 if the most recently received packet was UDP */
+		bool validkey_in: 1;            /* 1 if we have sent a valid key to him */
+		bool has_address: 1;            /* 1 if we know an external address for this node */
+		bool ping_sent: 1;              /* 1 if we sent a UDP probe but haven't received the reply yet */
+	};
+	uint32_t value;
 } node_status_t;
 
 typedef struct node_t {


### PR DESCRIPTION
It's not the most important thing in the world, but it's probably best to fix these warnings instead of turning off the check completely.

Note that it only shows up with `clang-tidy` 12 or newer.

Are you fine with JavaScript-ish casts `!!` or should I replace them with proper `(bool)foobar`?
