### PR TITLE
Add support for OpenSSL 3.0+

### DIFF
--- a/.ci/test/run.sh
+++ b/.ci/test/run.sh
@@ -86,6 +86,13 @@ nolegacy)
 gcrypt)
   run_tests gcrypt --with-libgcrypt
   ;;
+openssl3)
+  if [ -d /opt/ssl3 ]; then
+    run_tests openssl3 --with-openssl=/opt/ssl3 --with-openssl-include=/opt/ssl3/include --with-openssl-lib=/opt/ssl3/lib64
+  else
+    echo >&2 "OpenSSL 3 not installed, skipping test"
+  fi
+  ;;
 *)
   bail "unknown test flavor $1"
   ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
 
   static-analysis:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
@@ -115,7 +115,7 @@ jobs:
 
   sanitizer:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -133,6 +133,9 @@ jobs:
       - name: Install deps
         run: sudo sh .ci/deps.sh
 
+      - name: Run tests with OpenSSL 3
+        run: bash .ci/sanitizers/run.sh openssl3
+
       - name: Sanitize tests with default settings
         run: bash .ci/sanitizers/run.sh default
 
@@ -149,7 +152,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -180,6 +183,9 @@ jobs:
 
       - name: Create a non-privileged user
         run: sh .ci/test/prepare.sh
+
+      - name: Run tests with OpenSSL 3
+        run: sudo -u build CI=1 sh .ci/test/run.sh openssl3
 
       - name: Run tests with default settings
         run: sudo -u build CI=1 sh .ci/test/run.sh default

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -223,24 +223,28 @@ tincd_SOURCES += \
 	openssl/crypto.c \
 	openssl/digest.c openssl/digest.h \
 	openssl/prf.c \
-	openssl/rsa.c
+	openssl/rsa.c \
+	openssl/log.c openssl/log.h
 tinc_SOURCES += \
 	openssl/cipher.c openssl/cipher.h \
 	openssl/crypto.c \
 	openssl/digest.c openssl/digest.h \
 	openssl/prf.c \
 	openssl/rsa.c \
-	openssl/rsagen.c
+	openssl/rsagen.c \
+	openssl/log.c openssl/log.h
 sptps_test_SOURCES += \
 	openssl/crypto.c \
 	openssl/digest.c openssl/digest.h \
-	openssl/prf.c
+	openssl/prf.c \
+	openssl/log.c openssl/log.h
 sptps_keypair_SOURCES += \
 	openssl/crypto.c
 sptps_speed_SOURCES += \
 	openssl/crypto.c \
 	openssl/digest.c openssl/digest.h \
-	openssl/prf.c
+	openssl/prf.c \
+	openssl/log.c openssl/log.h
 else
 if GCRYPT
 tincd_SOURCES += \

--- a/src/openssl/cipher.c
+++ b/src/openssl/cipher.c
@@ -19,10 +19,10 @@
 
 #include "../system.h"
 
-#include <openssl/rand.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
 
+#include "log.h"
 #include "cipher.h"
 #include "../cipher.h"
 #include "../logger.h"
@@ -120,7 +120,7 @@ bool cipher_set_key(cipher_t *cipher, void *key, bool encrypt) {
 		return true;
 	}
 
-	logger(DEBUG_ALWAYS, LOG_ERR, "Error while setting key: %s", ERR_error_string(ERR_get_error(), NULL));
+	openssl_err("set key");
 	return false;
 }
 
@@ -137,7 +137,7 @@ bool cipher_set_key_from_rsa(cipher_t *cipher, void *key, size_t len, bool encry
 		return true;
 	}
 
-	logger(DEBUG_ALWAYS, LOG_ERR, "Error while setting key: %s", ERR_error_string(ERR_get_error(), NULL));
+	openssl_err("set key");
 	return false;
 }
 
@@ -166,7 +166,7 @@ bool cipher_encrypt(cipher_t *cipher, const void *indata, size_t inlen, void *ou
 		}
 	}
 
-	logger(DEBUG_ALWAYS, LOG_ERR, "Error while encrypting: %s", ERR_error_string(ERR_get_error(), NULL));
+	openssl_err("encrypt data");
 	return false;
 }
 
@@ -195,7 +195,7 @@ bool cipher_decrypt(cipher_t *cipher, const void *indata, size_t inlen, void *ou
 		}
 	}
 
-	logger(DEBUG_ALWAYS, LOG_ERR, "Error while decrypting: %s", ERR_error_string(ERR_get_error(), NULL));
+	openssl_err("decrypt data");
 	return false;
 }
 

--- a/src/openssl/crypto.c
+++ b/src/openssl/crypto.c
@@ -93,7 +93,9 @@ void randomize(void *out, size_t outlen) {
 void crypto_init(void) {
 	random_init();
 
+#if OPENSSL_VERSION_MAJOR < 3
 	ENGINE_load_builtin_engines();
+#endif
 
 	if(!RAND_status()) {
 		fprintf(stderr, "Not enough entropy for the PRNG!\n");

--- a/src/openssl/digest.h
+++ b/src/openssl/digest.h
@@ -25,7 +25,11 @@
 
 struct digest {
 	const EVP_MD *digest;
+#if OPENSSL_VERSION_MAJOR < 3
 	HMAC_CTX *hmac_ctx;
+#else
+	EVP_MAC_CTX *hmac_ctx;
+#endif
 	EVP_MD_CTX *md_ctx;
 	size_t maclength;
 };

--- a/src/openssl/log.c
+++ b/src/openssl/log.c
@@ -1,0 +1,8 @@
+#include <openssl/err.h>
+#include "log.h"
+#include "../logger.h"
+
+void openssl_err(const char *msg) {
+	const char *err = ERR_error_string(ERR_peek_last_error(), NULL);
+	logger(DEBUG_ALWAYS, LOG_ERR, "OpenSSL error: unable to %s: %s", msg, err);
+}

--- a/src/openssl/log.h
+++ b/src/openssl/log.h
@@ -1,0 +1,6 @@
+#ifndef OPENSSL_LOG_H
+#define OPENSSL_LOG_H
+
+extern void openssl_err(const char *msg);
+
+#endif // OPENSSL_LOG_H

--- a/src/openssl/rsa.c
+++ b/src/openssl/rsa.c
@@ -20,112 +20,253 @@
 #include "../system.h"
 
 #include <openssl/pem.h>
-#include <openssl/err.h>
 #include <openssl/rsa.h>
 
 #define TINC_RSA_INTERNAL
-typedef RSA rsa_t;
 
+#if OPENSSL_VERSION_MAJOR < 3
+typedef RSA rsa_t;
+#else
+#include <openssl/encoder.h>
+#include <openssl/decoder.h>
+#include <openssl/core_names.h>
+#include <openssl/param_build.h>
+#include <assert.h>
+
+typedef EVP_PKEY rsa_t;
+#endif
+
+#include "log.h"
 #include "../logger.h"
 #include "../rsa.h"
 
 // Set RSA keys
 
-rsa_t *rsa_set_hex_public_key(const char *n, const char *e) {
-	BIGNUM *bn_n = NULL;
-	BIGNUM *bn_e = NULL;
+#if OPENSSL_VERSION_MAJOR >= 3
+static EVP_PKEY *build_rsa_key(int selection, const BIGNUM *bn_n, const BIGNUM *bn_e, const BIGNUM *bn_d) {
+	assert(bn_n);
+	assert(bn_e);
 
-	if((size_t)BN_hex2bn(&bn_n, n) != strlen(n) || (size_t)BN_hex2bn(&bn_e, e) != strlen(e)) {
-		BN_free(bn_e);
-		BN_free(bn_n);
-		return false;
-	}
+	EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
 
-	rsa_t *rsa = RSA_new();
-
-	if(!rsa) {
+	if(!ctx) {
+		openssl_err("initialize key context");
 		return NULL;
 	}
 
-	RSA_set0_key(rsa, bn_n, bn_e, NULL);
+	OSSL_PARAM_BLD *bld = OSSL_PARAM_BLD_new();
+	OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_N, bn_n);
+	OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_E, bn_e);
 
-	return rsa;
+	if(bn_d) {
+		OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_D, bn_d);
+	}
+
+	OSSL_PARAM *params = OSSL_PARAM_BLD_to_param(bld);
+	EVP_PKEY *key = NULL;
+
+	bool ok = EVP_PKEY_fromdata_init(ctx) > 0
+	          && EVP_PKEY_fromdata(ctx, &key, selection, params) > 0;
+
+	OSSL_PARAM_free(params);
+	OSSL_PARAM_BLD_free(bld);
+	EVP_PKEY_CTX_free(ctx);
+
+	if(ok) {
+		return key;
+	}
+
+	openssl_err("build key");
+	return NULL;
+}
+#endif
+
+static bool hex_to_bn(BIGNUM **bn, const char *hex) {
+	return (size_t)BN_hex2bn(bn, hex) == strlen(hex);
 }
 
-rsa_t *rsa_set_hex_private_key(const char *n, const char *e, const char *d) {
+static rsa_t *rsa_set_hex_key(const char *n, const char *e, const char *d) {
+	rsa_t *rsa = NULL;
 	BIGNUM *bn_n = NULL;
 	BIGNUM *bn_e = NULL;
 	BIGNUM *bn_d = NULL;
 
-	if((size_t)BN_hex2bn(&bn_n, n) != strlen(n) || (size_t)BN_hex2bn(&bn_e, e) != strlen(e) || (size_t)BN_hex2bn(&bn_d, d) != strlen(d)) {
+	if(!hex_to_bn(&bn_n, n) || !hex_to_bn(&bn_e, e) || (d && !hex_to_bn(&bn_d, d))) {
+		goto exit;
+	}
+
+#if OPENSSL_VERSION_MAJOR < 3
+	rsa = RSA_new();
+
+	if(rsa) {
+		RSA_set0_key(rsa, bn_n, bn_e, bn_d);
+	}
+
+#else
+	int selection = bn_d ? EVP_PKEY_KEYPAIR : EVP_PKEY_PUBLIC_KEY;
+	rsa = build_rsa_key(selection, bn_n, bn_e, bn_d);
+#endif
+
+exit:
+#if OPENSSL_VERSION_MAJOR < 3
+
+	if(!rsa)
+#endif
+	{
 		BN_free(bn_d);
 		BN_free(bn_e);
 		BN_free(bn_n);
-		return false;
 	}
-
-	rsa_t *rsa = RSA_new();
-
-	if(!rsa) {
-		return NULL;
-	}
-
-	RSA_set0_key(rsa, bn_n, bn_e, bn_d);
 
 	return rsa;
 }
 
+rsa_t *rsa_set_hex_public_key(const char *n, const char *e) {
+	return rsa_set_hex_key(n, e, NULL);
+}
+
+rsa_t *rsa_set_hex_private_key(const char *n, const char *e, const char *d) {
+	return rsa_set_hex_key(n, e, d);
+}
+
 // Read PEM RSA keys
 
+#if OPENSSL_VERSION_MAJOR >= 3
+static rsa_t *read_key_from_pem(FILE *fp, int selection) {
+	rsa_t *rsa = NULL;
+	OSSL_DECODER_CTX *ctx = OSSL_DECODER_CTX_new_for_pkey(&rsa, "PEM", NULL, "RSA", selection, NULL, NULL);
+
+	if(!ctx) {
+		openssl_err("initialize decoder");
+		return NULL;
+	}
+
+	bool ok = OSSL_DECODER_from_fp(ctx, fp);
+	OSSL_DECODER_CTX_free(ctx);
+
+	if(!ok) {
+		rsa = NULL;
+		openssl_err("read RSA key from file");
+	}
+
+	return rsa;
+}
+#endif
+
 rsa_t *rsa_read_pem_public_key(FILE *fp) {
-	rsa_t *rsa = PEM_read_RSAPublicKey(fp, NULL, NULL, NULL);
+	rsa_t *rsa;
+
+#if OPENSSL_VERSION_MAJOR < 3
+	rsa = PEM_read_RSAPublicKey(fp, NULL, NULL, NULL);
 
 	if(!rsa) {
 		rewind(fp);
 		rsa = PEM_read_RSA_PUBKEY(fp, NULL, NULL, NULL);
 	}
 
+#else
+	rsa = read_key_from_pem(fp, OSSL_KEYMGMT_SELECT_PUBLIC_KEY);
+#endif
+
 	if(!rsa) {
-		logger(DEBUG_ALWAYS, LOG_ERR, "Unable to read RSA public key: %s", ERR_error_string(ERR_get_error(), NULL));
+		openssl_err("read RSA public key");
 	}
 
 	return rsa;
 }
 
 rsa_t *rsa_read_pem_private_key(FILE *fp) {
-	rsa_t *rsa = PEM_read_RSAPrivateKey(fp, NULL, NULL, NULL);
+	rsa_t *rsa;
+
+#if OPENSSL_VERSION_MAJOR < 3
+	rsa = PEM_read_RSAPrivateKey(fp, NULL, NULL, NULL);
+#else
+	rsa = read_key_from_pem(fp, OSSL_KEYMGMT_SELECT_PRIVATE_KEY);
+#endif
 
 	if(!rsa) {
-		logger(DEBUG_ALWAYS, LOG_ERR, "Unable to read RSA private key: %s", ERR_error_string(ERR_get_error(), NULL));
+		openssl_err("read RSA private key");
 	}
 
 	return rsa;
 }
 
 size_t rsa_size(const rsa_t *rsa) {
+#if OPENSSL_VERSION_MAJOR < 3
 	return RSA_size(rsa);
+#else
+	return EVP_PKEY_get_size(rsa);
+#endif
 }
 
 bool rsa_public_encrypt(rsa_t *rsa, const void *in, size_t len, void *out) {
+#if OPENSSL_VERSION_MAJOR < 3
+
 	if((size_t)RSA_public_encrypt((int) len, in, out, rsa, RSA_NO_PADDING) == len) {
 		return true;
 	}
 
-	logger(DEBUG_ALWAYS, LOG_ERR, "Unable to perform RSA encryption: %s", ERR_error_string(ERR_get_error(), NULL));
+#else
+	EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(rsa, NULL);
+
+	if(ctx) {
+		size_t outlen = len;
+
+		bool ok = EVP_PKEY_encrypt_init(ctx) > 0
+		          && EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_NO_PADDING) > 0
+		          && EVP_PKEY_encrypt(ctx, out, &outlen, in, len) > 0
+		          && outlen == len;
+
+		EVP_PKEY_CTX_free(ctx);
+
+		if(ok) {
+			return true;
+		}
+	}
+
+#endif
+
+	openssl_err("perform RSA encryption");
 	return false;
 }
 
 bool rsa_private_decrypt(rsa_t *rsa, const void *in, size_t len, void *out) {
+#if OPENSSL_VERSION_MAJOR < 3
+
 	if((size_t)RSA_private_decrypt((int) len, in, out, rsa, RSA_NO_PADDING) == len) {
 		return true;
 	}
 
-	logger(DEBUG_ALWAYS, LOG_ERR, "Unable to perform RSA decryption: %s", ERR_error_string(ERR_get_error(), NULL));
+#else
+	EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(rsa, NULL);
+
+	if(ctx) {
+		size_t outlen = len;
+
+		bool ok = EVP_PKEY_decrypt_init(ctx) > 0
+		          && EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_NO_PADDING) > 0
+		          && EVP_PKEY_decrypt(ctx, out, &outlen, in, len) > 0
+		          && outlen == len;
+
+		EVP_PKEY_CTX_free(ctx);
+
+		if(ok) {
+			return true;
+		}
+	}
+
+#endif
+
+	openssl_err("perform RSA decryption");
 	return false;
 }
 
 void rsa_free(rsa_t *rsa) {
 	if(rsa) {
+#if OPENSSL_VERSION_MAJOR < 3
 		RSA_free(rsa);
+#else
+		EVP_PKEY_free(rsa);
+#endif
 	}
 }

--- a/src/openssl/rsagen.c
+++ b/src/openssl/rsagen.c
@@ -23,11 +23,20 @@
 #include <openssl/err.h>
 
 #define TINC_RSA_INTERNAL
+
+#if OPENSSL_VERSION_MAJOR < 3
 typedef RSA rsa_t;
+#else
+typedef EVP_PKEY rsa_t;
+#include <openssl/encoder.h>
+#include <openssl/evp.h>
+#endif
 
 #include "../logger.h"
 #include "../rsagen.h"
+#include "log.h"
 
+#if OPENSSL_VERSION_MAJOR < 3
 /* This function prettyprints the key generation process */
 
 static int indicator(int a, int b, BN_GENCB *cb) {
@@ -68,41 +77,99 @@ static int indicator(int a, int b, BN_GENCB *cb) {
 
 	return 1;
 }
+#endif
 
 // Generate RSA key
 
 rsa_t *rsa_generate(size_t bits, unsigned long exponent) {
 	BIGNUM *bn_e = BN_new();
-	rsa_t *rsa = RSA_new();
-	BN_GENCB *cb = BN_GENCB_new();
+	rsa_t *rsa = NULL;
 
-	if(!bn_e || !rsa || !cb) {
+	if(!bn_e) {
 		abort();
 	}
 
 	BN_set_word(bn_e, exponent);
+
+#if OPENSSL_VERSION_MAJOR < 3
+	rsa = RSA_new();
+	BN_GENCB *cb = BN_GENCB_new();
+
+	if(!rsa || !cb) {
+		abort();
+	}
+
 	BN_GENCB_set(cb, indicator, NULL);
 
 	int result = RSA_generate_key_ex(rsa, (int) bits, bn_e, cb);
 
 	BN_GENCB_free(cb);
-	BN_free(bn_e);
 
 	if(!result) {
 		fprintf(stderr, "Error during key generation!\n");
 		RSA_free(rsa);
-		return NULL;
+		rsa = NULL;
 	}
+
+#else
+	EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+
+	bool ok = ctx
+	          && EVP_PKEY_keygen_init(ctx) > 0
+	          && EVP_PKEY_CTX_set1_rsa_keygen_pubexp(ctx, bn_e) > 0
+	          && EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, (int)bits) > 0
+	          && EVP_PKEY_keygen(ctx, &rsa) > 0;
+
+	if(ctx) {
+		EVP_PKEY_CTX_free(ctx);
+	}
+
+	if(!ok) {
+		openssl_err("generate key");
+		rsa = NULL;
+	}
+
+#endif
+
+	BN_free(bn_e);
 
 	return rsa;
 }
 
 // Write PEM RSA keys
 
+#if OPENSSL_VERSION_MAJOR >= 3
+static bool write_key_to_pem(const rsa_t *rsa, FILE *fp, int selection) {
+	OSSL_ENCODER_CTX *enc = OSSL_ENCODER_CTX_new_for_pkey(rsa, selection, "PEM", NULL, NULL);
+
+	if(!enc) {
+		openssl_err("create encoder context");
+		return false;
+	}
+
+	bool ok = OSSL_ENCODER_to_fp(enc, fp);
+	OSSL_ENCODER_CTX_free(enc);
+
+	if(!ok) {
+		openssl_err("write key to file");
+	}
+
+	return ok;
+}
+#endif
+
 bool rsa_write_pem_public_key(rsa_t *rsa, FILE *fp) {
+#if OPENSSL_VERSION_MAJOR < 3
 	return PEM_write_RSAPublicKey(fp, rsa);
+#else
+	return write_key_to_pem(rsa, fp, OSSL_KEYMGMT_SELECT_PUBLIC_KEY);
+#endif
 }
 
 bool rsa_write_pem_private_key(rsa_t *rsa, FILE *fp) {
+#if OPENSSL_VERSION_MAJOR < 3
 	return PEM_write_RSAPrivateKey(fp, rsa, NULL, NULL, 0, NULL, NULL);
+#else
+	return write_key_to_pem(rsa, fp, OSSL_KEYMGMT_SELECT_PRIVATE_KEY);
+#endif
 }


### PR DESCRIPTION
This is an attempt to close #347.

Since this touches cryptography you might prefer to do the work yourself. I'm okay with that; this PR could be used as a starting point.

I tested it on one of the nodes in my 20-something node network. Seems to work fine.

Here's the official [migration guide](https://www.openssl.org/docs/man3.0/man7/migration_guide.html). It's not of much help, the information on how to use the new APIs has to be picked piecemeal in OpenSSL sources, manpages, and examples.
