### PR TITLE
Restore Solaris support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,10 @@ os_name = host_machine.system()
 cc_name = cc.get_id()
 
 cc_defs = ['-D_GNU_SOURCE']
+if os_name == 'sunos'
+  cc_defs += '-D__EXTENSIONS__'
+endif
+
 cc_flags = [cc_defs]
 ld_flags = []
 

--- a/src/fd_device.c
+++ b/src/fd_device.c
@@ -22,7 +22,6 @@
 
 #include "system.h"
 
-#ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
 
 #include "conf.h"
@@ -240,4 +239,3 @@ const devops_t fd_devops = {
 	.read = read_packet,
 	.write = write_packet,
 };
-#endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -46,23 +46,31 @@ check_headers = [
   'sys/stat.h',
   'sys/time.h',
   'sys/types.h',
-  'sys/un.h',
   'sys/wait.h',
   'syslog.h',
   'termios.h',
 ]
 
+# 'struct msghdr' misses some required fields
+if os_name != 'sunos'
+  check_headers += 'sys/un.h'
+endif
+
 check_functions = [
   'asprintf',
   'daemon',
   'fchmod',
-  'fork',
   'gettimeofday',
   'mlockall',
   'putenv',
   'strsignal',
   'unsetenv',
 ]
+
+# Broken definition, fails to link
+if os_name != 'windows'
+  check_functions += 'fork'
+endif
 
 check_types = [
   'struct arphdr',
@@ -115,7 +123,6 @@ src_tincd = [
   'dummy_device.c',
   'edge.c',
   'event.c',
-  'fd_device.c',
   'graph.c',
   'meta.c',
   'multicast_device.c',
@@ -160,6 +167,10 @@ foreach h : check_headers
   endif
 endforeach
 
+if cdata.has('HAVE_SYS_UN_H')
+  src_tincd += 'fd_device.c'
+endif
+
 confdata = configuration_data()
 confdata.merge_from(cdata)
 configure_file(output: 'meson_config.h', configuration: confdata)
@@ -170,14 +181,10 @@ have_prefix = '''
 '''.format(build_root, meson.current_source_dir())
 
 foreach f : check_functions
-  if f == 'fork' and os_name == 'windows'
-    message('MinGW does not have correct definition for fork()')
-  else
-    if cc.has_function(f, prefix: have_prefix, args: cc_defs)
-      cdata.set('HAVE_' + f.to_upper(),
-                1,
-                description: 'function ' + f)
-    endif
+  if cc.has_function(f, prefix: have_prefix, args: cc_defs)
+    cdata.set('HAVE_' + f.to_upper(),
+              1,
+              description: 'function ' + f)
   endif
 endforeach
 

--- a/src/solaris/meson.build
+++ b/src/solaris/meson.build
@@ -1,2 +1,4 @@
 src_tincd += files('device.c')
 
+deps_common += cc.find_library('libsocket')
+

--- a/test/integration/meson.build
+++ b/test/integration/meson.build
@@ -6,7 +6,6 @@ tests = [
   'invite-join.test',
   'invite-offline.test',
   'invite-tinc-up.test',
-  'scripts.test',
   'security.test',
   'variables.test',
 ]
@@ -22,6 +21,10 @@ endif
 
 if os_name == 'linux'
   tests += 'ns-ping.test'
+endif
+
+if os_name != 'sunos'
+  tests += 'scripts.test'
 endif
 
 exe_splice = executable(

--- a/test/integration/testlib.sh
+++ b/test/integration/testlib.sh
@@ -45,6 +45,21 @@ DIR_BAZ=$(realdir "$PWD/$net3")
 
 # Register helper functions
 
+if [ "$(uname -s)" = SunOS ]; then
+  gnu=/usr/gnu/bin
+  grep="$gnu/grep"
+
+  grep() { $gnu/grep "$@"; }
+  tail() { $gnu/tail "$@"; }
+
+  if ! tail /dev/null || ! echo '' | grep ''; then
+    echo >&2 'Sorry, native Solaris tools are not supported. Please install GNU Coreutils.'
+    exit $EXIT_SKIP_TEST
+  fi
+else
+  grep='grep'
+fi
+
 # Alias gtimeout to timeout if it exists.
 if type gtimeout >/dev/null; then
   timeout() { gtimeout "$@"; }
@@ -361,7 +376,7 @@ wait_script() {
 
   new_line=$(
     sh -c "
-      grep -n -m $count '^$script,' <'$fifo'
+      $grep -n -m $count '^$script,' <'$fifo'
     " | awk -F: 'END { print $1 }'
   )
 


### PR DESCRIPTION
`scripts.test` is disabled on Solaris because it reliably produces somewhat different line ordering:

```
$ diff scripts.test.1/scripts.out scripts.test.1/scripts.out.expected
12d11
< bar-started-1
13a13
> bar-started-1
16d15
< bar-stopped
18a18
> bar-stopped
21d20
< bar-started-2
23a23
> bar-started-2
```

It's probably not worth it to spend any time on this. It was fun enough making it work on NetBSD — you adjust a couple of things, tests start passing there and failing everywhere else.

I also don't think it's possible to make tests work on native shell tools. For example, `grep` misses support for an important flag (`-m`) and doesn't provide any alternatives.

Thankfully the [system I'm using][omnios] has GNU coreutils preinstalled.

[omnios]: https://omnios.org/download.html


```
$ uname -a
SunOS omnios 5.11 omnios-r151040-d75907718a i86pc i386 i86pc
```
---

Did a bit of debugging. Looks like `tail` sometimes loses its position within a file when you append to it, and starts from the beginning. This makes `wait_script` completely useless. I haven't seen this behavior anywhere else.