### PR TITLE
Add support for building with MSVC

### DIFF
--- a/.ci/tidy/run.sh
+++ b/.ci/tidy/run.sh
@@ -5,7 +5,7 @@ set -eu
 ./.ci/build.sh "$@"
 
 # Which paths to ignore.
-paths='src/solaris src/mingw src/gcrypt'
+paths='src/solaris src/windows src/gcrypt'
 
 case "$(uname -s)" in
 Linux)

--- a/.ci/windows/build.cmd
+++ b/.ci/windows/build.cmd
@@ -1,0 +1,8 @@
+set crypto=%1
+set builddir=%crypto%
+
+echo configure build directory
+meson setup %builddir% -Dbuildtype=release -Dcrypto=%crypto% || exit 1
+
+echo build project
+meson compile -C %builddir% || exit 1

--- a/.ci/windows/test.cmd
+++ b/.ci/windows/test.cmd
@@ -1,0 +1,24 @@
+set builddir=%1
+set data=%builddir%\test-data
+set tinc=%builddir%\src\tinc
+set tincd=%tinc%d
+
+mkdir %data% || exit 1
+
+echo can tinc run at all?
+%tinc% --version || exit 1
+
+echo try to initialize a node
+%tinc% -c %data% -b init foo || exit 1
+
+echo try to generate EC keys
+%tinc% -c %data% -b generate-ed25519-keys || exit 1
+
+echo can tincd run?
+%tincd% --version || exit 1
+
+echo bail out if we're missing support for the legacy protocol
+%tinc% --version | findstr legacy_protocol || exit 0
+
+echo try to generate RSA keys
+%tinc% -c %data% -b generate-keys || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - linux
-      - windows
+      - mingw
 
     steps:
       - name: Create artifact directory
@@ -272,7 +272,7 @@ jobs:
           path: /tmp/logs/tests.*.tar.gz
         if: always()
 
-  windows:
+  mingw:
     runs-on: windows-latest
     timeout-minutes: 30
 
@@ -331,4 +331,42 @@ jobs:
         with:
           name: tests_windows
           path: /tmp/logs/tests.*.tar.gz
+        if: always()
+
+  msvc:
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - amd64_x86
+
+    steps:
+      - name: Install meson
+        run: pip3 install meson
+
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Activate dev environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: Build (nolegacy)
+        run: .ci\windows\build.cmd nolegacy
+
+      - name: Test (nolegacy)
+        run: .ci\windows\test.cmd nolegacy
+        if: always()
+
+      - name: Build (OpenSSL)
+        run: .ci\windows\build.cmd openssl
+        if: always()
+
+      - name: Test (OpenSSL)
+        run: .ci\windows\test.cmd openssl
         if: always()

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,12 +35,20 @@ Please consult your operating system's documentation for more details.
 
 ## Windows
 
-You will need to install [msys2][msys2] to build tinc under Windows.
+You can build tinc using either the native [Windows SDK][sdk-ms] (which comes with Visual Studio),
+or with the Unix-like [msys2 environment][sdk-msys2]. Install either one of them, plus
+the latest version of [meson][meson-release].
 
-[msys2]: https://msys2.org/
+If you prefer the native SDK, you might want to work on tinc (or build it) under Visual Studio.
+To do so, follow [these instructions][meson-vs].
 
 By default, tinc produces a static Windows build, so you don't need to install anything
 in order to _run_ the compiled binaries.
+
+[sdk-ms]: https://visualstudio.com/
+[sdk-msys2]: https://msys2.org/
+[meson-release]: https://github.com/mesonbuild/meson/releases
+[meson-vs]: https://mesonbuild.com/Using-with-Visual-Studio.html
 
 # Building
 

--- a/doc/tinc.texi
+++ b/doc/tinc.texi
@@ -571,7 +571,7 @@ The documentation that comes along with your distribution will tell you how to d
 
 @menu
 * Darwin (MacOS/X) build environment::
-* MinGW (Windows) build environment::
+* Windows build environment::
 @end menu
 
 
@@ -586,14 +586,16 @@ You need to download and install LibreSSL (or OpenSSL) and LZO,
 either directly from their websites (see @ref{Libraries}) or using Fink.
 
 @c ==================================================================
-@node       MinGW (Windows) build environment
-@subsection MinGW (Windows) build environment
+@node       Windows build environment
+@subsection Windows build environment
 
-You will need to install the MinGW environment from @uref{http://www.mingw.org}.
+You will need to install either the native Windows SDK from @uref{https://visualstudio.com},
+or the MinGW environment from @uref{https://msys2.org}.
+
 You also need to download and install LibreSSL (or OpenSSL) and LZO.
 
-When tinc is compiled using MinGW it runs natively under Windows,
-it is not necessary to keep MinGW installed.
+Whether tinc is compiled using MinGW or the native SDK, it runs natively under Windows,
+so it is not necessary to keep either SDK to run the compiled binaries.
 
 When detaching, tinc will install itself as a service,
 which will be restarted automatically after reboots.

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('tinc', 'c',
-  version: '1.18pre',
+  version: run_command([find_program('python3'), 'version.py', 'short'], check: true).stdout(),
   license: 'GPL-2.0-or-later',
   meson_version: '>=0.51',
   default_options: [
@@ -34,6 +34,13 @@ cc = meson.get_compiler('c')
 os_name = host_machine.system()
 cpu_family = host_machine.cpu_family()
 cc_name = cc.get_id()
+
+python = find_program('python3')
+if meson_version.version_compare('>=0.55')
+  python_path = python.full_path()
+else
+  python_path = python.path()
+endif
 
 cc_defs = ['-D_GNU_SOURCE']
 if os_name == 'sunos'

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('tinc', 'c',
-  version: run_command('./src/git_tag.sh', check: true).stdout().strip(),
+  version: '1.18pre',
   license: 'GPL-2.0-or-later',
   meson_version: '>=0.51',
   default_options: [
@@ -12,6 +12,7 @@ project('tinc', 'c',
 dir_run_state = get_option('runstatedir')
 opt_crypto = get_option('crypto')
 opt_curses = get_option('curses')
+opt_debug = get_option('debug')
 opt_docs = get_option('docs')
 opt_harden = get_option('hardening')
 opt_jumbograms = get_option('jumbograms')
@@ -31,6 +32,7 @@ meson_version = meson.version()
 
 cc = meson.get_compiler('c')
 os_name = host_machine.system()
+cpu_family = host_machine.cpu_family()
 cc_name = cc.get_id()
 
 cc_defs = ['-D_GNU_SOURCE']
@@ -47,33 +49,45 @@ else
   static = opt_static.enabled()
 endif
 
-if static
+if static and cc_name != 'msvc'
   ld_flags += '-static'
 endif
 
 if opt_harden
-  cc_flags += [
-    '-D_FORTIFY_SOURCE=2',
-    '-fwrapv',
-    '-fno-strict-overflow',
-    '-Wreturn-type',
-    '-Wold-style-definition',
-    '-Wmissing-declarations',
-    '-Wmissing-prototypes',
-    '-Wstrict-prototypes',
-    '-Wredundant-decls',
-    '-Wbad-function-cast',
-    '-Wwrite-strings',
-    '-fdiagnostics-show-option',
-    '-fstrict-aliasing',
-    '-Wmissing-noreturn',
-  ]
-  if cc_name == 'clang'
-    cc_flags += '-Qunused-arguments'
-  endif
-  ld_flags += ['-Wl,-z,relro', '-Wl,-z,now']
-  if os_name == 'windows'
-    ld_flags += ['-Wl,--dynamicbase', '-Wl,--nxcompat']
+  if cc_name == 'msvc'
+    # Most of these flags are already ON by default in the latest version of MSVC.
+    # Add anyway in case someone is building using an old toolchain.
+    cc_flags += ['/guard:cf', '/GS']
+    ld_flags += [
+      '/guard:cf',
+      '/NXCOMPAT',
+      '/DYNAMICBASE',
+      cpu_family.endswith('64') ? '/HIGHENTROPYVA' : '/SAFESEH',
+    ]
+  else
+    cc_flags += [
+      '-D_FORTIFY_SOURCE=2',
+      '-fwrapv',
+      '-fno-strict-overflow',
+      '-Wreturn-type',
+      '-Wold-style-definition',
+      '-Wmissing-declarations',
+      '-Wmissing-prototypes',
+      '-Wstrict-prototypes',
+      '-Wredundant-decls',
+      '-Wbad-function-cast',
+      '-Wwrite-strings',
+      '-fdiagnostics-show-option',
+      '-fstrict-aliasing',
+      '-Wmissing-noreturn',
+    ]
+    if cc_name == 'clang'
+      cc_flags += '-Qunused-arguments'
+    endif
+    ld_flags += ['-Wl,-z,relro', '-Wl,-z,now']
+    if os_name == 'windows'
+      ld_flags += ['-Wl,--dynamicbase', '-Wl,--nxcompat']
+    endif
   endif
 endif
 

--- a/src/cipher.h
+++ b/src/cipher.h
@@ -38,7 +38,7 @@
 
 typedef struct cipher cipher_t;
 
-extern cipher_t *cipher_alloc(void) __attribute__((__malloc__));
+extern cipher_t *cipher_alloc(void) ATTR_MALLOC;
 extern void cipher_free(cipher_t **cipher);
 extern bool cipher_open_by_name(cipher_t *cipher, const char *name);
 extern bool cipher_open_by_nid(cipher_t *cipher, int nid);
@@ -46,10 +46,10 @@ extern void cipher_close(cipher_t *cipher);
 extern size_t cipher_keylength(const cipher_t *cipher);
 extern size_t cipher_blocksize(const cipher_t *cipher);
 extern uint64_t cipher_budget(const cipher_t *cipher);
-extern bool cipher_set_key(cipher_t *cipher, void *key, bool encrypt) __attribute__((__warn_unused_result__));
-extern bool cipher_set_key_from_rsa(cipher_t *cipher, void *rsa, size_t len, bool encrypt) __attribute__((__warn_unused_result__));
-extern bool cipher_encrypt(cipher_t *cipher, const void *indata, size_t inlen, void *outdata, size_t *outlen, bool oneshot) __attribute__((__warn_unused_result__));
-extern bool cipher_decrypt(cipher_t *cipher, const void *indata, size_t inlen, void *outdata, size_t *outlen, bool oneshot) __attribute__((__warn_unused_result__));
+extern bool cipher_set_key(cipher_t *cipher, void *key, bool encrypt) ATTR_WARN_UNUSED;
+extern bool cipher_set_key_from_rsa(cipher_t *cipher, void *rsa, size_t len, bool encrypt) ATTR_WARN_UNUSED;
+extern bool cipher_encrypt(cipher_t *cipher, const void *indata, size_t inlen, void *outdata, size_t *outlen, bool oneshot) ATTR_WARN_UNUSED;
+extern bool cipher_decrypt(cipher_t *cipher, const void *indata, size_t inlen, void *outdata, size_t *outlen, bool oneshot) ATTR_WARN_UNUSED;
 extern int cipher_get_nid(const cipher_t *cipher);
 extern bool cipher_active(const cipher_t *cipher);
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -43,7 +43,7 @@ extern list_t cmdline_conf;
 extern splay_tree_t *create_configuration(void);
 extern void init_configuration(splay_tree_t *);
 extern void exit_configuration(splay_tree_t **config_tree);
-extern config_t *new_config(void) __attribute__((__malloc__));
+extern config_t *new_config(void) ATTR_MALLOC;
 extern void free_config(config_t *config);
 extern void config_add(splay_tree_t *config_tree, config_t *config);
 extern config_t *lookup_config(splay_tree_t *config_tree, const char *variable);

--- a/src/connection.h
+++ b/src/connection.h
@@ -114,7 +114,7 @@ extern connection_t *everyone;
 
 extern void init_connections(void);
 extern void exit_connections(void);
-extern connection_t *new_connection(void) __attribute__((__malloc__));
+extern connection_t *new_connection(void) ATTR_MALLOC;
 extern void free_connection(connection_t *c);
 extern void connection_add(connection_t *c);
 extern void connection_del(connection_t *c);

--- a/src/control.c
+++ b/src/control.c
@@ -185,7 +185,7 @@ bool init_control(void) {
 	free(localhost);
 	fclose(f);
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	int unix_fd = socket(AF_UNIX, SOCK_STREAM, 0);
 
 	if(unix_fd < 0) {
@@ -232,7 +232,7 @@ bool init_control(void) {
 }
 
 void exit_control(void) {
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	unlink(unixsocketname);
 	io_del(&unix_socket);
 	close(unix_socket.fd);

--- a/src/digest.h
+++ b/src/digest.h
@@ -39,12 +39,12 @@ typedef struct digest digest_t;
 
 extern bool digest_open_by_name(digest_t *digest, const char *name, size_t maclength);
 extern bool digest_open_by_nid(digest_t *digest, int nid, size_t maclength);
-extern digest_t *digest_alloc(void) __attribute__((__malloc__));
+extern digest_t *digest_alloc(void) ATTR_MALLOC;
 extern void digest_free(digest_t **digest);
 extern void digest_close(digest_t *digest);
-extern bool digest_create(digest_t *digest, const void *indata, size_t inlen, void *outdata) __attribute__((__warn_unused_result__));
-extern bool digest_verify(digest_t *digest, const void *indata, size_t inlen, const void *digestdata) __attribute__((__warn_unused_result__));
-extern bool digest_set_key(digest_t *digest, const void *key, size_t len) __attribute__((__warn_unused_result__));
+extern bool digest_create(digest_t *digest, const void *indata, size_t inlen, void *outdata) ATTR_WARN_UNUSED;
+extern bool digest_verify(digest_t *digest, const void *indata, size_t inlen, const void *digestdata) ATTR_WARN_UNUSED;
+extern bool digest_set_key(digest_t *digest, const void *key, size_t len) ATTR_WARN_UNUSED;
 extern int digest_get_nid(const digest_t *digest);
 extern size_t digest_keylength(const digest_t *digest);
 extern size_t digest_length(const digest_t *digest);

--- a/src/dirent.h
+++ b/src/dirent.h
@@ -1,0 +1,1068 @@
+/*
+ * Dirent interface for Microsoft Visual Studio
+ *
+ * Copyright (C) 1998-2019 Toni Ronkko
+ * This file is part of dirent.  Dirent may be freely distributed
+ * under the MIT license.  For all details and documentation, see
+ * https://github.com/tronkko/dirent
+ */
+#ifndef DIRENT_H
+#define DIRENT_H
+
+/* Hide warnings about unreferenced local functions */
+#if defined(__clang__)
+#       pragma clang diagnostic ignored "-Wunused-function"
+#elif defined(_MSC_VER)
+#       pragma warning(disable:4505)
+#elif defined(__GNUC__)
+#       pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
+/*
+ * Include windows.h without Windows Sockets 1.1 to prevent conflicts with
+ * Windows Sockets 2.0.
+ */
+#ifndef WIN32_LEAN_AND_MEAN
+#       define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <wchar.h>
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <ctype.h>
+
+/* Indicates that d_type field is available in dirent structure */
+#define _DIRENT_HAVE_D_TYPE
+
+/* Indicates that d_namlen field is available in dirent structure */
+#define _DIRENT_HAVE_D_NAMLEN
+
+/* Entries missing from MSVC 6.0 */
+#if !defined(FILE_ATTRIBUTE_DEVICE)
+#       define FILE_ATTRIBUTE_DEVICE 0x40
+#endif
+
+/* File type and permission flags for stat(), general mask */
+#if !defined(S_IFMT)
+#       define S_IFMT _S_IFMT
+#endif
+
+/* Directory bit */
+#if !defined(S_IFDIR)
+#       define S_IFDIR _S_IFDIR
+#endif
+
+/* Character device bit */
+#if !defined(S_IFCHR)
+#       define S_IFCHR _S_IFCHR
+#endif
+
+/* Pipe bit */
+#if !defined(S_IFFIFO)
+#       define S_IFFIFO _S_IFFIFO
+#endif
+
+/* Regular file bit */
+#if !defined(S_IFREG)
+#       define S_IFREG _S_IFREG
+#endif
+
+/* Read permission */
+#if !defined(S_IREAD)
+#       define S_IREAD _S_IREAD
+#endif
+
+/* Write permission */
+#if !defined(S_IWRITE)
+#       define S_IWRITE _S_IWRITE
+#endif
+
+/* Execute permission */
+#if !defined(S_IEXEC)
+#       define S_IEXEC _S_IEXEC
+#endif
+
+/* Pipe */
+#if !defined(S_IFIFO)
+#       define S_IFIFO _S_IFIFO
+#endif
+
+/* Block device */
+#if !defined(S_IFBLK)
+#       define S_IFBLK 0
+#endif
+
+/* Link */
+#if !defined(S_IFLNK)
+#       define S_IFLNK 0
+#endif
+
+/* Socket */
+#if !defined(S_IFSOCK)
+#       define S_IFSOCK 0
+#endif
+
+/* Read user permission */
+#if !defined(S_IRUSR)
+#       define S_IRUSR S_IREAD
+#endif
+
+/* Write user permission */
+#if !defined(S_IWUSR)
+#       define S_IWUSR S_IWRITE
+#endif
+
+/* Execute user permission */
+#if !defined(S_IXUSR)
+#       define S_IXUSR 0
+#endif
+
+/* Read group permission */
+#if !defined(S_IRGRP)
+#       define S_IRGRP 0
+#endif
+
+/* Write group permission */
+#if !defined(S_IWGRP)
+#       define S_IWGRP 0
+#endif
+
+/* Execute group permission */
+#if !defined(S_IXGRP)
+#       define S_IXGRP 0
+#endif
+
+/* Read others permission */
+#if !defined(S_IROTH)
+#       define S_IROTH 0
+#endif
+
+/* Write others permission */
+#if !defined(S_IWOTH)
+#       define S_IWOTH 0
+#endif
+
+/* Execute others permission */
+#if !defined(S_IXOTH)
+#       define S_IXOTH 0
+#endif
+
+/* Maximum length of file name */
+#if !defined(PATH_MAX)
+#       define PATH_MAX MAX_PATH
+#endif
+#if !defined(FILENAME_MAX)
+#       define FILENAME_MAX MAX_PATH
+#endif
+#if !defined(NAME_MAX)
+#       define NAME_MAX FILENAME_MAX
+#endif
+
+/* File type flags for d_type */
+#define DT_UNKNOWN 0
+#define DT_REG S_IFREG
+#define DT_DIR S_IFDIR
+#define DT_FIFO S_IFIFO
+#define DT_SOCK S_IFSOCK
+#define DT_CHR S_IFCHR
+#define DT_BLK S_IFBLK
+#define DT_LNK S_IFLNK
+
+/* Macros for converting between st_mode and d_type */
+#define IFTODT(mode) ((mode) & S_IFMT)
+#define DTTOIF(type) (type)
+
+/*
+ * File type macros.  Note that block devices, sockets and links cannot be
+ * distinguished on Windows and the macros S_ISBLK, S_ISSOCK and S_ISLNK are
+ * only defined for compatibility.  These macros should always return false
+ * on Windows.
+ */
+#if !defined(S_ISFIFO)
+#       define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
+#endif
+#if !defined(S_ISDIR)
+#       define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+#if !defined(S_ISREG)
+#       define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#endif
+#if !defined(S_ISLNK)
+#       define S_ISLNK(mode) (((mode) & S_IFMT) == S_IFLNK)
+#endif
+#if !defined(S_ISSOCK)
+#       define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
+#endif
+#if !defined(S_ISCHR)
+#       define S_ISCHR(mode) (((mode) & S_IFMT) == S_IFCHR)
+#endif
+#if !defined(S_ISBLK)
+#       define S_ISBLK(mode) (((mode) & S_IFMT) == S_IFBLK)
+#endif
+
+/* Return the exact length of the file name without zero terminator */
+#define _D_EXACT_NAMLEN(p) ((p)->d_namlen)
+
+/* Return the maximum size of a file name */
+#define _D_ALLOC_NAMLEN(p) ((PATH_MAX)+1)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Wide-character version */
+struct _wdirent {
+	/* Always zero */
+	long d_ino;
+
+	/* File position within stream */
+	long d_off;
+
+	/* Structure size */
+	unsigned short d_reclen;
+
+	/* Length of name without \0 */
+	size_t d_namlen;
+
+	/* File type */
+	int d_type;
+
+	/* File name */
+	wchar_t d_name[PATH_MAX + 1];
+};
+typedef struct _wdirent _wdirent;
+
+struct _WDIR {
+	/* Current directory entry */
+	struct _wdirent ent;
+
+	/* Private file data */
+	WIN32_FIND_DATAW data;
+
+	/* True if data is valid */
+	int cached;
+
+	/* Win32 search handle */
+	HANDLE handle;
+
+	/* Initial directory name */
+	wchar_t *patt;
+};
+typedef struct _WDIR _WDIR;
+
+/* Multi-byte character version */
+struct dirent {
+	/* Always zero */
+	long d_ino;
+
+	/* File position within stream */
+	long d_off;
+
+	/* Structure size */
+	unsigned short d_reclen;
+
+	/* Length of name without \0 */
+	size_t d_namlen;
+
+	/* File type */
+	int d_type;
+
+	/* File name */
+	char d_name[PATH_MAX + 1];
+};
+typedef struct dirent dirent;
+
+struct DIR {
+	struct dirent ent;
+	struct _WDIR *wdirp;
+};
+typedef struct DIR DIR;
+
+
+/* Dirent functions */
+static DIR *opendir(const char *dirname);
+static _WDIR *_wopendir(const wchar_t *dirname);
+
+static struct dirent *readdir(DIR *dirp);
+static struct _wdirent *_wreaddir(_WDIR *dirp);
+
+static int readdir_r(
+        DIR *dirp, struct dirent *entry, struct dirent **result);
+static int _wreaddir_r(
+        _WDIR *dirp, struct _wdirent *entry, struct _wdirent **result);
+
+static int closedir(DIR *dirp);
+static int _wclosedir(_WDIR *dirp);
+
+static void rewinddir(DIR *dirp);
+static void _wrewinddir(_WDIR *dirp);
+
+static int scandir(const char *dirname, struct dirent ***namelist,
+                   int (*filter)(const struct dirent *),
+                   int (*compare)(const struct dirent **, const struct dirent **));
+
+static int alphasort(const struct dirent **a, const struct dirent **b);
+
+static int versionsort(const struct dirent **a, const struct dirent **b);
+
+static int strverscmp(const char *a, const char *b);
+
+/* For compatibility with Symbian */
+#define wdirent _wdirent
+#define WDIR _WDIR
+#define wopendir _wopendir
+#define wreaddir _wreaddir
+#define wclosedir _wclosedir
+#define wrewinddir _wrewinddir
+
+/* Compatibility with older Microsoft compilers and non-Microsoft compilers */
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+#       define wcstombs_s dirent_wcstombs_s
+#       define mbstowcs_s dirent_mbstowcs_s
+#endif
+
+/* Optimize dirent_set_errno() away on modern Microsoft compilers */
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+#       define dirent_set_errno _set_errno
+#endif
+
+
+/* Internal utility functions */
+static WIN32_FIND_DATAW *dirent_first(_WDIR *dirp);
+static WIN32_FIND_DATAW *dirent_next(_WDIR *dirp);
+
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static int dirent_mbstowcs_s(
+        size_t *pReturnValue, wchar_t *wcstr, size_t sizeInWords,
+        const char *mbstr, size_t count);
+#endif
+
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static int dirent_wcstombs_s(
+        size_t *pReturnValue, char *mbstr, size_t sizeInBytes,
+        const wchar_t *wcstr, size_t count);
+#endif
+
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static void dirent_set_errno(int error);
+#endif
+
+
+/*
+ * Open directory stream DIRNAME for read and return a pointer to the
+ * internal working area that is used to retrieve individual directory
+ * entries.
+ */
+static _WDIR *_wopendir(const wchar_t *dirname) {
+	wchar_t *p;
+
+	/* Must have directory name */
+	if(dirname == NULL || dirname[0] == '\0') {
+		dirent_set_errno(ENOENT);
+		return NULL;
+	}
+
+	/* Allocate new _WDIR structure */
+	_WDIR *dirp = (_WDIR *) malloc(sizeof(struct _WDIR));
+
+	if(!dirp) {
+		return NULL;
+	}
+
+	/* Reset _WDIR structure */
+	dirp->handle = INVALID_HANDLE_VALUE;
+	dirp->patt = NULL;
+	dirp->cached = 0;
+
+	/*
+	 * Compute the length of full path plus zero terminator
+	 *
+	 * Note that on WinRT there's no way to convert relative paths
+	 * into absolute paths, so just assume it is an absolute path.
+	 */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+	/* Desktop */
+	DWORD n = GetFullPathNameW(dirname, 0, NULL, NULL);
+#else
+	/* WinRT */
+	size_t n = wcslen(dirname);
+#endif
+
+	/* Allocate room for absolute directory name and search pattern */
+	dirp->patt = (wchar_t *) malloc(sizeof(wchar_t) * n + 16);
+
+	if(dirp->patt == NULL) {
+		goto exit_closedir;
+	}
+
+	/*
+	 * Convert relative directory name to an absolute one.  This
+	 * allows rewinddir() to function correctly even when current
+	 * working directory is changed between opendir() and rewinddir().
+	 *
+	 * Note that on WinRT there's no way to convert relative paths
+	 * into absolute paths, so just assume it is an absolute path.
+	 */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+	/* Desktop */
+	n = GetFullPathNameW(dirname, n, dirp->patt, NULL);
+
+	if(n <= 0) {
+		goto exit_closedir;
+	}
+
+#else
+	/* WinRT */
+	wcsncpy_s(dirp->patt, n + 1, dirname, n);
+#endif
+
+	/* Append search pattern \* to the directory name */
+	p = dirp->patt + n;
+
+	switch(p[-1]) {
+	case '\\':
+	case '/':
+	case ':':
+		/* Directory ends in path separator, e.g. c:\temp\ */
+		/*NOP*/
+		;
+		break;
+
+	default:
+		/* Directory name doesn't end in path separator */
+		*p++ = '\\';
+	}
+
+	*p++ = '*';
+	*p = '\0';
+
+	/* Open directory stream and retrieve the first entry */
+	if(!dirent_first(dirp)) {
+		goto exit_closedir;
+	}
+
+	/* Success */
+	return dirp;
+
+	/* Failure */
+exit_closedir:
+	_wclosedir(dirp);
+	return NULL;
+}
+
+/*
+ * Read next directory entry.
+ *
+ * Returns pointer to static directory entry which may be overwritten by
+ * subsequent calls to _wreaddir().
+ */
+static struct _wdirent *_wreaddir(_WDIR *dirp) {
+	/*
+	 * Read directory entry to buffer.  We can safely ignore the return
+	 * value as entry will be set to NULL in case of error.
+	 */
+	struct _wdirent *entry;
+	(void) _wreaddir_r(dirp, &dirp->ent, &entry);
+
+	/* Return pointer to statically allocated directory entry */
+	return entry;
+}
+
+/*
+ * Read next directory entry.
+ *
+ * Returns zero on success.  If end of directory stream is reached, then sets
+ * result to NULL and returns zero.
+ */
+static int _wreaddir_r(
+        _WDIR *dirp, struct _wdirent *entry, struct _wdirent **result) {
+	/* Read next directory entry */
+	WIN32_FIND_DATAW *datap = dirent_next(dirp);
+
+	if(!datap) {
+		/* Return NULL to indicate end of directory */
+		*result = NULL;
+		return /*OK*/0;
+	}
+
+	/*
+	 * Copy file name as wide-character string.  If the file name is too
+	 * long to fit in to the destination buffer, then truncate file name
+	 * to PATH_MAX characters and zero-terminate the buffer.
+	 */
+	size_t n = 0;
+
+	while(n < PATH_MAX && datap->cFileName[n] != 0) {
+		entry->d_name[n] = datap->cFileName[n];
+		n++;
+	}
+
+	entry->d_name[n] = 0;
+
+	/* Length of file name excluding zero terminator */
+	entry->d_namlen = n;
+
+	/* File type */
+	DWORD attr = datap->dwFileAttributes;
+
+	if((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
+		entry->d_type = DT_CHR;
+	} else if((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+		entry->d_type = DT_DIR;
+	} else {
+		entry->d_type = DT_REG;
+	}
+
+	/* Reset dummy fields */
+	entry->d_ino = 0;
+	entry->d_off = 0;
+	entry->d_reclen = sizeof(struct _wdirent);
+
+	/* Set result address */
+	*result = entry;
+	return /*OK*/0;
+}
+
+/*
+ * Close directory stream opened by opendir() function.  This invalidates the
+ * DIR structure as well as any directory entry read previously by
+ * _wreaddir().
+ */
+static int _wclosedir(_WDIR *dirp) {
+	if(!dirp) {
+		dirent_set_errno(EBADF);
+		return /*failure*/ -1;
+	}
+
+	/* Release search handle */
+	if(dirp->handle != INVALID_HANDLE_VALUE) {
+		FindClose(dirp->handle);
+	}
+
+	/* Release search pattern */
+	free(dirp->patt);
+
+	/* Release directory structure */
+	free(dirp);
+	return /*success*/0;
+}
+
+/*
+ * Rewind directory stream such that _wreaddir() returns the very first
+ * file name again.
+ */
+static void _wrewinddir(_WDIR *dirp) {
+	if(!dirp) {
+		return;
+	}
+
+	/* Release existing search handle */
+	if(dirp->handle != INVALID_HANDLE_VALUE) {
+		FindClose(dirp->handle);
+	}
+
+	/* Open new search handle */
+	dirent_first(dirp);
+}
+
+/* Get first directory entry */
+static WIN32_FIND_DATAW *dirent_first(_WDIR *dirp) {
+	if(!dirp) {
+		return NULL;
+	}
+
+	/* Open directory and retrieve the first entry */
+	dirp->handle = FindFirstFileExW(
+	                       dirp->patt, FindExInfoStandard, &dirp->data,
+	                       FindExSearchNameMatch, NULL, 0);
+
+	if(dirp->handle == INVALID_HANDLE_VALUE) {
+		goto error;
+	}
+
+	/* A directory entry is now waiting in memory */
+	dirp->cached = 1;
+	return &dirp->data;
+
+error:
+	/* Failed to open directory: no directory entry in memory */
+	dirp->cached = 0;
+
+	/* Set error code */
+	DWORD errorcode = GetLastError();
+
+	switch(errorcode) {
+	case ERROR_ACCESS_DENIED:
+		/* No read access to directory */
+		dirent_set_errno(EACCES);
+		break;
+
+	case ERROR_DIRECTORY:
+		/* Directory name is invalid */
+		dirent_set_errno(ENOTDIR);
+		break;
+
+	case ERROR_PATH_NOT_FOUND:
+	default:
+		/* Cannot find the file */
+		dirent_set_errno(ENOENT);
+	}
+
+	return NULL;
+}
+
+/* Get next directory entry */
+static WIN32_FIND_DATAW *dirent_next(_WDIR *dirp) {
+	/* Is the next directory entry already in cache? */
+	if(dirp->cached) {
+		/* Yes, a valid directory entry found in memory */
+		dirp->cached = 0;
+		return &dirp->data;
+	}
+
+	/* No directory entry in cache */
+	if(dirp->handle == INVALID_HANDLE_VALUE) {
+		return NULL;
+	}
+
+	/* Read the next directory entry from stream */
+	if(FindNextFileW(dirp->handle, &dirp->data) == FALSE) {
+		goto exit_close;
+	}
+
+	/* Success */
+	return &dirp->data;
+
+	/* Failure */
+exit_close:
+	FindClose(dirp->handle);
+	dirp->handle = INVALID_HANDLE_VALUE;
+	return NULL;
+}
+
+/* Open directory stream using plain old C-string */
+static DIR *opendir(const char *dirname) {
+	/* Must have directory name */
+	if(dirname == NULL || dirname[0] == '\0') {
+		dirent_set_errno(ENOENT);
+		return NULL;
+	}
+
+	/* Allocate memory for DIR structure */
+	struct DIR *dirp = (DIR *) malloc(sizeof(struct DIR));
+
+	if(!dirp) {
+		return NULL;
+	}
+
+	/* Convert directory name to wide-character string */
+	wchar_t wname[PATH_MAX + 1];
+	size_t n;
+	int error = mbstowcs_s(&n, wname, PATH_MAX + 1, dirname, PATH_MAX + 1);
+
+	if(error) {
+		goto exit_failure;
+	}
+
+	/* Open directory stream using wide-character name */
+	dirp->wdirp = _wopendir(wname);
+
+	if(!dirp->wdirp) {
+		goto exit_failure;
+	}
+
+	/* Success */
+	return dirp;
+
+	/* Failure */
+exit_failure:
+	free(dirp);
+	return NULL;
+}
+
+/* Read next directory entry */
+static struct dirent *readdir(DIR *dirp) {
+	/*
+	 * Read directory entry to buffer.  We can safely ignore the return
+	 * value as entry will be set to NULL in case of error.
+	 */
+	struct dirent *entry;
+	(void) readdir_r(dirp, &dirp->ent, &entry);
+
+	/* Return pointer to statically allocated directory entry */
+	return entry;
+}
+
+/*
+ * Read next directory entry into called-allocated buffer.
+ *
+ * Returns zero on success.  If the end of directory stream is reached, then
+ * sets result to NULL and returns zero.
+ */
+static int readdir_r(
+        DIR *dirp, struct dirent *entry, struct dirent **result) {
+	/* Read next directory entry */
+	WIN32_FIND_DATAW *datap = dirent_next(dirp->wdirp);
+
+	if(!datap) {
+		/* No more directory entries */
+		*result = NULL;
+		return /*OK*/0;
+	}
+
+	/* Attempt to convert file name to multi-byte string */
+	size_t n;
+	int error = wcstombs_s(
+	                    &n, entry->d_name, PATH_MAX + 1,
+	                    datap->cFileName, PATH_MAX + 1);
+
+	/*
+	 * If the file name cannot be represented by a multi-byte string, then
+	 * attempt to use old 8+3 file name.  This allows the program to
+	 * access files although file names may seem unfamiliar to the user.
+	 *
+	 * Be ware that the code below cannot come up with a short file name
+	 * unless the file system provides one.  At least VirtualBox shared
+	 * folders fail to do this.
+	 */
+	if(error && datap->cAlternateFileName[0] != '\0') {
+		error = wcstombs_s(
+		                &n, entry->d_name, PATH_MAX + 1,
+		                datap->cAlternateFileName, PATH_MAX + 1);
+	}
+
+	if(!error) {
+		/* Length of file name excluding zero terminator */
+		entry->d_namlen = n - 1;
+
+		/* File attributes */
+		DWORD attr = datap->dwFileAttributes;
+
+		if((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
+			entry->d_type = DT_CHR;
+		} else if((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+			entry->d_type = DT_DIR;
+		} else {
+			entry->d_type = DT_REG;
+		}
+
+		/* Reset dummy fields */
+		entry->d_ino = 0;
+		entry->d_off = 0;
+		entry->d_reclen = sizeof(struct dirent);
+	} else {
+		/*
+		 * Cannot convert file name to multi-byte string so construct
+		 * an erroneous directory entry and return that.  Note that
+		 * we cannot return NULL as that would stop the processing
+		 * of directory entries completely.
+		 */
+		entry->d_name[0] = '?';
+		entry->d_name[1] = '\0';
+		entry->d_namlen = 1;
+		entry->d_type = DT_UNKNOWN;
+		entry->d_ino = 0;
+		entry->d_off = -1;
+		entry->d_reclen = 0;
+	}
+
+	/* Return pointer to directory entry */
+	*result = entry;
+	return /*OK*/0;
+}
+
+/* Close directory stream */
+static int closedir(DIR *dirp) {
+	int ok;
+
+	if(!dirp) {
+		goto exit_failure;
+	}
+
+	/* Close wide-character directory stream */
+	ok = _wclosedir(dirp->wdirp);
+	dirp->wdirp = NULL;
+
+	/* Release multi-byte character version */
+	free(dirp);
+	return ok;
+
+exit_failure:
+	/* Invalid directory stream */
+	dirent_set_errno(EBADF);
+	return /*failure*/ -1;
+}
+
+/* Rewind directory stream to beginning */
+static void rewinddir(DIR *dirp) {
+	if(!dirp) {
+		return;
+	}
+
+	/* Rewind wide-character string directory stream */
+	_wrewinddir(dirp->wdirp);
+}
+
+/* Scan directory for entries */
+static int scandir(
+        const char *dirname, struct dirent ***namelist,
+        int (*filter)(const struct dirent *),
+        int (*compare)(const struct dirent **, const struct dirent **)) {
+	int result;
+
+	/* Open directory stream */
+	DIR *dir = opendir(dirname);
+
+	if(!dir) {
+		/* Cannot open directory */
+		return /*Error*/ -1;
+	}
+
+	/* Read directory entries to memory */
+	struct dirent *tmp = NULL;
+	struct dirent **files = NULL;
+	size_t size = 0;
+	size_t allocated = 0;
+
+	while(1) {
+		/* Allocate room for a temporary directory entry */
+		if(!tmp) {
+			tmp = (struct dirent *) malloc(sizeof(struct dirent));
+
+			if(!tmp) {
+				goto exit_failure;
+			}
+		}
+
+		/* Read directory entry to temporary area */
+		struct dirent *entry;
+
+		if(readdir_r(dir, tmp, &entry) != /*OK*/0) {
+			goto exit_failure;
+		}
+
+		/* Stop if we already read the last directory entry */
+		if(entry == NULL) {
+			goto exit_success;
+		}
+
+		/* Determine whether to include the entry in results */
+		if(filter && !filter(tmp)) {
+			continue;
+		}
+
+		/* Enlarge pointer table to make room for another pointer */
+		if(size >= allocated) {
+			/* Compute number of entries in the new table */
+			size_t num_entries = size * 2 + 16;
+
+			/* Allocate new pointer table or enlarge existing */
+			void *p = realloc(files, sizeof(void *) * num_entries);
+
+			if(!p) {
+				goto exit_failure;
+			}
+
+			/* Got the memory */
+			files = (dirent **) p;
+			allocated = num_entries;
+		}
+
+		/* Store the temporary entry to ptr table */
+		files[size++] = tmp;
+		tmp = NULL;
+	}
+
+exit_failure:
+
+	/* Release allocated file entries */
+	for(size_t i = 0; i < size; i++) {
+		free(files[i]);
+	}
+
+	/* Release the pointer table */
+	free(files);
+	files = NULL;
+
+	/* Exit with error code */
+	result = /*error*/ -1;
+	goto exit_status;
+
+exit_success:
+	/* Sort directory entries */
+	qsort(files, size, sizeof(void *),
+	      (int (*)(const void *, const void *)) compare);
+
+	/* Pass pointer table to caller */
+	if(namelist) {
+		*namelist = files;
+	}
+
+	/* Return the number of directory entries read */
+	result = (int) size;
+
+exit_status:
+	/* Release temporary directory entry, if we had one */
+	free(tmp);
+
+	/* Close directory stream */
+	closedir(dir);
+	return result;
+}
+
+/* Alphabetical sorting */
+static int alphasort(const struct dirent **a, const struct dirent **b) {
+	return strcoll((*a)->d_name, (*b)->d_name);
+}
+
+/* Sort versions */
+static int versionsort(const struct dirent **a, const struct dirent **b) {
+	return strverscmp((*a)->d_name, (*b)->d_name);
+}
+
+/* Compare strings */
+static int strverscmp(const char *a, const char *b) {
+	size_t i = 0;
+	size_t j;
+
+	/* Find first difference */
+	while(a[i] == b[i]) {
+		if(a[i] == '\0') {
+			/* No difference */
+			return 0;
+		}
+
+		++i;
+	}
+
+	/* Count backwards and find the leftmost digit */
+	j = i;
+
+	while(j > 0 && isdigit(a[j - 1])) {
+		--j;
+	}
+
+	/* Determine mode of comparison */
+	if(a[j] == '0' || b[j] == '0') {
+		/* Find the next non-zero digit */
+		while(a[j] == '0' && a[j] == b[j]) {
+			j++;
+		}
+
+		/* String with more digits is smaller, e.g 002 < 01 */
+		if(isdigit(a[j])) {
+			if(!isdigit(b[j])) {
+				return -1;
+			}
+		} else if(isdigit(b[j])) {
+			return 1;
+		}
+	} else if(isdigit(a[j]) && isdigit(b[j])) {
+		/* Numeric comparison */
+		size_t k1 = j;
+		size_t k2 = j;
+
+		/* Compute number of digits in each string */
+		while(isdigit(a[k1])) {
+			k1++;
+		}
+
+		while(isdigit(b[k2])) {
+			k2++;
+		}
+
+		/* Number with more digits is bigger, e.g 999 < 1000 */
+		if(k1 < k2) {
+			return -1;
+		} else if(k1 > k2) {
+			return 1;
+		}
+	}
+
+	/* Alphabetical comparison */
+	return (int)((unsigned char) a[i]) - ((unsigned char) b[i]);
+}
+
+/* Convert multi-byte string to wide character string */
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static int dirent_mbstowcs_s(
+        size_t *pReturnValue, wchar_t *wcstr,
+        size_t sizeInWords, const char *mbstr, size_t count) {
+	/* Older Visual Studio or non-Microsoft compiler */
+	size_t n = mbstowcs(wcstr, mbstr, sizeInWords);
+
+	if(wcstr && n >= count) {
+		return /*error*/ 1;
+	}
+
+	/* Zero-terminate output buffer */
+	if(wcstr && sizeInWords) {
+		if(n >= sizeInWords) {
+			n = sizeInWords - 1;
+		}
+
+		wcstr[n] = 0;
+	}
+
+	/* Length of multi-byte string with zero terminator */
+	if(pReturnValue) {
+		*pReturnValue = n + 1;
+	}
+
+	/* Success */
+	return 0;
+}
+#endif
+
+/* Convert wide-character string to multi-byte string */
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static int dirent_wcstombs_s(
+        size_t *pReturnValue, char *mbstr,
+        size_t sizeInBytes, const wchar_t *wcstr, size_t count) {
+	/* Older Visual Studio or non-Microsoft compiler */
+	size_t n = wcstombs(mbstr, wcstr, sizeInBytes);
+
+	if(mbstr && n >= count) {
+		return /*error*/1;
+	}
+
+	/* Zero-terminate output buffer */
+	if(mbstr && sizeInBytes) {
+		if(n >= sizeInBytes) {
+			n = sizeInBytes - 1;
+		}
+
+		mbstr[n] = '\0';
+	}
+
+	/* Length of resulting multi-bytes string WITH zero-terminator */
+	if(pReturnValue) {
+		*pReturnValue = n + 1;
+	}
+
+	/* Success */
+	return 0;
+}
+#endif
+
+/* Set errno variable */
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static void dirent_set_errno(int error) {
+	/* Non-Microsoft compiler or older Microsoft compiler */
+	errno = error;
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#endif /*DIRENT_H*/

--- a/src/dropin.c
+++ b/src/dropin.c
@@ -130,7 +130,7 @@ int vasprintf(char **buf, const char *fmt, va_list ap) {
 
 #ifndef HAVE_GETTIMEOFDAY
 int gettimeofday(struct timeval *tv, void *tz) {
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	FILETIME ft;
 	GetSystemTimeAsFileTime(&ft);
 	uint64_t lt = (uint64_t)ft.dwLowDateTime | ((uint64_t)ft.dwHighDateTime << 32);

--- a/src/dropin.c
+++ b/src/dropin.c
@@ -145,3 +145,12 @@ int gettimeofday(struct timeval *tv, void *tz) {
 	return 0;
 }
 #endif
+
+bool sleep_millis(unsigned int ms) {
+#ifdef _MSC_VER
+	Sleep(ms);
+	return true;
+#else
+	return !usleep(ms * 1000);
+#endif
+}

--- a/src/dropin.h
+++ b/src/dropin.h
@@ -52,7 +52,7 @@ extern int gettimeofday(struct timeval *, void *);
 	} while (0)
 #endif
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 #define mkdir(a, b) mkdir(a)
 #ifndef SHUT_RDWR
 #define SHUT_RDWR SD_BOTH

--- a/src/dropin.h
+++ b/src/dropin.h
@@ -73,9 +73,6 @@ extern int gettimeofday(struct timeval *, void *);
 
 #ifdef _MSC_VER
 
-#define __attribute(args)
-#define __attribute__(args)
-
 #define PATH_MAX MAX_PATH
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp

--- a/src/dropin.h
+++ b/src/dropin.h
@@ -71,4 +71,30 @@ extern int gettimeofday(struct timeval *, void *);
 #define MAX(a,b) (((a)>(b))?(a):(b))
 #endif
 
-#endif
+#ifdef _MSC_VER
+
+#define __attribute(args)
+#define __attribute__(args)
+
+#define PATH_MAX MAX_PATH
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#define __const const
+
+typedef int mode_t;
+typedef int pid_t;
+typedef SSIZE_T ssize_t;
+
+static const int STDIN_FILENO = 0;
+static const int F_OK = 0;
+static const int X_OK = 0;
+static const int W_OK = 2;
+static const int R_OK = 4;
+
+#else // _MSC_VER
+
+#endif // _MSC_VER
+
+extern bool sleep_millis(unsigned int ms);
+
+#endif // TINC_DROPIN_H

--- a/src/ecdh.h
+++ b/src/ecdh.h
@@ -29,8 +29,8 @@
 typedef struct ecdh ecdh_t;
 #endif
 
-extern ecdh_t *ecdh_generate_public(void *pubkey) __attribute__((__malloc__));
-extern bool ecdh_compute_shared(ecdh_t *ecdh, const void *pubkey, void *shared) __attribute__((__warn_unused_result__));
+extern ecdh_t *ecdh_generate_public(void *pubkey) ATTR_MALLOC;
+extern bool ecdh_compute_shared(ecdh_t *ecdh, const void *pubkey, void *shared) ATTR_WARN_UNUSED;
 extern void ecdh_free(ecdh_t *ecdh);
 
 #endif

--- a/src/ecdsa.h
+++ b/src/ecdsa.h
@@ -26,13 +26,13 @@
 typedef struct ecdsa ecdsa_t;
 #endif
 
-extern ecdsa_t *ecdsa_set_base64_public_key(const char *p) __attribute__((__malloc__));
+extern ecdsa_t *ecdsa_set_base64_public_key(const char *p) ATTR_MALLOC;
 extern char *ecdsa_get_base64_public_key(ecdsa_t *ecdsa);
-extern ecdsa_t *ecdsa_read_pem_public_key(FILE *fp) __attribute__((__malloc__));
-extern ecdsa_t *ecdsa_read_pem_private_key(FILE *fp) __attribute__((__malloc__));
+extern ecdsa_t *ecdsa_read_pem_public_key(FILE *fp) ATTR_MALLOC;
+extern ecdsa_t *ecdsa_read_pem_private_key(FILE *fp) ATTR_MALLOC;
 extern size_t ecdsa_size(ecdsa_t *ecdsa);
-extern bool ecdsa_sign(ecdsa_t *ecdsa, const void *in, size_t inlen, void *out) __attribute__((__warn_unused_result__));
-extern bool ecdsa_verify(ecdsa_t *ecdsa, const void *in, size_t inlen, const void *out) __attribute__((__warn_unused_result__));
+extern bool ecdsa_sign(ecdsa_t *ecdsa, const void *in, size_t inlen, void *out) ATTR_WARN_UNUSED;
+extern bool ecdsa_verify(ecdsa_t *ecdsa, const void *in, size_t inlen, const void *out) ATTR_WARN_UNUSED;
 extern bool ecdsa_active(ecdsa_t *ecdsa);
 extern void ecdsa_free(ecdsa_t *ecdsa);
 

--- a/src/ecdsagen.h
+++ b/src/ecdsagen.h
@@ -22,8 +22,8 @@
 
 #include "ecdsa.h"
 
-extern ecdsa_t *ecdsa_generate(void) __attribute__((__malloc__));
-extern bool ecdsa_write_pem_public_key(ecdsa_t *ecdsa, FILE *fp) __attribute__((__warn_unused_result__));
-extern bool ecdsa_write_pem_private_key(ecdsa_t *ecdsa, FILE *fp) __attribute__((__warn_unused_result__));
+extern ecdsa_t *ecdsa_generate(void) ATTR_MALLOC;
+extern bool ecdsa_write_pem_public_key(ecdsa_t *ecdsa, FILE *fp) ATTR_WARN_UNUSED;
+extern bool ecdsa_write_pem_private_key(ecdsa_t *ecdsa, FILE *fp) ATTR_WARN_UNUSED;
 
 #endif

--- a/src/ed25519/fixedint.h
+++ b/src/ed25519/fixedint.h
@@ -7,7 +7,7 @@
     Not a compatible replacement for <stdint.h>, do not blindly use it as such.
 */
 
-#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined(__WATCOMC__) && (defined(_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_) || defined(__UINT_FAST64_TYPE__)) )) && !defined(FIXEDINT_H_INCLUDED)
+#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined(_MSC_VER) && _MSC_VER >= 1600) || (defined(__WATCOMC__) && (defined(_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_) || defined(__UINT_FAST64_TYPE__)) )) && !defined(FIXEDINT_H_INCLUDED)
 #include <stdint.h>
 #define FIXEDINT_H_INCLUDED
 

--- a/src/edge.h
+++ b/src/edge.h
@@ -42,7 +42,7 @@ typedef struct edge_t {
 extern splay_tree_t edge_weight_tree;          /* Tree with all known edges sorted on weight */
 
 extern void exit_edges(void);
-extern edge_t *new_edge(void) __attribute__((__malloc__));
+extern edge_t *new_edge(void) ATTR_MALLOC;
 extern void free_edge(edge_t *e);
 extern void init_edge_tree(splay_tree_t *tree);
 extern void edge_add(edge_t *e);

--- a/src/ethernet.h
+++ b/src/ethernet.h
@@ -68,6 +68,8 @@ struct ether_header {
 };
 #endif
 
+STATIC_ASSERT(sizeof(struct ether_header) == 14, "ether_header has incorrect size");
+
 #ifndef HAVE_STRUCT_ARPHDR
 struct arphdr {
 	uint16_t ar_hrd;
@@ -86,6 +88,8 @@ struct arphdr {
 #define ARPOP_NAK 10
 #endif
 
+STATIC_ASSERT(sizeof(struct arphdr) == 8, "arphdr has incorrect size");
+
 #ifndef HAVE_STRUCT_ETHER_ARP
 struct  ether_arp {
 	struct  arphdr ea_hdr;
@@ -100,5 +104,7 @@ struct  ether_arp {
 #define arp_pln ea_hdr.ar_pln
 #define arp_op ea_hdr.ar_op
 #endif
+
+STATIC_ASSERT(sizeof(struct ether_arp) == 28, "ether_arp has incorrect size");
 
 #endif

--- a/src/ethernet.h
+++ b/src/ethernet.h
@@ -61,24 +61,23 @@
 #endif
 
 #ifndef HAVE_STRUCT_ETHER_HEADER
-struct ether_header {
+PACKED(struct ether_header {
 	uint8_t ether_dhost[ETH_ALEN];
 	uint8_t ether_shost[ETH_ALEN];
 	uint16_t ether_type;
-};
+});
 #endif
 
 STATIC_ASSERT(sizeof(struct ether_header) == 14, "ether_header has incorrect size");
 
 #ifndef HAVE_STRUCT_ARPHDR
-struct arphdr {
+PACKED(struct arphdr {
 	uint16_t ar_hrd;
 	uint16_t ar_pro;
 	uint8_t ar_hln;
 	uint8_t ar_pln;
 	uint16_t ar_op;
-};
-
+});
 #define ARPOP_REQUEST 1
 #define ARPOP_REPLY 2
 #define ARPOP_RREQUEST 3
@@ -91,13 +90,13 @@ struct arphdr {
 STATIC_ASSERT(sizeof(struct arphdr) == 8, "arphdr has incorrect size");
 
 #ifndef HAVE_STRUCT_ETHER_ARP
-struct  ether_arp {
+PACKED(struct ether_arp {
 	struct  arphdr ea_hdr;
 	uint8_t arp_sha[ETH_ALEN];
 	uint8_t arp_spa[4];
 	uint8_t arp_tha[ETH_ALEN];
 	uint8_t arp_tpa[4];
-};
+});
 #define arp_hrd ea_hdr.ar_hrd
 #define arp_pro ea_hdr.ar_pro
 #define arp_hln ea_hdr.ar_hln

--- a/src/ethernet.h
+++ b/src/ethernet.h
@@ -65,7 +65,7 @@ struct ether_header {
 	uint8_t ether_dhost[ETH_ALEN];
 	uint8_t ether_shost[ETH_ALEN];
 	uint16_t ether_type;
-} __attribute__((__gcc_struct__)) __attribute((__packed__));
+};
 #endif
 
 #ifndef HAVE_STRUCT_ARPHDR
@@ -75,7 +75,7 @@ struct arphdr {
 	uint8_t ar_hln;
 	uint8_t ar_pln;
 	uint16_t ar_op;
-} __attribute__((__gcc_struct__)) __attribute((__packed__));
+};
 
 #define ARPOP_REQUEST 1
 #define ARPOP_REPLY 2
@@ -93,7 +93,7 @@ struct  ether_arp {
 	uint8_t arp_spa[4];
 	uint8_t arp_tha[ETH_ALEN];
 	uint8_t arp_tpa[4];
-} __attribute__((__gcc_struct__)) __attribute((__packed__));
+};
 #define arp_hrd ea_hdr.ar_hrd
 #define arp_pro ea_hdr.ar_pro
 #define arp_hln ea_hdr.ar_hln

--- a/src/event.c
+++ b/src/event.c
@@ -30,7 +30,7 @@
 #include "net.h"
 
 struct timeval now;
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 
 #ifdef HAVE_SYS_EPOLL_H
 static int epollset = 0;
@@ -58,7 +58,7 @@ static inline int event_epoll_init(void) {
 #endif
 
 static int io_compare(const io_t *a, const io_t *b) {
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	return a->fd - b->fd;
 #else
 
@@ -114,7 +114,7 @@ void io_add(io_t *io, io_cb_t cb, void *data, int fd, int flags) {
 	}
 
 	io->fd = fd;
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 
 	if(io->fd != -1) {
 		io->event = WSACreateEvent();
@@ -141,7 +141,7 @@ void io_add(io_t *io, io_cb_t cb, void *data, int fd, int flags) {
 #endif
 }
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 void io_add_event(io_t *io, io_cb_t cb, void *data, WSAEVENT event) {
 	io->event = event;
 	io_add(io, cb, data, -1, 0);
@@ -167,7 +167,7 @@ void io_set(io_t *io, int flags) {
 		return;
 	}
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 #ifdef HAVE_SYS_EPOLL_H
 	epoll_ctl(epollset, EPOLL_CTL_DEL, io->fd, NULL);
 
@@ -230,7 +230,7 @@ void io_del(io_t *io) {
 	}
 
 	io_set(io, 0);
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 
 	if(io->fd != -1 && WSACloseEvent(io->event) == FALSE) {
 		abort();
@@ -281,7 +281,7 @@ void timeout_del(timeout_t *timeout) {
 	};
 }
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 
 // From Matz's Ruby
 #ifndef NSIG
@@ -379,7 +379,7 @@ static struct timeval *timeout_execute(struct timeval *diff) {
 bool event_loop(void) {
 	running = true;
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 
 #ifdef HAVE_SYS_EPOLL_H
 

--- a/src/event.h
+++ b/src/event.h
@@ -33,7 +33,7 @@ typedef void (*signal_cb_t)(void *data);
 typedef struct io_t {
 	int fd;
 	int flags;
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	WSAEVENT event;
 #endif
 	io_cb_t cb;
@@ -57,7 +57,7 @@ typedef struct signal_t {
 extern struct timeval now;
 
 extern void io_add(io_t *io, io_cb_t cb, void *data, int fd, int flags);
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 extern void io_add_event(io_t *io, io_cb_t cb, void *data, WSAEVENT event);
 #endif
 extern void io_del(io_t *io);

--- a/src/fsck.c
+++ b/src/fsck.c
@@ -141,8 +141,9 @@ static void check_conffile(const char *nodename, bool server) {
 		++total_vars;
 	}
 
-	int count[total_vars];
-	memset(count, 0, sizeof(count));
+	const size_t countlen = total_vars * sizeof(int);
+	int *count = alloca(countlen);
+	memset(count, 0, countlen);
 
 	for splay_each(config_t, conf, &config) {
 		int var_type = 0;

--- a/src/fsck.c
+++ b/src/fsck.c
@@ -185,7 +185,7 @@ static void check_conffile(const char *nodename, bool server) {
 	splay_empty_tree(&config);
 }
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 typedef int uid_t;
 
 static uid_t getuid(void) {
@@ -219,7 +219,7 @@ static void check_key_file_mode(const char *fname) {
 		}
 	}
 }
-#endif // HAVE_MINGW
+#endif // HAVE_WINDOWS
 
 static char *read_node_name(void) {
 	if(access(tinc_conf, R_OK) == 0) {

--- a/src/git_tag.sh
+++ b/src/git_tag.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-git describe --always --tags --match='release-*' "$@" | sed 's/release-//'

--- a/src/have.h
+++ b/src/have.h
@@ -45,6 +45,12 @@
 #include <math.h>
 #include <time.h>
 
+#ifdef HAVE_STATIC_ASSERT
+#define STATIC_ASSERT(expr, msg) _Static_assert((expr), msg)
+#else
+#define STATIC_ASSERT(check, msg)
+#endif
+
 #ifdef HAVE_ALLOCA_H
 #include <alloca.h>
 #elif defined(HAVE_NETBSD)

--- a/src/have.h
+++ b/src/have.h
@@ -61,6 +61,30 @@
 #endif
 #endif
 
+#ifdef HAVE_ATTR_MALLOC
+#define ATTR_MALLOC __attribute__((__malloc__))
+#else
+#define ATTR_MALLOC
+#endif
+
+#ifdef HAVE_ATTR_NONNULL
+#define ATTR_NONNULL __attribute__((__nonnull__))
+#else
+#define ATTR_NONNULL
+#endif
+
+#ifdef HAVE_ATTR_WARN_UNUSED_RESULT
+#define ATTR_WARN_UNUSED __attribute__((__warn_unused_result__))
+#else
+#define ATTR_WARN_UNUSED
+#endif
+
+#ifdef HAVE_ATTR_FORMAT
+#define ATTR_FORMAT(func, str, nonstr) __attribute__((format(func, str, nonstr)))
+#else
+#define ATTR_FORMAT(func, str, nonstr)
+#endif
+
 #ifdef HAVE_ALLOCA_H
 #include <alloca.h>
 #elif defined(HAVE_NETBSD)

--- a/src/have.h
+++ b/src/have.h
@@ -51,6 +51,16 @@
 #define STATIC_ASSERT(check, msg)
 #endif
 
+#ifdef HAVE_ATTR_PACKED
+#define PACKED(...) __VA_ARGS__ __attribute__((__packed__))
+#else
+#ifdef _MSC_VER
+#define PACKED(...) __pragma(pack(push, 1)) __VA_ARGS__ __pragma(pack(pop))
+#else
+#warning Your compiler does not support __packed__. Use at your own risk.
+#endif
+#endif
+
 #ifdef HAVE_ALLOCA_H
 #include <alloca.h>
 #elif defined(HAVE_NETBSD)

--- a/src/have.h
+++ b/src/have.h
@@ -21,7 +21,7 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 #define WINVER 0x0600
 #define _WIN32_WINNT 0x0600
 #define WIN32_LEAN_AND_MEAN
@@ -51,7 +51,7 @@
 #define alloca(size) __builtin_alloca(size)
 #endif
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 #ifdef HAVE_W32API_H
 #include <w32api.h>
 #endif
@@ -65,7 +65,7 @@
 #include <process.h>
 #include <direct.h>
 #endif
-#endif // HAVE_MINGW
+#endif // HAVE_WINDOWS
 
 #ifdef HAVE_TERMIOS_H
 #include <termios.h>
@@ -237,7 +237,7 @@
 #undef STATUS
 #endif
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 #define SLASH "\\"
 #else
 #define SLASH "/"

--- a/src/have.h
+++ b/src/have.h
@@ -25,6 +25,8 @@
 #define WINVER 0x0600
 #define _WIN32_WINNT 0x0600
 #define WIN32_LEAN_AND_MEAN
+#define _CRT_SECURE_NO_WARNINGS
+#define _CRT_NONSTDC_NO_WARNINGS
 #endif
 
 #include <stdio.h>
@@ -36,17 +38,34 @@
 #include <signal.h>
 #include <errno.h>
 #include <fcntl.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #include <limits.h>
 #include <math.h>
 #include <time.h>
 
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#elif defined(HAVE_NETBSD)
+#define alloca(size) __builtin_alloca(size)
+#endif
+
 #ifdef HAVE_MINGW
+#ifdef HAVE_W32API_H
 #include <w32api.h>
+#endif
+
 #include <winsock2.h>
 #include <windows.h>
 #include <ws2tcpip.h>
+
+#ifdef _MSC_VER
+#include <io.h>
+#include <process.h>
+#include <direct.h>
 #endif
+#endif // HAVE_MINGW
 
 #ifdef HAVE_TERMIOS_H
 #include <termios.h>
@@ -109,6 +128,8 @@
 
 #ifdef HAVE_DIRENT_H
 #include <dirent.h>
+#elif defined(_MSC_VER)
+#include "dirent.h"
 #endif
 
 /* SunOS really wants sys/socket.h BEFORE net/if.h,

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -25,7 +25,7 @@
 
 static long start;
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 void ifconfig_header(FILE *out) {
 	fprintf(out, "#!/bin/sh\n");
 	start = ftell(out);
@@ -128,7 +128,7 @@ void ifconfig_address(FILE *out, const char *value) {
 		return;
 	}
 
-#elif defined(HAVE_MINGW)
+#elif defined(HAVE_WINDOWS)
 
 	switch(address.type) {
 	case SUBNET_MAC:
@@ -226,7 +226,7 @@ void ifconfig_route(FILE *out, const char *value) {
 		}
 	}
 
-#elif defined(HAVE_MINGW)
+#elif defined(HAVE_WINDOWS)
 
 	if(*gateway_str) {
 		switch(subnet.type) {

--- a/src/include/meson.build
+++ b/src/include/meson.build
@@ -1,7 +1,7 @@
 configure_file(output: 'config.h', configuration: cdata)
 
 src_lib_common += vcs_tag(
-  command: './git_tag.sh',
+  command: ['git', 'describe', '--always', '--tags', '--match=release-*'],
   fallback: 'unknown',
   input: '../version_git.h.in',
   output: 'version_git.h',

--- a/src/include/meson.build
+++ b/src/include/meson.build
@@ -1,7 +1,7 @@
 configure_file(output: 'config.h', configuration: cdata)
 
 src_lib_common += vcs_tag(
-  command: ['git', 'describe', '--always', '--tags', '--match=release-*'],
+  command: [python_path, src_root / 'version.py'],
   fallback: 'unknown',
   input: '../version_git.h.in',
   output: 'version_git.h',

--- a/src/invitation.c
+++ b/src/invitation.c
@@ -996,7 +996,7 @@ ask_netname:
 	char filename2[PATH_MAX];
 	snprintf(filename, sizeof(filename), "%s" SLASH "tinc-up.invitation", confbase);
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	snprintf(filename2, sizeof(filename2), "%s" SLASH "tinc-up.bat", confbase);
 #else
 	snprintf(filename2, sizeof(filename2), "%s" SLASH "tinc-up", confbase);
@@ -1028,7 +1028,7 @@ ask_netname:
 
 				if(response == 'e') {
 					char *command;
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 					const char *editor = getenv("VISUAL");
 
 					if(!editor) {
@@ -1358,7 +1358,7 @@ next:
 				continue;
 			}
 
-#if HAVE_MINGW
+#if HAVE_WINDOWS
 
 			// If socket has been shut down, recv() on Windows returns -1 and sets sockerrno
 			// to WSAESHUTDOWN, while on UNIX-like operating systems recv() returns 0, so we

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -86,6 +86,8 @@ struct ip {
 };
 #endif
 
+STATIC_ASSERT(sizeof(struct ip) == 20, "ip has incorrect size");
+
 #ifndef IP_OFFMASK
 #define IP_OFFMASK 0x1fff
 #endif
@@ -147,5 +149,7 @@ struct icmp {
 #define icmp_data icmp_dun.id_data
 };
 #endif
+
+STATIC_ASSERT(sizeof(struct icmp) == 28, "icmp has incorrect size");
 
 #endif

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -64,26 +64,30 @@
 #endif
 
 #ifndef HAVE_STRUCT_IP
-struct ip {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-	unsigned int ip_hl: 4;
-	unsigned int ip_v: 4;
+#define IP_NIBBLE1 ip_hl
+#define IP_NIBBLE2 ip_v
 #else
-	unsigned int ip_v: 4;
-	unsigned int ip_hl: 4;
+#define IP_NIBBLE1 ip_v
+#define IP_NIBBLE2 ip_hl
 #endif
+PACKED(struct ip {
+	uint8_t IP_NIBBLE1: 4;
+	uint8_t IP_NIBBLE2: 4;
 	uint8_t ip_tos;
 	uint16_t ip_len;
 	uint16_t ip_id;
 	uint16_t ip_off;
-#define IP_RF 0x8000
-#define IP_DF 0x4000
-#define IP_MF 0x2000
 	uint8_t ip_ttl;
 	uint8_t ip_p;
 	uint16_t ip_sum;
 	struct in_addr ip_src, ip_dst;
-};
+});
+#undef IP_NIBBLE1
+#undef IP_NIBBLE2
+#define IP_RF 0x8000
+#define IP_DF 0x4000
+#define IP_MF 0x2000
 #endif
 
 STATIC_ASSERT(sizeof(struct ip) == 20, "ip has incorrect size");
@@ -93,7 +97,7 @@ STATIC_ASSERT(sizeof(struct ip) == 20, "ip has incorrect size");
 #endif
 
 #ifndef HAVE_STRUCT_ICMP
-struct icmp {
+PACKED(struct icmp {
 	uint8_t icmp_type;
 	uint8_t icmp_code;
 	uint16_t icmp_cksum;
@@ -118,16 +122,6 @@ struct icmp {
 			uint16_t irt_lifetime;
 		} ih_rtradv;
 	} icmp_hun;
-#define icmp_pptr icmp_hun.ih_pptr
-#define icmp_gwaddr icmp_hun.ih_gwaddr
-#define icmp_id icmp_hun.ih_idseq.icd_id
-#define icmp_seq icmp_hun.ih_idseq.icd_seq
-#define icmp_void icmp_hun.ih_void
-#define icmp_pmvoid icmp_hun.ih_pmtu.ipm_void
-#define icmp_nextmtu icmp_hun.ih_pmtu.ipm_nextmtu
-#define icmp_num_addrs icmp_hun.ih_rtradv.irt_num_addrs
-#define icmp_wpa icmp_hun.ih_rtradv.irt_wpa
-#define icmp_lifetime icmp_hun.ih_rtradv.irt_lifetime
 	union {
 		struct {
 			uint32_t its_otime;
@@ -140,6 +134,17 @@ struct icmp {
 		uint32_t id_mask;
 		uint8_t id_data[1];
 	} icmp_dun;
+});
+#define icmp_pptr icmp_hun.ih_pptr
+#define icmp_gwaddr icmp_hun.ih_gwaddr
+#define icmp_id icmp_hun.ih_idseq.icd_id
+#define icmp_seq icmp_hun.ih_idseq.icd_seq
+#define icmp_void icmp_hun.ih_void
+#define icmp_pmvoid icmp_hun.ih_pmtu.ipm_void
+#define icmp_nextmtu icmp_hun.ih_pmtu.ipm_nextmtu
+#define icmp_num_addrs icmp_hun.ih_rtradv.irt_num_addrs
+#define icmp_wpa icmp_hun.ih_rtradv.irt_wpa
+#define icmp_lifetime icmp_hun.ih_rtradv.irt_lifetime
 #define icmp_otime icmp_dun.id_ts.its_otime
 #define icmp_rtime icmp_dun.id_ts.its_rtime
 #define icmp_ttime icmp_dun.id_ts.its_ttime
@@ -147,7 +152,6 @@ struct icmp {
 #define icmp_radv icmp_dun.id_radv
 #define icmp_mask icmp_dun.id_mask
 #define icmp_data icmp_dun.id_data
-};
 #endif
 
 STATIC_ASSERT(sizeof(struct icmp) == 28, "icmp has incorrect size");

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -83,7 +83,7 @@ struct ip {
 	uint8_t ip_p;
 	uint16_t ip_sum;
 	struct in_addr ip_src, ip_dst;
-} __attribute__((__gcc_struct__)) __attribute((__packed__));
+};
 #endif
 
 #ifndef IP_OFFMASK
@@ -145,7 +145,7 @@ struct icmp {
 #define icmp_radv icmp_dun.id_radv
 #define icmp_mask icmp_dun.id_mask
 #define icmp_data icmp_dun.id_data
-} __attribute__((__gcc_struct__)) __attribute((__packed__));
+};
 #endif
 
 #endif

--- a/src/ipv6.h
+++ b/src/ipv6.h
@@ -51,7 +51,7 @@ struct ip6_hdr {
 	} ip6_ctlun;
 	struct in6_addr ip6_src;
 	struct in6_addr ip6_dst;
-} __attribute__((__gcc_struct__)) __attribute((__packed__));
+};
 #define ip6_vfc ip6_ctlun.ip6_un2_vfc
 #define ip6_flow ip6_ctlun.ip6_un1.ip6_un1_flow
 #define ip6_plen ip6_ctlun.ip6_un1.ip6_un1_plen
@@ -70,7 +70,7 @@ struct icmp6_hdr {
 		uint16_t icmp6_un_data16[2];
 		uint8_t icmp6_un_data8[4];
 	} icmp6_dataun;
-} __attribute__((__gcc_struct__)) __attribute((__packed__));
+};
 #define ICMP6_DST_UNREACH_NOROUTE 0
 #define ICMP6_DST_UNREACH 1
 #define ICMP6_PACKET_TOO_BIG 2
@@ -90,7 +90,7 @@ struct icmp6_hdr {
 struct nd_neighbor_solicit {
 	struct icmp6_hdr nd_ns_hdr;
 	struct in6_addr nd_ns_target;
-} __attribute__((__gcc_struct__)) __attribute((__packed__));
+};
 #define ND_OPT_SOURCE_LINKADDR 1
 #define ND_OPT_TARGET_LINKADDR 2
 #define nd_ns_type nd_ns_hdr.icmp6_type
@@ -103,7 +103,7 @@ struct nd_neighbor_solicit {
 struct nd_opt_hdr {
 	uint8_t nd_opt_type;
 	uint8_t nd_opt_len;
-} __attribute__((__gcc_struct__)) __attribute((__packed__));
+};
 #endif
 
 #endif

--- a/src/ipv6.h
+++ b/src/ipv6.h
@@ -39,7 +39,7 @@
 #endif
 
 #ifndef HAVE_STRUCT_IP6_HDR
-struct ip6_hdr {
+PACKED(struct ip6_hdr {
 	union {
 		struct ip6_hdrctl {
 			uint32_t ip6_un1_flow;
@@ -51,7 +51,7 @@ struct ip6_hdr {
 	} ip6_ctlun;
 	struct in6_addr ip6_src;
 	struct in6_addr ip6_dst;
-};
+});
 #define ip6_vfc ip6_ctlun.ip6_un2_vfc
 #define ip6_flow ip6_ctlun.ip6_un1.ip6_un1_flow
 #define ip6_plen ip6_ctlun.ip6_un1.ip6_un1_plen
@@ -63,7 +63,7 @@ struct ip6_hdr {
 STATIC_ASSERT(sizeof(struct ip6_hdr) == 40, "ip6_hdr has incorrect size");
 
 #ifndef HAVE_STRUCT_ICMP6_HDR
-struct icmp6_hdr {
+PACKED(struct icmp6_hdr {
 	uint8_t icmp6_type;
 	uint8_t icmp6_code;
 	uint16_t icmp6_cksum;
@@ -72,7 +72,7 @@ struct icmp6_hdr {
 		uint16_t icmp6_un_data16[2];
 		uint8_t icmp6_un_data8[4];
 	} icmp6_dataun;
-};
+});
 #define ICMP6_DST_UNREACH_NOROUTE 0
 #define ICMP6_DST_UNREACH 1
 #define ICMP6_PACKET_TOO_BIG 2
@@ -91,10 +91,10 @@ struct icmp6_hdr {
 STATIC_ASSERT(sizeof(struct icmp6_hdr) == 8, "icmp6_hdr has incorrect size");
 
 #ifndef HAVE_STRUCT_ND_NEIGHBOR_SOLICIT
-struct nd_neighbor_solicit {
+PACKED(struct nd_neighbor_solicit {
 	struct icmp6_hdr nd_ns_hdr;
 	struct in6_addr nd_ns_target;
-};
+});
 #define ND_OPT_SOURCE_LINKADDR 1
 #define ND_OPT_TARGET_LINKADDR 2
 #define nd_ns_type nd_ns_hdr.icmp6_type
@@ -106,10 +106,10 @@ struct nd_neighbor_solicit {
 STATIC_ASSERT(sizeof(struct nd_neighbor_solicit) == 24, "nd_neighbor_solicit has incorrect size");
 
 #ifndef HAVE_STRUCT_ND_OPT_HDR
-struct nd_opt_hdr {
+PACKED(struct nd_opt_hdr {
 	uint8_t nd_opt_type;
 	uint8_t nd_opt_len;
-};
+});
 #endif
 
 STATIC_ASSERT(sizeof(struct nd_opt_hdr) == 2, "nd_opt_hdr has incorrect size");

--- a/src/ipv6.h
+++ b/src/ipv6.h
@@ -60,6 +60,8 @@ struct ip6_hdr {
 #define ip6_hops ip6_ctlun.ip6_un1.ip6_un1_hlim
 #endif
 
+STATIC_ASSERT(sizeof(struct ip6_hdr) == 40, "ip6_hdr has incorrect size");
+
 #ifndef HAVE_STRUCT_ICMP6_HDR
 struct icmp6_hdr {
 	uint8_t icmp6_type;
@@ -86,6 +88,8 @@ struct icmp6_hdr {
 #define icmp6_mtu icmp6_data32[0]
 #endif
 
+STATIC_ASSERT(sizeof(struct icmp6_hdr) == 8, "icmp6_hdr has incorrect size");
+
 #ifndef HAVE_STRUCT_ND_NEIGHBOR_SOLICIT
 struct nd_neighbor_solicit {
 	struct icmp6_hdr nd_ns_hdr;
@@ -99,11 +103,15 @@ struct nd_neighbor_solicit {
 #define nd_ns_reserved nd_ns_hdr.icmp6_data32[0]
 #endif
 
+STATIC_ASSERT(sizeof(struct nd_neighbor_solicit) == 24, "nd_neighbor_solicit has incorrect size");
+
 #ifndef HAVE_STRUCT_ND_OPT_HDR
 struct nd_opt_hdr {
 	uint8_t nd_opt_type;
 	uint8_t nd_opt_len;
 };
 #endif
+
+STATIC_ASSERT(sizeof(struct nd_opt_hdr) == 2, "nd_opt_hdr has incorrect size");
 
 #endif

--- a/src/keys.c
+++ b/src/keys.c
@@ -79,7 +79,7 @@ bool disable_old_keys(const char *filename, const char *what) {
 			return false;
 		}
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 		// We cannot atomically replace files on Windows.
 		char bakfile[PATH_MAX] = "";
 		snprintf(bakfile, sizeof(bakfile), "%s.bak", filename);
@@ -95,7 +95,7 @@ bool disable_old_keys(const char *filename, const char *what) {
 			return false;
 		}
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 		unlink(bakfile);
 #endif
 		fprintf(stderr, "Warning: old key(s) found and disabled.\n");
@@ -128,7 +128,7 @@ ecdsa_t *read_ecdsa_private_key(splay_tree_t *config_tree, char **keyfile) {
 		return NULL;
 	}
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	struct stat s;
 
 	if(fstat(fileno(fp), &s)) {
@@ -262,7 +262,7 @@ rsa_t *read_rsa_private_key(splay_tree_t *config_tree, char **keyfile) {
 		return NULL;
 	}
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	struct stat s;
 
 	if(fstat(fileno(fp), &s)) {

--- a/src/list.h
+++ b/src/list.h
@@ -45,7 +45,7 @@ typedef struct list_t {
 
 /* (De)constructors */
 
-extern list_t *list_alloc(list_action_t delete) __attribute__((__malloc__));
+extern list_t *list_alloc(list_action_t delete) ATTR_MALLOC;
 extern void list_free(list_t *list);
 extern list_node_t *list_alloc_node(void);
 extern void list_free_node(list_t *list, list_node_t *node);

--- a/src/logger.c
+++ b/src/logger.c
@@ -34,7 +34,7 @@ debug_t debug_level = DEBUG_NOTHING;
 static logmode_t logmode = LOGMODE_STDERR;
 static pid_t logpid;
 static FILE *logfile = NULL;
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 static HANDLE loghandle = NULL;
 #endif
 static const char *logident = NULL;
@@ -72,7 +72,7 @@ static void real_logger(debug_t level, int priority, const char *message) {
 			break;
 
 		case LOGMODE_SYSLOG:
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 			{
 				const char *messages[] = {message};
 				ReportEvent(loghandle, priority, 0, 0, NULL, 1, 0, messages, NULL);
@@ -195,7 +195,7 @@ void openlogger(const char *ident, logmode_t mode) {
 		break;
 
 	case LOGMODE_SYSLOG:
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 		loghandle = RegisterEventSource(NULL, logident);
 
 		if(!loghandle) {
@@ -248,7 +248,7 @@ void closelogger(void) {
 		break;
 
 	case LOGMODE_SYSLOG:
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 		DeregisterEventSource(loghandle);
 		break;
 #else

--- a/src/logger.h
+++ b/src/logger.h
@@ -44,7 +44,7 @@ typedef enum logmode_t {
 	LOGMODE_SYSLOG
 } logmode_t;
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 #define LOG_EMERG EVENTLOG_ERROR_TYPE
 #define LOG_ALERT EVENTLOG_ERROR_TYPE
 #define LOG_CRIT EVENTLOG_ERROR_TYPE

--- a/src/logger.h
+++ b/src/logger.h
@@ -21,6 +21,8 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "system.h"
+
 typedef enum debug_t {
 	DEBUG_UNSET = -1,               /* Used by tinc as the default debug level. */
 	DEBUG_NOTHING = 0,              /* Quiet mode, only show starting/stopping of the daemon */

--- a/src/logger.h
+++ b/src/logger.h
@@ -75,7 +75,7 @@ extern bool logcontrol;
 extern int umbilical;
 extern void openlogger(const char *ident, logmode_t mode);
 extern void reopenlogger(void);
-extern void logger(debug_t level, int priority, const char *format, ...) __attribute__((__format__(printf, 3, 4)));
+extern void logger(debug_t level, int priority, const char *format, ...) ATTR_FORMAT(printf, 3, 4);
 extern void closelogger(void);
 
 #endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,8 +11,11 @@ cdata.set_quoted('SBINDIR', dir_sbin)
 
 cdata.set('HAVE_' + os_name.to_upper(), 1)
 
-foreach attr : ['malloc', 'nonnull', 'warn_unused_result']
-  cc.has_function_attribute(attr)
+foreach attr : ['malloc', 'nonnull', 'warn_unused_result', 'packed']
+  if cc.has_function_attribute(attr)
+    cdata.set('HAVE_ATTR_' + attr.to_upper(), 1,
+              description: '__attribute__(@0@)'.format(attr))
+  endif
 endforeach
 
 if cc.compiles('''

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ foreach attr : ['malloc', 'nonnull', 'warn_unused_result']
 endforeach
 
 check_headers = [
+  'alloca.h',
   'arpa/inet.h',
   'arpa/nameser.h',
   'dirent.h',
@@ -48,7 +49,9 @@ check_headers = [
   'sys/types.h',
   'sys/wait.h',
   'syslog.h',
+  'string.h',
   'termios.h',
+  'unistd.h',
 ]
 
 # 'struct msghdr' misses some required fields

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,10 +11,10 @@ cdata.set_quoted('SBINDIR', dir_sbin)
 
 cdata.set('HAVE_' + os_name.to_upper(), 1)
 
-foreach attr : ['malloc', 'nonnull', 'warn_unused_result', 'packed']
+foreach attr : ['malloc', 'nonnull', 'warn_unused_result', 'packed', 'format']
   if cc.has_function_attribute(attr)
     cdata.set('HAVE_ATTR_' + attr.to_upper(), 1,
-              description: '__attribute__(@0@)'.format(attr))
+              description: '__attribute__((__@0@__))'.format(attr))
   endif
 endforeach
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -159,7 +159,7 @@ elif os_name.endswith('bsd') or os_name in ['dragonfly', 'darwin']
 elif os_name == 'sunos'
   subdir('solaris')
 elif os_name == 'windows'
-  subdir('mingw')
+  subdir('windows')
 endif
 
 foreach h : check_headers
@@ -228,9 +228,7 @@ if not opt_miniupnpc.disabled()
   endif
 endif
 
-if opt_curses.auto() and os_name == 'windows'
-  message('curses does not link under MinGW')
-else
+if not opt_curses.disabled()
   # The meta-dependency covers more alternatives, but is only available in 0.54+
   curses_name = meson_version.version_compare('>=0.54') ? 'curses' : 'ncurses'
   dep_curses = dependency(curses_name, required: opt_curses, static: static)
@@ -242,7 +240,7 @@ endif
 
 # Some distributions do not supply pkg-config files for readline
 if opt_readline.auto() and os_name == 'windows'
-  message('readline does not link under MinGW')
+  message('readline not available on Windows')
 else
   dep_readline = dependency('readline', required: opt_readline, static: static)
   if not dep_readline.found()

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,14 @@ foreach attr : ['malloc', 'nonnull', 'warn_unused_result']
   cc.has_function_attribute(attr)
 endforeach
 
+if cc.compiles('''
+    _Static_assert(1, "ok");
+    int main(void) { return 0; }
+''')
+  cdata.set('HAVE_STATIC_ASSERT', 1,
+            description: 'C11 _Static_assert()')
+endif
+
 check_headers = [
   'alloca.h',
   'arpa/inet.h',

--- a/src/mingw/meson.build
+++ b/src/mingw/meson.build
@@ -1,11 +1,17 @@
-win_common_libs = ['ws2_32', 'iphlpapi', 'winpthread']
+check_headers += 'w32api.h'
 
-if opt_harden
+win_common_libs = ['ws2_32', 'iphlpapi', 'threads']
+
+if opt_harden and cc_name != 'msvc'
   win_common_libs += 'ssp'
 endif
 
 foreach libname : win_common_libs
-  deps_common += cc.find_library(libname)
+  dep = dependency(libname, required: false)
+  if not dep.found()
+    dep = cc.find_library(libname)
+  endif
+  deps_common += dep
 endforeach
 
 src_tincd += files('device.c')

--- a/src/names.c
+++ b/src/names.c
@@ -39,7 +39,7 @@ char *program_name = NULL;
   Set all files and paths according to netname
 */
 void make_names(bool daemon) {
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	HKEY key;
 	char installdir[1024] = "";
 	DWORD len = sizeof(installdir);
@@ -58,7 +58,7 @@ void make_names(bool daemon) {
 		identname = xstrdup("tinc");
 	}
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 
 	if(!RegOpenKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\tinc", 0, KEY_READ, &key)) {
 		if(!RegQueryValueEx(key, NULL, 0, 0, (LPBYTE)installdir, &len)) {
@@ -94,7 +94,7 @@ void make_names(bool daemon) {
 		}
 	}
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	(void)daemon;
 
 	if(!logfilename) {

--- a/src/net.c
+++ b/src/net.c
@@ -269,9 +269,7 @@ static void periodic_handler(void *data) {
 
 	if(contradicting_del_edge > 100 && contradicting_add_edge > 100) {
 		logger(DEBUG_ALWAYS, LOG_WARNING, "Possible node with same Name as us! Sleeping %d seconds.", sleeptime);
-		nanosleep(&(struct timespec) {
-			sleeptime, 0
-		}, NULL);
+		sleep_millis(sleeptime * 1000);
 		sleeptime *= 2;
 
 		if(sleeptime < 0) {

--- a/src/net.c
+++ b/src/net.c
@@ -160,7 +160,7 @@ void terminate_connection(connection_t *c, bool report) {
 		do_outgoing_connection(outgoing);
 	}
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	/* Clean up dead proxy processes */
 
 	while(waitpid(-1, NULL, WNOHANG) > 0);
@@ -308,7 +308,7 @@ void handle_meta_connection_data(connection_t *c) {
 	}
 }
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 static void sigterm_handler(void *data) {
 	logger(DEBUG_ALWAYS, LOG_NOTICE, "Got %s signal", strsignal(((signal_t *)data)->signum));
 	event_exit();
@@ -487,7 +487,7 @@ int main_loop(void) {
 		0, 0
 	});
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	signal_t sighup = {0};
 	signal_t sigterm = {0};
 	signal_t sigquit = {0};
@@ -506,7 +506,7 @@ int main_loop(void) {
 		return 1;
 	}
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	signal_del(&sighup);
 	signal_del(&sigterm);
 	signal_del(&sigquit);

--- a/src/net.h
+++ b/src/net.h
@@ -215,7 +215,7 @@ extern void load_all_nodes(void);
 extern void try_tx(struct node_t *n, bool mtu);
 extern void tarpit(int fd);
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 #define closesocket(s) close(s)
 #endif
 

--- a/src/net_socket.c
+++ b/src/net_socket.c
@@ -47,7 +47,7 @@ int fwmark;
 
 listen_socket_t listen_socket[MAXSOCKETS];
 int listen_sockets;
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 io_t unix_socket;
 #endif
 
@@ -425,7 +425,7 @@ void finish_connecting(connection_t *c) {
 }
 
 static void do_outgoing_pipe(connection_t *c, const char *command) {
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	int fd[2];
 
 	if(socketpair(AF_UNIX, SOCK_STREAM, 0, fd)) {
@@ -783,7 +783,7 @@ void handle_new_meta_connection(void *data, int flags) {
 	c->allow_request = ID;
 }
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 /*
   accept a new UNIX socket connection
 */

--- a/src/netutl.h
+++ b/src/netutl.h
@@ -25,10 +25,10 @@
 
 extern bool hostnames;
 
-extern struct addrinfo *str2addrinfo(const char *address, const char *service, int socktype) __attribute__((__malloc__));
+extern struct addrinfo *str2addrinfo(const char *address, const char *service, int socktype) ATTR_MALLOC;
 extern sockaddr_t str2sockaddr(const char *address, const char *port);
 extern void sockaddr2str(const sockaddr_t *sa, char **address, char **port);
-extern char *sockaddr2hostname(const sockaddr_t *sa) __attribute__((__malloc__));
+extern char *sockaddr2hostname(const sockaddr_t *sa) ATTR_MALLOC;
 extern int sockaddrcmp(const sockaddr_t *a, const sockaddr_t *b);
 extern int sockaddrcmp_noport(const sockaddr_t *a, const sockaddr_t *b);
 extern void sockaddrunmap(sockaddr_t *sa);

--- a/src/node.h
+++ b/src/node.h
@@ -120,7 +120,7 @@ extern struct node_t *myself;
 extern splay_tree_t node_tree;
 
 extern void exit_nodes(void);
-extern node_t *new_node(void) __attribute__((__malloc__));
+extern node_t *new_node(void) ATTR_MALLOC;
 extern void free_node(node_t *n);
 extern void node_add(node_t *n);
 extern void node_del(node_t *n);

--- a/src/nolegacy/crypto.c
+++ b/src/nolegacy/crypto.c
@@ -21,7 +21,7 @@
 
 #include "../crypto.h"
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 
 static int random_fd = -1;
 

--- a/src/openssl/crypto.c
+++ b/src/openssl/crypto.c
@@ -24,7 +24,7 @@
 
 #include "../crypto.h"
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 
 static int random_fd = -1;
 

--- a/src/openssl/digest.c
+++ b/src/openssl/digest.c
@@ -138,7 +138,7 @@ void digest_close(digest_t *digest) {
 
 bool digest_create(digest_t *digest, const void *indata, size_t inlen, void *outdata) {
 	size_t len = EVP_MD_size(digest->digest);
-	unsigned char tmpdata[len];
+	unsigned char *tmpdata = alloca(len);
 
 	if(digest->hmac_ctx) {
 		bool ok;
@@ -152,7 +152,7 @@ bool digest_create(digest_t *digest, const void *indata, size_t inlen, void *out
 
 		ok = mac_ctx
 		     && EVP_MAC_update(mac_ctx, indata, inlen)
-		     && EVP_MAC_final(mac_ctx, tmpdata, NULL, sizeof(tmpdata));
+		     && EVP_MAC_final(mac_ctx, tmpdata, NULL, len);
 
 		EVP_MAC_CTX_free(mac_ctx);
 #endif
@@ -184,7 +184,7 @@ bool digest_create(digest_t *digest, const void *indata, size_t inlen, void *out
 
 bool digest_verify(digest_t *digest, const void *indata, size_t inlen, const void *cmpdata) {
 	size_t len = digest->maclength;
-	unsigned char outdata[len];
+	unsigned char *outdata = alloca(len);
 
 	return digest_create(digest, indata, inlen, outdata) && !memcmp(cmpdata, outdata, digest->maclength);
 }

--- a/src/openssl/prf.c
+++ b/src/openssl/prf.c
@@ -48,11 +48,11 @@ static bool prf_xor(int nid, const uint8_t *secret, size_t secretlen, uint8_t *s
 	   It consists of the previous HMAC result plus the seed.
 	 */
 
-	char data[len + seedlen];
+	char *data = alloca(len + seedlen);
 	memset(data, 0, len);
 	memcpy(data + len, seed, seedlen);
 
-	uint8_t hash[len];
+	uint8_t *hash = alloca(len);
 
 	while(outlen > 0) {
 		/* Inner HMAC */

--- a/src/prf.h
+++ b/src/prf.h
@@ -22,6 +22,6 @@
 
 #include "system.h"
 
-extern bool prf(const uint8_t *secret, size_t secretlen, uint8_t *seed, size_t seedlen, uint8_t *out, size_t outlen) __attribute__((__warn_unused_result__));
+extern bool prf(const uint8_t *secret, size_t secretlen, uint8_t *seed, size_t seedlen, uint8_t *out, size_t outlen) ATTR_WARN_UNUSED;
 
 #endif

--- a/src/process.c
+++ b/src/process.c
@@ -25,7 +25,7 @@
 #include "process.h"
 #include "version.h"
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 #include "utils.h"
 #endif
 
@@ -42,7 +42,7 @@ bool use_logfile = false;
 
 /* Some functions the less gifted operating systems might lack... */
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 static SC_HANDLE manager = NULL;
 static SC_HANDLE service = NULL;
 static SERVICE_STATUS status = {0};
@@ -202,7 +202,7 @@ bool init_service(void) {
 bool detach(void) {
 	logmode_t logmode;
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	signal(SIGPIPE, SIG_IGN);
 	signal(SIGUSR1, SIG_IGN);
 	signal(SIGUSR2, SIG_IGN);
@@ -212,7 +212,7 @@ bool detach(void) {
 #endif
 
 	if(do_detach) {
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 
 		if(daemon(1, 0)) {
 			logger(DEBUG_ALWAYS, LOG_ERR, "Couldn't detach from terminal: %s", strerror(errno));

--- a/src/process.h
+++ b/src/process.h
@@ -29,7 +29,7 @@ extern bool use_syslog;
 
 extern bool detach(void);
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 #include "event.h"
 
 extern io_t stop_io;

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -118,10 +118,11 @@ void forward_request(connection_t *from, const char *request) {
 
 	// Create a temporary newline-terminated copy of the request
 	size_t len = strlen(request);
-	char tmp[len + 1];
+	const size_t tmplen = len + 1;
+	char *tmp = alloca(tmplen);
 	memcpy(tmp, request, len);
 	tmp[len] = '\n';
-	broadcast_meta(from, tmp, sizeof(tmp));
+	broadcast_meta(from, tmp, tmplen);
 }
 
 bool receive_request(connection_t *c, const char *request) {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -80,7 +80,7 @@ extern ecdsa_t *invitation_key;
 
 /* Basic functions */
 
-extern bool send_request(struct connection_t *c, const char *format, ...) __attribute__((__format__(printf, 2, 3)));
+extern bool send_request(struct connection_t *c, const char *format, ...) ATTR_FORMAT(printf, 2, 3);
 extern void forward_request(struct connection_t *c, const char *request);
 extern bool receive_request(struct connection_t *c, const char *request);
 

--- a/src/rsa.h
+++ b/src/rsa.h
@@ -27,12 +27,12 @@ typedef struct rsa rsa_t;
 #endif
 
 extern void rsa_free(rsa_t *rsa);
-extern rsa_t *rsa_set_hex_public_key(const char *n, const char *e) __attribute__((__malloc__));
-extern rsa_t *rsa_set_hex_private_key(const char *n, const char *e, const char *d) __attribute__((__malloc__));
-extern rsa_t *rsa_read_pem_public_key(FILE *fp) __attribute__((__malloc__));
-extern rsa_t *rsa_read_pem_private_key(FILE *fp) __attribute__((__malloc__));
+extern rsa_t *rsa_set_hex_public_key(const char *n, const char *e) ATTR_MALLOC;
+extern rsa_t *rsa_set_hex_private_key(const char *n, const char *e, const char *d) ATTR_MALLOC;
+extern rsa_t *rsa_read_pem_public_key(FILE *fp) ATTR_MALLOC;
+extern rsa_t *rsa_read_pem_private_key(FILE *fp) ATTR_MALLOC;
 extern size_t rsa_size(const rsa_t *rsa);
-extern bool rsa_public_encrypt(rsa_t *rsa, const void *in, size_t len, void *out) __attribute__((__warn_unused_result__));
-extern bool rsa_private_decrypt(rsa_t *rsa, const void *in, size_t len, void *out) __attribute__((__warn_unused_result__));
+extern bool rsa_public_encrypt(rsa_t *rsa, const void *in, size_t len, void *out) ATTR_WARN_UNUSED;
+extern bool rsa_private_decrypt(rsa_t *rsa, const void *in, size_t len, void *out) ATTR_WARN_UNUSED;
 
 #endif

--- a/src/rsagen.h
+++ b/src/rsagen.h
@@ -22,8 +22,8 @@
 
 #include "rsa.h"
 
-extern rsa_t *rsa_generate(size_t bits, unsigned long exponent) __attribute__((__malloc__));
-extern bool rsa_write_pem_public_key(rsa_t *rsa, FILE *fp) __attribute__((__warn_unused_result__));
-extern bool rsa_write_pem_private_key(rsa_t *rsa, FILE *fp) __attribute__((__warn_unused_result__));
+extern rsa_t *rsa_generate(size_t bits, unsigned long exponent) ATTR_MALLOC;
+extern bool rsa_write_pem_public_key(rsa_t *rsa, FILE *fp) ATTR_WARN_UNUSED;
+extern bool rsa_write_pem_private_key(rsa_t *rsa, FILE *fp) ATTR_WARN_UNUSED;
 
 #endif

--- a/src/script.c
+++ b/src/script.c
@@ -37,7 +37,7 @@ static void unputenv(const char *p) {
 
 	ptrdiff_t len = e - p;
 #ifndef HAVE_UNSETENV
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	// Windows requires putenv("FOO=") to unset %FOO%
 	len++;
 #endif
@@ -148,7 +148,7 @@ bool execute_script(const char *name, environment_t *env) {
 
 	/* First check if there is a script */
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 
 	if(!*scriptextension) {
 		const char *pathext = getenv("PATHEXT");

--- a/src/script.c
+++ b/src/script.c
@@ -42,7 +42,7 @@ static void unputenv(const char *p) {
 	len++;
 #endif
 #endif
-	char var[len + 1];
+	char *var = alloca(len + 1);
 	strncpy(var, p, len);
 	var[len] = 0;
 #ifdef HAVE_UNSETENV
@@ -159,9 +159,11 @@ bool execute_script(const char *name, environment_t *env) {
 
 		size_t pathlen = strlen(pathext);
 		size_t scriptlen = strlen(scriptname);
-		char fullname[scriptlen + pathlen + 1];
+
+		const size_t fullnamelen = scriptlen + pathlen + 1;
+		char *fullname = alloca(fullnamelen);
 		char *ext = fullname + scriptlen;
-		strncpy(fullname, scriptname, sizeof(fullname));
+		strncpy(fullname, scriptname, fullnamelen);
 
 		const char *p = pathext;
 		bool found = false;

--- a/src/splay_tree.h
+++ b/src/splay_tree.h
@@ -63,10 +63,10 @@ typedef struct splay_tree_t {
 
 /* (De)constructors */
 
-extern splay_tree_t *splay_alloc_tree(splay_compare_t compare, splay_action_t delete) __attribute__((__malloc__));
+extern splay_tree_t *splay_alloc_tree(splay_compare_t compare, splay_action_t delete) ATTR_MALLOC;
 extern void splay_free_tree(splay_tree_t *tree);
 
-extern splay_node_t *splay_alloc_node(void) __attribute__((__malloc__));
+extern splay_node_t *splay_alloc_node(void) ATTR_MALLOC;
 extern void splay_free_node(splay_tree_t *tree, splay_node_t *node);
 
 /* Insertion and deletion */

--- a/src/sptps_test.c
+++ b/src/sptps_test.c
@@ -25,7 +25,7 @@
 
 #include <getopt.h>
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 #include <pthread.h>
 #endif
 
@@ -37,7 +37,7 @@
 #include "utils.h"
 #include "names.h"
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 #define closesocket(s) close(s)
 #endif
 
@@ -160,7 +160,7 @@ static void usage(void) {
 	fprintf(stderr, message, program_name);
 }
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 
 int stdin_sock_fd = -1;
 
@@ -308,7 +308,7 @@ server_err:
 	return -1;
 }
 
-#endif // HAVE_MINGW
+#endif // HAVE_WINDOWS
 
 int main(int argc, char *argv[]) {
 	program_name = argv[0];
@@ -428,7 +428,7 @@ int main(int argc, char *argv[]) {
 
 #endif
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	static struct WSAData wsa_state;
 
 	if(WSAStartup(MAKEWORD(2, 2), &wsa_state)) {
@@ -566,7 +566,7 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 
 	if(!readonly) {
 		in = start_input_reader();
@@ -607,7 +607,7 @@ int main(int argc, char *argv[]) {
 		}
 
 		if(FD_ISSET(in, &fds)) {
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 			ssize_t len = recv(in, buf, readsize, 0);
 #else
 			ssize_t len = read(in, buf, readsize);
@@ -621,7 +621,7 @@ int main(int argc, char *argv[]) {
 			}
 
 			if(len == 0) {
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 				shutdown(in, SD_SEND);
 				closesocket(in);
 #endif

--- a/src/subnet.h
+++ b/src/subnet.h
@@ -65,7 +65,7 @@ typedef struct subnet_t {
 extern splay_tree_t subnet_tree;
 
 extern int subnet_compare(const struct subnet_t *a, const struct subnet_t *b);
-extern subnet_t *new_subnet(void) __attribute__((__malloc__));
+extern subnet_t *new_subnet(void) ATTR_MALLOC;
 extern void free_subnet(subnet_t *subnet);
 extern void init_subnets(void);
 extern void exit_subnets(void);

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -281,7 +281,7 @@ ask_filename:
 		}
 	}
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 
 	if(filename[0] != '\\' && filename[0] != '/' && !strchr(filename, ':')) {
 #else
@@ -651,7 +651,7 @@ static bool stop_tincd(void) {
 	return true;
 }
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 static bool remove_service(void) {
 	SC_HANDLE manager = NULL;
 	SC_HANDLE service = NULL;
@@ -748,7 +748,7 @@ bool connect_tincd(bool verbose) {
 
 	fclose(f);
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 
 	if((pid == 0) || (kill(pid, 0) && (errno == ESRCH))) {
 		fprintf(stderr, "Could not find tincd running at pid %d\n", pid);
@@ -886,7 +886,7 @@ static int cmd_start(int argc, char *argv[]) {
 	char *c;
 	char *slash = strrchr(program_name, '/');
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 
 	if((c = strrchr(program_name, '\\')) > slash) {
 		slash = c;
@@ -904,7 +904,7 @@ static int cmd_start(int argc, char *argv[]) {
 	char **nargv = xzalloc((optind + argc) * sizeof(*nargv));
 
 	char *arg0 = c;
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	/*
 	   Windows has no real concept of an "argv array". A command line is just one string.
 	   The CRT of the new process will decode the command line string to generate argv before calling main(), and (by convention)
@@ -925,7 +925,7 @@ static int cmd_start(int argc, char *argv[]) {
 		nargv[nargc++] = argv[i];
 	}
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	int status = spawnvp(_P_WAIT, c, nargv);
 
 	free(nargv);
@@ -1024,7 +1024,7 @@ static int cmd_stop(int argc, char *argv[]) {
 		return 1;
 	}
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	return remove_service() ? EXIT_SUCCESS : EXIT_FAILURE;
 #else
 
@@ -2058,7 +2058,7 @@ static int cmd_config(int argc, char *argv[]) {
 	}
 
 	// Replace the configuration file with the new one
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 
 	if(remove(filename)) {
 		fprintf(stderr, "Error replacing file %s: %s\n", filename, strerror(errno));
@@ -2234,7 +2234,7 @@ static int cmd_init(int argc, char *argv[]) {
 
 	check_port(name);
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	char filename[PATH_MAX];
 	snprintf(filename, sizeof(filename), "%s" SLASH "tinc-up", confbase);
 
@@ -2396,7 +2396,7 @@ static int cmd_edit(int argc, char *argv[]) {
 	}
 
 	char *command;
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	const char *editor = getenv("VISUAL");
 
 	if(!editor) {
@@ -3290,7 +3290,7 @@ int main(int argc, char *argv[]) {
 		return 0;
 	}
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	static struct WSAData wsa_state;
 
 	if(WSAStartup(MAKEWORD(2, 2), &wsa_state)) {

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -19,8 +19,6 @@
 
 #include "system.h"
 
-#include <getopt.h>
-
 #ifdef HAVE_READLINE
 #include "readline/readline.h"
 #include "readline/history.h"

--- a/src/tincd.c
+++ b/src/tincd.c
@@ -37,7 +37,7 @@
 #include <lz4.h>
 #endif
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 #include <pwd.h>
 #include <grp.h>
 #include <time.h>
@@ -66,7 +66,7 @@ static bool show_version = false;
 static bool do_mlock = false;
 #endif
 
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 /* If nonzero, chroot to netdir after startup. */
 static bool do_chroot = false;
 
@@ -96,7 +96,7 @@ static struct option const long_options[] = {
 	{NULL, 0, NULL, 0}
 };
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 static struct WSAData wsa_state;
 int main2(int argc, char **argv);
 #endif
@@ -121,7 +121,7 @@ static void usage(bool status) {
 		        "      --pidfile=FILENAME        Write PID and control socket cookie to FILENAME.\n"
 		        "      --bypass-security         Disables meta protocol security, for debugging.\n"
 		        "  -o, --option[HOST.]KEY=VALUE  Set global/host configuration value.\n"
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 		        "  -R, --chroot                  chroot to NET dir at startup.\n"
 		        "  -U, --user=USER               setuid to given USER at startup.\n"
 #endif
@@ -196,7 +196,7 @@ static bool parse_options(int argc, char **argv) {
 			list_insert_tail(&cmdline_conf, cfg);
 			break;
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 
 		case 'R':
 		case 'U':
@@ -289,7 +289,7 @@ exit_fail:
 }
 
 static bool drop_privs(void) {
-#ifndef HAVE_MINGW
+#ifndef HAVE_WINDOWS
 	uid_t uid = 0;
 
 	if(switchuser) {
@@ -342,7 +342,7 @@ static bool drop_privs(void) {
 	return true;
 }
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 # define setpriority(level) !SetPriorityClass(GetCurrentProcess(), (level))
 
 static void stop_handler(void *data, int flags) {
@@ -445,7 +445,7 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 
 	if(WSAStartup(MAKEWORD(2, 2), &wsa_state)) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "System call `%s' failed: %s", "WSAStartup", winerror(GetLastError()));
@@ -511,7 +511,7 @@ int main(int argc, char **argv) {
 
 #endif
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	io_add_event(&stop_io, stop_handler, NULL, WSACreateEvent());
 
 	if(stop_io.event == FALSE) {

--- a/src/upnp.c
+++ b/src/upnp.c
@@ -159,9 +159,7 @@ static void *upnp_thread(void *data) {
 		time_t now = time(NULL);
 
 		if(now < refresh_time) {
-			nanosleep(&(struct timespec) {
-				refresh_time - now, 0
-			}, NULL);
+			sleep_millis((refresh_time - now) * 1000);
 		}
 	}
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -176,7 +176,7 @@ size_t b64encode_tinc_urlsafe(const void *src, char *dst, size_t length) {
 	return b64encode_tinc_internal(src, dst, length, base64_urlsafe);
 }
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 const char *winerror(int err) {
 	static char buf[1024], *ptr;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -34,7 +34,7 @@ extern size_t b64encode_tinc(const void *src, char *dst, size_t length);
 extern size_t b64encode_tinc_urlsafe(const void *src, char *dst, size_t length);
 extern size_t b64decode_tinc(const char *src, void *dst, size_t length);
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 extern const char *winerror(int);
 #define strerror(x) ((x)>0?strerror(x):winerror(GetLastError()))
 #define sockerrno WSAGetLastError()

--- a/src/windows/common.h
+++ b/src/windows/common.h
@@ -1,5 +1,5 @@
-#ifndef TINC_MINGW_COMMON_H
-#define TINC_MINGW_COMMON_H
+#ifndef TINC_WINDOWS_COMMON_H
+#define TINC_WINDOWS_COMMON_H
 
 /*
  *  TAP-Win32 -- A kernel driver to provide virtual tap device functionality

--- a/src/windows/device.c
+++ b/src/windows/device.c
@@ -1,5 +1,5 @@
 /*
-    device.c -- Interaction with Windows tap driver in a MinGW environment
+    device.c -- Interaction with the TAP-Windows driver
     Copyright (C) 2002-2005 Ivo Timmermans,
                   2002-2022 Guus Sliepen <guus@tinc-vpn.org>
 

--- a/src/windows/meson.build
+++ b/src/windows/meson.build
@@ -16,5 +16,3 @@ endforeach
 
 src_tincd += files('device.c')
 
-cdata.set('HAVE_MINGW', 1)
-

--- a/src/xalloc.h
+++ b/src/xalloc.h
@@ -23,7 +23,7 @@
 
 #include "system.h"
 
-static inline void *xmalloc(size_t n) __attribute__((__malloc__));
+static inline void *xmalloc(size_t n) ATTR_MALLOC;
 static inline void *xmalloc(size_t n) {
 	void *p = malloc(n);
 
@@ -34,7 +34,7 @@ static inline void *xmalloc(size_t n) {
 	return p;
 }
 
-static inline void *xzalloc(size_t n) __attribute__((__malloc__));
+static inline void *xzalloc(size_t n) ATTR_MALLOC;
 static inline void *xzalloc(size_t n) {
 	void *p = calloc(1, n);
 
@@ -55,7 +55,7 @@ static inline void *xrealloc(void *p, size_t n) {
 	return p;
 }
 
-static inline char *xstrdup(const char *s) __attribute__((__malloc__)) __attribute((__nonnull__));
+static inline char *xstrdup(const char *s) ATTR_MALLOC ATTR_NONNULL;
 static inline char *xstrdup(const char *s) {
 	char *p = strdup(s);
 
@@ -87,7 +87,7 @@ static inline int xvasprintf(char **strp, const char *fmt, va_list ap) {
 	return result;
 }
 
-static inline int xasprintf(char **strp, const char *fmt, ...) __attribute__((__format__(printf, 2, 3)));
+static inline int xasprintf(char **strp, const char *fmt, ...) ATTR_FORMAT(printf, 2, 3);
 static inline int xasprintf(char **strp, const char *fmt, ...) {
 	va_list ap;
 	va_start(ap, fmt);

--- a/src/xalloc.h
+++ b/src/xalloc.h
@@ -67,7 +67,7 @@ static inline char *xstrdup(const char *s) {
 }
 
 static inline int xvasprintf(char **strp, const char *fmt, va_list ap) {
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	char buf[1024];
 	int result = vsnprintf(buf, sizeof(buf), fmt, ap);
 

--- a/test/integration/splice.c
+++ b/test/integration/splice.c
@@ -19,7 +19,7 @@
 
 #include "../../src/system.h"
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 static const char *winerror(int err) {
 	static char buf[1024], *ptr;
 
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
 		protocol = "17.7";
 	}
 
-#ifdef HAVE_MINGW
+#ifdef HAVE_WINDOWS
 	static struct WSAData wsa_state;
 
 	if(WSAStartup(MAKEWORD(2, 2), &wsa_state)) {

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,3 +1,6 @@
-subdir('integration')
+if cc_name != 'msvc'
+  subdir('integration')
+endif
+
 subdir('unit')
 

--- a/version.py
+++ b/version.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from sys import argv, exit
+import subprocess as subp
+
+prefix = "release-"
+
+cmd = [
+    "git",
+    "describe",
+    "--always",
+    "--tags",
+    "--match=" + prefix + "*",
+]
+
+if "short" in argv:
+    cmd.append("--abbrev=0")
+
+result = subp.run(cmd, stdout=subp.PIPE, encoding="utf-8")
+version = result.stdout
+
+if not result.returncode and version and version.startswith(prefix):
+    version = version[len(prefix):].strip()
+
+print(version if version else "unknown", end="")
+exit(not version)


### PR DESCRIPTION
Integration tests are disabled because of their dependence on Unix-like environment.

~~Project version will either have to be updated manually from now on, or you could start using tags without the `release-` prefix (then let me know and I'll update `meson.build`). We need`'release-1.18'.replace('release-', '')` to work, which only became available [in 0.58](https://mesonbuild.com/Syntax.html#replace), and you can't check what OS you're building for before `project()` is finished, so there's no way to ship an alternative script for Windows.~~

All compiler attributes are ignored for now, except for `packed`. I just realized we're checking for attribute support, but not doing anything with that information (same thing was happening with autotools). I think it's best to fix this in a separate PR.

---

mac had a random failure. NetBSD looks suspicious. I'll test it more locally.