### PR TITLE
CI: fix paths in Windows installer script for the dev release

### DIFF
--- a/.ci/package/win/installer.nsi
+++ b/.ci/package/win/installer.nsi
@@ -18,8 +18,8 @@ RequestExecutionLevel admin
 Section "Tinc"
   SetOutPath $INSTDIR
 
-  File ..\..\..\build\src\tinc.exe
-  File ..\..\..\build\src\tincd.exe
+  File ..\..\..\default\src\tinc.exe
+  File ..\..\..\default\src\tincd.exe
   File ..\..\..\wintap.exe
 
   CreateDirectory "$SMPROGRAMS\Tinc"


### PR DESCRIPTION

My bad. I forgot about the installer, since it only runs on pushes to the main branch.

I'll start always doing that with my "fork" to avoid this situation in the future.

https://github.com/hg/tinc/releases/tag/latest

The failure in static analysis job was entirely GitHub's fault; it happens relatively frequently.
