### PR TITLE
Reduce duplication in request handler tables

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -22,11 +22,14 @@
 */
 
 #include "ecdsa.h"
+#include "connection.h"
 
 /* Protocol version. Different major versions are incompatible. */
 
 #define PROT_MAJOR 17
-#define PROT_MINOR 7 /* Should not exceed 255! */
+#define PROT_MINOR 7
+
+STATIC_ASSERT(PROT_MINOR <= 255, "PROT_MINOR must not exceed 255");
 
 /* Silly Windows */
 
@@ -53,10 +56,17 @@ typedef enum request_t {
 	LAST                                            /* Guardian for the highest request number */
 } request_t;
 
+typedef bool (request_handler_t)(connection_t *c, const char *request);
+
 typedef struct past_request_t {
 	const char *request;
 	time_t firstseen;
 } past_request_t;
+
+typedef struct {
+	request_handler_t *const handler;
+	const char *name;
+} request_entry_t;
 
 extern bool tunnelserver;
 extern bool strictsubnets;
@@ -87,11 +97,12 @@ extern bool receive_request(struct connection_t *c, const char *request);
 extern void exit_requests(void);
 extern bool seen_request(const char *request);
 
+extern const request_entry_t *get_request_entry(request_t req);
+
 /* Requests */
 
 extern bool send_id(struct connection_t *c);
 extern bool send_metakey(struct connection_t *c);
-extern bool send_metakey_ec(struct connection_t *c);
 extern bool send_challenge(struct connection_t *c);
 extern bool send_chal_reply(struct connection_t *c);
 extern bool send_ack(struct connection_t *c);
@@ -112,27 +123,25 @@ extern bool send_mtu_info(struct node_t *from, struct node_t *to, int mtu);
 
 /* Request handlers  */
 
-extern bool id_h(struct connection_t *c, const char *request);
-extern bool metakey_h(struct connection_t *c, const char *request);
-extern bool challenge_h(struct connection_t *c, const char *request);
-extern bool chal_reply_h(struct connection_t *c, const char *request);
-extern bool ack_h(struct connection_t *c, const char *request);
-extern bool status_h(struct connection_t *c, const char *request);
-extern bool error_h(struct connection_t *c, const char *request);
-extern bool termreq_h(struct connection_t *c, const char *request);
-extern bool ping_h(struct connection_t *c, const char *request);
-extern bool pong_h(struct connection_t *c, const char *request);
-extern bool add_subnet_h(struct connection_t *c, const char *request);
-extern bool del_subnet_h(struct connection_t *c, const char *request);
-extern bool add_edge_h(struct connection_t *c, const char *request);
-extern bool del_edge_h(struct connection_t *c, const char *request);
-extern bool key_changed_h(struct connection_t *c, const char *request);
-extern bool req_key_h(struct connection_t *c, const char *request);
-extern bool ans_key_h(struct connection_t *c, const char *request);
-extern bool tcppacket_h(struct connection_t *c, const char *request);
-extern bool sptps_tcppacket_h(struct connection_t *c, const char *request);
-extern bool control_h(struct connection_t *c, const char *request);
-extern bool udp_info_h(struct connection_t *c, const char *request);
-extern bool mtu_info_h(struct connection_t *c, const char *request);
+extern request_handler_t id_h;
+extern request_handler_t metakey_h;
+extern request_handler_t challenge_h;
+extern request_handler_t chal_reply_h;
+extern request_handler_t ack_h;
+extern request_handler_t termreq_h;
+extern request_handler_t ping_h;
+extern request_handler_t pong_h;
+extern request_handler_t add_subnet_h;
+extern request_handler_t del_subnet_h;
+extern request_handler_t add_edge_h;
+extern request_handler_t del_edge_h;
+extern request_handler_t key_changed_h;
+extern request_handler_t req_key_h;
+extern request_handler_t ans_key_h;
+extern request_handler_t tcppacket_h;
+extern request_handler_t sptps_tcppacket_h;
+extern request_handler_t control_h;
+extern request_handler_t udp_info_h;
+extern request_handler_t mtu_info_h;
 
 #endif

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -27,6 +27,9 @@ tests = {
   'subnet': {
     'code': 'test_subnet.c',
   },
+  'protocol': {
+    'code': 'test_protocol.c',
+  },
   'splay_tree': {
     'code': 'test_splay_tree.c',
     'link': link_tinc,

--- a/test/unit/test_protocol.c
+++ b/test/unit/test_protocol.c
@@ -1,0 +1,27 @@
+#include "unittest.h"
+#include "../../src/protocol.h"
+
+static void test_get_invalid_request(void **state) {
+	(void)state;
+
+	assert_null(get_request_entry(ALL));
+	assert_null(get_request_entry(LAST));
+}
+
+static void test_get_valid_request_returns_nonnull(void **state) {
+	(void)state;
+
+	for(request_t req = ID; req < LAST; ++req) {
+		const request_entry_t *ent = get_request_entry(req);
+		assert_non_null(ent);
+		assert_non_null(ent->name);
+	}
+}
+
+int main(void) {
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_get_invalid_request),
+		cmocka_unit_test(test_get_valid_request_returns_nonnull),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION

A couple of small refactors. Nothing serious, just some things I noticed while getting acquainted with the codebase.

They're now closer together so there's less chance for messing up the order, and we always do bounds checks now (the table is hidden inside a function so you can't use it directly).
