### PR TITLE
Use struct for legacy proto fields in connection_t

### DIFF
--- a/src/cipher.h
+++ b/src/cipher.h
@@ -36,12 +36,10 @@
 #error Incorrect cryptographic library, please reconfigure.
 #endif
 
-typedef struct cipher cipher_t;
-
 extern cipher_t *cipher_alloc(void) ATTR_MALLOC;
 extern void cipher_free(cipher_t **cipher);
 extern bool cipher_open_by_name(cipher_t *cipher, const char *name);
-extern bool cipher_open_by_nid(cipher_t *cipher, int nid);
+extern bool cipher_open_by_nid(cipher_t *cipher, nid_t nid);
 extern void cipher_close(cipher_t *cipher);
 extern size_t cipher_keylength(const cipher_t *cipher);
 extern size_t cipher_blocksize(const cipher_t *cipher);
@@ -50,7 +48,7 @@ extern bool cipher_set_key(cipher_t *cipher, void *key, bool encrypt) ATTR_WARN_
 extern bool cipher_set_key_from_rsa(cipher_t *cipher, void *rsa, size_t len, bool encrypt) ATTR_WARN_UNUSED;
 extern bool cipher_encrypt(cipher_t *cipher, const void *indata, size_t inlen, void *outdata, size_t *outlen, bool oneshot) ATTR_WARN_UNUSED;
 extern bool cipher_decrypt(cipher_t *cipher, const void *indata, size_t inlen, void *outdata, size_t *outlen, bool oneshot) ATTR_WARN_UNUSED;
-extern int cipher_get_nid(const cipher_t *cipher);
+extern nid_t cipher_get_nid(const cipher_t *cipher);
 extern bool cipher_active(const cipher_t *cipher);
 
 #endif // DISABLE_LEGACY

--- a/src/compression.h
+++ b/src/compression.h
@@ -22,4 +22,6 @@ typedef enum compression_level_t {
 	COMPRESS_GUARD = INT_MAX, /* ensure that sizeof(compression_level_t) == sizeof(int) */
 } compression_level_t;
 
-#endif
+STATIC_ASSERT(sizeof(compression_level_t) == sizeof(int), "compression_level_t has invalid size");
+
+#endif // TINC_COMPRESSION_H

--- a/src/connection.c
+++ b/src/connection.c
@@ -57,17 +57,72 @@ connection_t *new_connection(void) {
 	return xzalloc(sizeof(connection_t));
 }
 
+#ifndef DISABLE_LEGACY
+bool init_crypto_by_nid(legacy_crypto_t *c, int cipher, int digest) {
+	if(!cipher_open_by_nid(&c->cipher, cipher)) {
+		return false;
+	}
+
+	if(!digest_open_by_nid(&c->digest, digest, DIGEST_ALGO_SIZE)) {
+		cipher_close(&c->cipher);
+		return false;
+	}
+
+	c->budget = cipher_budget(&c->cipher);
+	return true;
+}
+
+bool init_crypto_by_name(legacy_crypto_t *c, const char *cipher, const char *digest) {
+	if(!cipher_open_by_name(&c->cipher, cipher)) {
+		return false;
+	}
+
+	if(!digest_open_by_name(&c->digest, digest, DIGEST_ALGO_SIZE)) {
+		cipher_close(&c->cipher);
+		return false;
+	}
+
+	c->budget = cipher_budget(&c->cipher);
+	return true;
+}
+
+bool decrease_budget(legacy_crypto_t *c, size_t bytes) {
+	if(bytes > c->budget) {
+		return false;
+	} else {
+		c->budget -= bytes;
+		return true;
+	}
+}
+
+static void close_legacy_crypto(legacy_crypto_t *c) {
+	cipher_close(&c->cipher);
+	digest_close(&c->digest);
+}
+
+legacy_ctx_t *new_legacy_ctx(rsa_t *rsa) {
+	legacy_ctx_t *ctx = xzalloc(sizeof(legacy_ctx_t));
+	ctx->rsa = rsa;
+	return ctx;
+}
+
+void free_legacy_ctx(legacy_ctx_t *ctx) {
+	if(ctx) {
+		close_legacy_crypto(&ctx->in);
+		close_legacy_crypto(&ctx->out);
+		rsa_free(ctx->rsa);
+		free(ctx);
+	}
+}
+#endif
+
 void free_connection(connection_t *c) {
 	if(!c) {
 		return;
 	}
 
 #ifndef DISABLE_LEGACY
-	cipher_close(&c->incipher);
-	digest_close(&c->indigest);
-	cipher_close(&c->outcipher);
-	digest_close(&c->outdigest);
-	rsa_free(c->rsa);
+	free_legacy_ctx(c->legacy);
 #endif
 
 	sptps_stop(&c->sptps);

--- a/src/connection.c
+++ b/src/connection.c
@@ -58,7 +58,7 @@ connection_t *new_connection(void) {
 }
 
 #ifndef DISABLE_LEGACY
-bool init_crypto_by_nid(legacy_crypto_t *c, int cipher, int digest) {
+bool init_crypto_by_nid(legacy_crypto_t *c, nid_t cipher, nid_t digest) {
 	if(!cipher_open_by_nid(&c->cipher, cipher)) {
 		return false;
 	}

--- a/src/connection.h
+++ b/src/connection.h
@@ -27,6 +27,7 @@
 #include "rsa.h"
 #include "list.h"
 #include "sptps.h"
+#include "logger.h"
 
 #define OPTION_INDIRECT         0x0001
 #define OPTION_TCPONLY          0x0002
@@ -59,6 +60,7 @@ typedef union connection_status_t {
 #include "edge.h"
 #include "net.h"
 #include "node.h"
+#include "compression.h"
 
 #ifndef DISABLE_LEGACY
 typedef struct legacy_crypto_t {
@@ -107,7 +109,11 @@ typedef struct connection_t {
 	sptps_t sptps;
 
 	int outmaclength;
-	int outcompression;             /* compression level from compression_level_t */
+
+	union {
+		compression_level_t outcompression;
+		debug_t log_level; // used for REQ_LOG
+	};
 
 	uint8_t *hischallenge;          /* The challenge we sent to him */
 	uint8_t *mychallenge;           /* The challenge we received */

--- a/src/connection.h
+++ b/src/connection.h
@@ -67,7 +67,7 @@ typedef struct legacy_crypto_t {
 	uint64_t budget;
 } legacy_crypto_t;
 
-bool init_crypto_by_nid(legacy_crypto_t *c, int cipher, int digest) ATTR_WARN_UNUSED;
+bool init_crypto_by_nid(legacy_crypto_t *c, nid_t cipher, nid_t digest) ATTR_WARN_UNUSED;
 bool init_crypto_by_name(legacy_crypto_t *c, const char *cipher, const char *digest) ATTR_WARN_UNUSED;
 bool decrease_budget(legacy_crypto_t *c, size_t bytes) ATTR_WARN_UNUSED;
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -60,7 +60,6 @@ typedef union connection_status_t {
 #include "edge.h"
 #include "net.h"
 #include "node.h"
-#include "compression.h"
 
 #ifndef DISABLE_LEGACY
 typedef struct legacy_crypto_t {
@@ -109,11 +108,7 @@ typedef struct connection_t {
 	sptps_t sptps;
 
 	int outmaclength;
-
-	union {
-		compression_level_t outcompression;
-		debug_t log_level; // used for REQ_LOG
-	};
+	debug_t log_level;              /* used for REQ_LOG */
 
 	uint8_t *hischallenge;          /* The challenge we sent to him */
 	uint8_t *mychallenge;           /* The challenge we received */

--- a/src/connection.h
+++ b/src/connection.h
@@ -60,6 +60,27 @@ typedef union connection_status_t {
 #include "net.h"
 #include "node.h"
 
+#ifndef DISABLE_LEGACY
+typedef struct legacy_crypto_t {
+	cipher_t cipher;
+	digest_t digest;
+	uint64_t budget;
+} legacy_crypto_t;
+
+bool init_crypto_by_nid(legacy_crypto_t *c, int cipher, int digest) ATTR_WARN_UNUSED;
+bool init_crypto_by_name(legacy_crypto_t *c, const char *cipher, const char *digest) ATTR_WARN_UNUSED;
+bool decrease_budget(legacy_crypto_t *c, size_t bytes) ATTR_WARN_UNUSED;
+
+typedef struct legacy_ctx_t {
+	rsa_t *rsa;                    /* his public RSA key or my private RSA key */
+	legacy_crypto_t in;            /* cipher/digest he will use to send data to us */
+	legacy_crypto_t out;           /* cipher/digest we will use to send data to him */
+} legacy_ctx_t;
+
+legacy_ctx_t *new_legacy_ctx(rsa_t *rsa) ATTR_MALLOC;
+void free_legacy_ctx(legacy_ctx_t *ctx);
+#endif
+
 typedef struct connection_t {
 	char *name;                     /* name he claims to have */
 	char *hostname;                 /* the hostname of its real ip */
@@ -79,13 +100,7 @@ typedef struct connection_t {
 	struct edge_t *edge;            /* edge associated with this connection */
 
 #ifndef DISABLE_LEGACY
-	rsa_t *rsa;                     /* his public RSA key */
-	cipher_t incipher;              /* Cipher he will use to send data to us */
-	cipher_t outcipher;             /* Cipher we will use to send data to him */
-	digest_t indigest;
-	digest_t outdigest;
-	uint64_t inbudget;
-	uint64_t outbudget;
+	legacy_ctx_t *legacy;
 #endif
 
 	ecdsa_t *ecdsa;                 /* his public ECDSA key */

--- a/src/control.c
+++ b/src/control.c
@@ -129,11 +129,14 @@ bool control_h(connection_t *c, const char *request) {
 		pcap = true;
 		return true;
 
-	case REQ_LOG:
-		sscanf(request, "%*d %*d %d", &c->outcompression);
+	case REQ_LOG: {
+		int level = 0;
+		sscanf(request, "%*d %*d %d", &level);
+		c->log_level = CLAMP(level, DEBUG_UNSET, DEBUG_SCARY_THINGS);
 		c->status.log = true;
 		logcontrol = true;
 		return true;
+	}
 
 	default:
 		return send_request(c, "%d %d", CONTROL, REQ_INVALID);

--- a/src/digest.h
+++ b/src/digest.h
@@ -38,14 +38,14 @@
 typedef struct digest digest_t;
 
 extern bool digest_open_by_name(digest_t *digest, const char *name, size_t maclength);
-extern bool digest_open_by_nid(digest_t *digest, int nid, size_t maclength);
+extern bool digest_open_by_nid(digest_t *digest, nid_t nid, size_t maclength);
 extern digest_t *digest_alloc(void) ATTR_MALLOC;
 extern void digest_free(digest_t **digest);
 extern void digest_close(digest_t *digest);
 extern bool digest_create(digest_t *digest, const void *indata, size_t inlen, void *outdata) ATTR_WARN_UNUSED;
 extern bool digest_verify(digest_t *digest, const void *indata, size_t inlen, const void *digestdata) ATTR_WARN_UNUSED;
 extern bool digest_set_key(digest_t *digest, const void *key, size_t len) ATTR_WARN_UNUSED;
-extern int digest_get_nid(const digest_t *digest);
+extern nid_t digest_get_nid(const digest_t *digest);
 extern size_t digest_keylength(const digest_t *digest);
 extern size_t digest_length(const digest_t *digest);
 extern bool digest_active(const digest_t *digest);

--- a/src/dropin.h
+++ b/src/dropin.h
@@ -71,6 +71,8 @@ extern int gettimeofday(struct timeval *, void *);
 #define MAX(a,b) (((a)>(b))?(a):(b))
 #endif
 
+#define CLAMP(val, min, max) MIN((max), MAX((min), (val)))
+
 #ifdef _MSC_VER
 
 #define PATH_MAX MAX_PATH

--- a/src/fsck.c
+++ b/src/fsck.c
@@ -541,9 +541,7 @@ static bool check_public_keys(splay_tree_t *config, const char *name, rsa_t *rsa
 
 	bool success = true;
 #ifndef DISABLE_LEGACY
-	rsa_t *rsa_pub = NULL;
-	read_rsa_public_key(&rsa_pub, config, name);
-
+	rsa_t *rsa_pub = read_rsa_public_key(config, name);
 	success = check_rsa_pubkey(rsa_priv, rsa_pub, host_file);
 	rsa_free(rsa_pub);
 #endif

--- a/src/gcrypt/cipher.h
+++ b/src/gcrypt/cipher.h
@@ -24,13 +24,15 @@
 
 #include <gcrypt.h>
 
-struct cipher {
+#include "../legacy.h"
+
+typedef struct cipher {
 	gcry_cipher_hd_t handle;
 	uint8_t *key;
-	int nid;
+	nid_t nid;
 	uint16_t keylen;
 	uint16_t blklen;
 	bool padding;
-};
+} cipher_t;
 
 #endif

--- a/src/gcrypt/digest.c
+++ b/src/gcrypt/digest.c
@@ -25,17 +25,17 @@
 
 static struct {
 	const char *name;
-	enum gcry_md_algos algo;
-	int nid;
+	md_algo_t algo;
+	nid_t nid;
 } digesttable[] = {
-	{"none", GCRY_MD_NONE, 0},
-	{"sha1", GCRY_MD_SHA1, 64},
+	{"none",   GCRY_MD_NONE,   0},
+	{"sha1",   GCRY_MD_SHA1,   64},
 	{"sha256", GCRY_MD_SHA256, 672},
 	{"sha384", GCRY_MD_SHA384, 673},
 	{"sha512", GCRY_MD_SHA512, 674},
 };
 
-static bool nametodigest(const char *name, enum gcry_md_algos *algo) {
+static bool nametodigest(md_algo_t *algo, const char *name) {
 	for(size_t i = 0; i < sizeof(digesttable) / sizeof(*digesttable); i++) {
 		if(digesttable[i].name && !strcasecmp(name, digesttable[i].name)) {
 			*algo = digesttable[i].algo;
@@ -46,7 +46,7 @@ static bool nametodigest(const char *name, enum gcry_md_algos *algo) {
 	return false;
 }
 
-static bool nidtodigest(int nid, enum gcry_md_algos *algo) {
+static bool nidtodigest(md_algo_t *algo, nid_t nid) {
 	for(size_t i = 0; i < sizeof(digesttable) / sizeof(*digesttable); i++) {
 		if(nid == digesttable[i].nid) {
 			*algo = digesttable[i].algo;
@@ -57,7 +57,7 @@ static bool nidtodigest(int nid, enum gcry_md_algos *algo) {
 	return false;
 }
 
-static bool digesttonid(enum gcry_md_algos algo, int *nid) {
+static bool digesttonid(nid_t *nid, md_algo_t algo) {
 	for(size_t i = 0; i < sizeof(digesttable) / sizeof(*digesttable); i++) {
 		if(algo == digesttable[i].algo) {
 			*nid = digesttable[i].nid;
@@ -68,8 +68,8 @@ static bool digesttonid(enum gcry_md_algos algo, int *nid) {
 	return false;
 }
 
-static bool digest_open(digest_t *digest, enum gcry_md_algos algo, size_t maclength) {
-	if(!digesttonid(algo, &digest->nid)) {
+static bool digest_open(digest_t *digest, md_algo_t algo, size_t maclength) {
+	if(!digesttonid(&digest->nid, algo)) {
 		logger(DEBUG_ALWAYS, LOG_DEBUG, "Digest %d has no corresponding nid!", algo);
 		return false;
 	}
@@ -89,9 +89,9 @@ static bool digest_open(digest_t *digest, enum gcry_md_algos algo, size_t maclen
 }
 
 bool digest_open_by_name(digest_t *digest, const char *name, size_t maclength) {
-	enum gcry_md_algos algo;
+	md_algo_t algo;
 
-	if(!nametodigest(name, &algo)) {
+	if(!nametodigest(&algo, name)) {
 		logger(DEBUG_ALWAYS, LOG_DEBUG, "Unknown digest name '%s'!", name);
 		return false;
 	}
@@ -99,10 +99,10 @@ bool digest_open_by_name(digest_t *digest, const char *name, size_t maclength) {
 	return digest_open(digest, algo, maclength);
 }
 
-bool digest_open_by_nid(digest_t *digest, int nid, size_t maclength) {
-	enum gcry_md_algos algo;
+bool digest_open_by_nid(digest_t *digest, nid_t nid, size_t maclength) {
+	md_algo_t algo;
 
-	if(!nidtodigest(nid, &algo)) {
+	if(!nidtodigest(&algo, nid)) {
 		logger(DEBUG_ALWAYS, LOG_DEBUG, "Unknown digest ID %d!", nid);
 		return false;
 	}
@@ -160,7 +160,7 @@ bool digest_verify(digest_t *digest, const void *indata, size_t inlen, const voi
 	return digest_create(digest, indata, inlen, outdata) && !memcmp(cmpdata, outdata, len);
 }
 
-int digest_get_nid(const digest_t *digest) {
+nid_t digest_get_nid(const digest_t *digest) {
 	if(!digest || !digest->nid) {
 		return 0;
 	}

--- a/src/gcrypt/digest.h
+++ b/src/gcrypt/digest.h
@@ -22,9 +22,13 @@
 
 #include <gcrypt.h>
 
+#include "../legacy.h"
+
+typedef enum gcry_md_algos md_algo_t;
+
 typedef struct digest {
-	enum gcry_md_algos algo;
-	int nid;
+	md_algo_t algo;
+	nid_t nid;
 	size_t maclength;
 	gcry_md_hd_t hmac;
 } digest_t;

--- a/src/keys.c
+++ b/src/keys.c
@@ -295,7 +295,7 @@ rsa_t *read_rsa_private_key(splay_tree_t *config_tree, char **keyfile) {
 	return key;
 }
 
-bool read_rsa_public_key(rsa_t **rsa, splay_tree_t *config_tree, const char *name) {
+rsa_t *read_rsa_public_key(splay_tree_t *config_tree, const char *name) {
 	FILE *fp;
 	char *fname;
 	char *n;
@@ -303,9 +303,9 @@ bool read_rsa_public_key(rsa_t **rsa, splay_tree_t *config_tree, const char *nam
 	/* First, check for simple PublicKey statement */
 
 	if(get_config_string(lookup_config(config_tree, "PublicKey"), &n)) {
-		*rsa = rsa_set_hex_public_key(n, "FFFF");
+		rsa_t *rsa = rsa_set_hex_public_key(n, "FFFF");
 		free(n);
-		return *rsa != NULL;
+		return rsa;
 	}
 
 	/* Else, check for PublicKeyFile statement and read it */
@@ -322,15 +322,15 @@ bool read_rsa_public_key(rsa_t **rsa, splay_tree_t *config_tree, const char *nam
 		return false;
 	}
 
-	*rsa = rsa_read_pem_public_key(fp);
+	rsa_t *rsa = rsa_read_pem_public_key(fp);
 	fclose(fp);
 
-	if(!*rsa) {
+	if(!rsa) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Reading RSA public key file `%s' failed: %s", fname, strerror(errno));
 	}
 
 	free(fname);
 
-	return *rsa != NULL;
+	return rsa;
 }
 #endif

--- a/src/keys.h
+++ b/src/keys.h
@@ -12,7 +12,7 @@ extern bool read_ecdsa_public_key(ecdsa_t **ecdsa, splay_tree_t **config_tree, c
 
 #ifndef DISABLE_LEGACY
 extern rsa_t *read_rsa_private_key(splay_tree_t *config, char **keyfile);
-extern bool read_rsa_public_key(rsa_t **rsa, splay_tree_t *config_tree, const char *name);
+extern rsa_t *read_rsa_public_key(splay_tree_t *config_tree, const char *name);
 #endif
 
 #endif // TINC_KEYS_H

--- a/src/legacy.h
+++ b/src/legacy.h
@@ -1,0 +1,6 @@
+#ifndef TINC_LEGACY_H
+#define TINC_LEGACY_H
+
+typedef int nid_t;
+
+#endif // TINC_LEGACY_H

--- a/src/logger.c
+++ b/src/logger.c
@@ -110,7 +110,7 @@ static void real_logger(debug_t level, int priority, const char *message) {
 
 			logcontrol = true;
 
-			if(level > (c->outcompression >= COMPRESS_NONE ? c->outcompression : debug_level)) {
+			if(level > (c->log_level != DEBUG_UNSET ? c->log_level : debug_level)) {
 				continue;
 			}
 

--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -927,8 +927,6 @@ static bool setup_myself(void) {
 		myself->incompression = COMPRESS_NONE;
 	}
 
-	myself->connection->outcompression = COMPRESS_NONE;
-
 	/* Done */
 
 	myself->nexthop = myself;

--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -712,9 +712,11 @@ static bool setup_myself(void) {
 		}
 	}
 
-	myself->connection->rsa = read_rsa_private_key(&config_tree, NULL);
+	rsa_t *rsa = read_rsa_private_key(&config_tree, NULL);
 
-	if(!myself->connection->rsa) {
+	if(rsa) {
+		myself->connection->legacy = new_legacy_ctx(rsa);
+	} else {
 		if(experimental) {
 			logger(DEBUG_ALWAYS, LOG_WARNING, "Support for legacy protocol disabled.");
 		} else {

--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -873,7 +873,11 @@ static bool setup_myself(void) {
 #endif
 
 	/* Compression */
-	if(get_config_int(lookup_config(&config_tree, "Compression"), &myself->incompression)) {
+	int incompression = 0;
+
+	if(get_config_int(lookup_config(&config_tree, "Compression"), &incompression)) {
+		myself->incompression = incompression;
+
 		switch(myself->incompression) {
 		case COMPRESS_LZ4:
 #ifdef HAVE_LZ4

--- a/src/net_socket.c
+++ b/src/net_socket.c
@@ -648,7 +648,6 @@ begin:
 	c->status.connecting = true;
 	c->name = xstrdup(outgoing->node->name);
 	c->outmaclength = myself->connection->outmaclength;
-	c->outcompression = myself->connection->outcompression;
 	c->last_ping_time = now.tv_sec;
 
 	connection_add(c);
@@ -757,7 +756,6 @@ void handle_new_meta_connection(void *data, int flags) {
 	c = new_connection();
 	c->name = xstrdup("<unknown>");
 	c->outmaclength = myself->connection->outmaclength;
-	c->outcompression = myself->connection->outcompression;
 
 	c->address = sa;
 	c->hostname = sockaddr2hostname(&sa);

--- a/src/net_socket.c
+++ b/src/net_socket.c
@@ -647,10 +647,6 @@ begin:
 	c->last_ping_time = time(NULL);
 	c->status.connecting = true;
 	c->name = xstrdup(outgoing->node->name);
-#ifndef DISABLE_LEGACY
-	c->outcipher = myself->connection->outcipher;
-	c->outdigest = myself->connection->outdigest;
-#endif
 	c->outmaclength = myself->connection->outmaclength;
 	c->outcompression = myself->connection->outcompression;
 	c->last_ping_time = now.tv_sec;
@@ -760,10 +756,6 @@ void handle_new_meta_connection(void *data, int flags) {
 
 	c = new_connection();
 	c->name = xstrdup("<unknown>");
-#ifndef DISABLE_LEGACY
-	c->outcipher = myself->connection->outcipher;
-	c->outdigest = myself->connection->outdigest;
-#endif
 	c->outmaclength = myself->connection->outmaclength;
 	c->outcompression = myself->connection->outcompression;
 

--- a/src/node.h
+++ b/src/node.h
@@ -27,6 +27,7 @@
 #include "digest.h"
 #include "event.h"
 #include "subnet.h"
+#include "compression.h"
 
 typedef union node_status_t {
 	struct {
@@ -71,8 +72,8 @@ typedef struct node_t {
 	digest_t *outdigest;                    /* Digest for UDP packets */
 #endif
 
-	int incompression;                      /* Compressionlevel, 0 = no compression */
-	int outcompression;                     /* Compressionlevel, 0 = no compression */
+	compression_level_t incompression;      /* Compression level, 0 = no compression */
+	compression_level_t outcompression;     /* Compression level, 0 = no compression */
 
 	int distance;
 	struct node_t *nexthop;                 /* nearest node from us to him */

--- a/src/openssl/cipher.c
+++ b/src/openssl/cipher.c
@@ -52,7 +52,7 @@ bool cipher_open_by_name(cipher_t *cipher, const char *name) {
 	return true;
 }
 
-bool cipher_open_by_nid(cipher_t *cipher, int nid) {
+bool cipher_open_by_nid(cipher_t *cipher, nid_t nid) {
 	const EVP_CIPHER *evp_cipher = EVP_get_cipherbynid(nid);
 
 	if(!evp_cipher) {
@@ -179,7 +179,7 @@ bool cipher_decrypt(cipher_t *cipher, const void *indata, size_t inlen, void *ou
 	                              EVP_DecryptInit_ex, EVP_DecryptUpdate, EVP_DecryptFinal_ex);
 }
 
-int cipher_get_nid(const cipher_t *cipher) {
+nid_t cipher_get_nid(const cipher_t *cipher) {
 	if(!cipher || !cipher->cipher) {
 		return 0;
 	}

--- a/src/openssl/cipher.h
+++ b/src/openssl/cipher.h
@@ -22,9 +22,11 @@
 
 #include <openssl/evp.h>
 
-struct cipher {
+#include "../legacy.h"
+
+typedef struct cipher {
 	EVP_CIPHER_CTX *ctx;
 	const EVP_CIPHER *cipher;
-};
+} cipher_t;
 
 #endif

--- a/src/openssl/digest.c
+++ b/src/openssl/digest.c
@@ -55,7 +55,7 @@ bool digest_open_by_name(digest_t *digest, const char *name, size_t maclength) {
 	return true;
 }
 
-bool digest_open_by_nid(digest_t *digest, int nid, size_t maclength) {
+bool digest_open_by_nid(digest_t *digest, nid_t nid, size_t maclength) {
 	const EVP_MD *evp_md = EVP_get_digestbynid(nid);
 
 	if(!evp_md) {
@@ -189,7 +189,7 @@ bool digest_verify(digest_t *digest, const void *indata, size_t inlen, const voi
 	return digest_create(digest, indata, inlen, outdata) && !memcmp(cmpdata, outdata, digest->maclength);
 }
 
-int digest_get_nid(const digest_t *digest) {
+nid_t digest_get_nid(const digest_t *digest) {
 	if(!digest || !digest->digest) {
 		return 0;
 	}

--- a/src/openssl/digest.h
+++ b/src/openssl/digest.h
@@ -23,6 +23,8 @@
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 
+#include "../legacy.h"
+
 struct digest {
 	const EVP_MD *digest;
 #if OPENSSL_VERSION_MAJOR < 3

--- a/src/openssl/prf.c
+++ b/src/openssl/prf.c
@@ -29,7 +29,7 @@
    We use SHA512 instead of MD5 and SHA1.
  */
 
-static bool prf_xor(int nid, const uint8_t *secret, size_t secretlen, uint8_t *seed, size_t seedlen, uint8_t *out, size_t outlen) {
+static bool prf_xor(nid_t nid, const uint8_t *secret, size_t secretlen, uint8_t *seed, size_t seedlen, uint8_t *out, size_t outlen) {
 	digest_t digest = {0};
 
 	if(!digest_open_by_nid(&digest, nid, DIGEST_ALGO_SIZE)) {

--- a/src/protocol_auth.c
+++ b/src/protocol_auth.c
@@ -42,6 +42,7 @@
 #include "utils.h"
 #include "xalloc.h"
 #include "random.h"
+#include "compression.h"
 
 #include "ed25519/sha512.h"
 #include "keys.h"
@@ -608,7 +609,7 @@ bool send_metakey(connection_t *c) {
 	bool result = send_request(c, "%d %d %d %d %d %s", METAKEY,
 	                           cipher_get_nid(&c->legacy->out.cipher),
 	                           digest_get_nid(&c->legacy->out.digest), c->outmaclength,
-	                           c->outcompression, hexkey);
+	                           COMPRESS_NONE, hexkey);
 
 	c->status.encryptout = true;
 	return result;

--- a/src/protocol_key.c
+++ b/src/protocol_key.c
@@ -33,6 +33,7 @@
 #include "utils.h"
 #include "compression.h"
 #include "random.h"
+#include "legacy.h"
 
 void send_key_changed(void) {
 #ifndef DISABLE_LEGACY

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -611,7 +611,7 @@ static void pcap(int fd, FILE *out, uint32_t snaplen) {
 	}
 }
 
-static void logcontrol(int fd, FILE *out, int level) {
+static void log_control(int fd, FILE *out, int level) {
 	sendline(fd, "%d %d %d", CONTROL, REQ_LOG, level);
 	char data[1024];
 	char line[32];
@@ -1523,7 +1523,7 @@ static int cmd_log(int argc, char *argv[]) {
 	signal(SIGINT, sigint_handler);
 #endif
 
-	logcontrol(fd, stdout, argc > 1 ? atoi(argv[1]) : -1);
+	log_control(fd, stdout, argc > 1 ? atoi(argv[1]) : DEBUG_UNSET);
 
 #ifdef SIGINT
 	signal(SIGINT, SIG_DFL);

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -21,6 +21,9 @@ link_tincd = { 'lib': lib_tincd, 'dep': deps_tincd }
 # }
 
 tests = {
+  'dropin': {
+    'code': 'test_dropin.c',
+  },
   'random': {
     'code': 'test_random.c',
   },

--- a/test/unit/test_dropin.c
+++ b/test/unit/test_dropin.c
@@ -1,0 +1,44 @@
+#include "unittest.h"
+
+static const char buf[3];
+
+static void test_min(void **state) {
+	(void)state;
+
+	assert_int_equal(-1, MIN(1, -1));
+	assert_int_equal(-2, MIN(1 + 2 * 3, 3 - 2 * 5 / 2));
+
+	assert_ptr_equal(buf[0], MIN(buf[1], buf[0]));
+}
+
+static void test_max(void **state) {
+	(void)state;
+
+	assert_int_equal(1, MAX(1, -1));
+	assert_int_equal(4, MAX(1 + 3 - 3 / 4 * 5, 10 / 5 + 2 - 2));
+
+	assert_ptr_equal(buf[1], MAX(buf[1], buf[0]));
+}
+
+static void test_clamp(void **state) {
+	(void)state;
+
+	assert_int_equal(10, CLAMP(INT_MAX, -10, 10));
+	assert_int_equal(-10, CLAMP(INT_MIN, -10, 10));
+	assert_int_equal(7, CLAMP(3 + 4, 6, 8));
+
+	assert_int_equal(5, CLAMP(-1000, 5, 5));
+	assert_int_equal(5, CLAMP(0,     5, 5));
+	assert_int_equal(5, CLAMP(1000,  5, 5));
+
+	assert_ptr_equal(buf[1], CLAMP(buf[2], buf[0], buf[1]));
+}
+
+int main(void) {
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_min),
+		cmocka_unit_test(test_max),
+		cmocka_unit_test(test_clamp),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
I remember reading quite a while ago that legacy protocol stuff in `connection_t` should be separated into another struct. Was this what you meant?
