### PR TITLE
Convert tincd path args to absolute paths

### DIFF
--- a/src/tincd.c
+++ b/src/tincd.c
@@ -158,6 +158,17 @@ static void usage(bool status) {
 	}
 }
 
+// Try to resolve path to absolute, return a copy of the argument if this fails.
+static char *get_path_arg(char *arg) {
+	char *result = absolute_path(arg);
+
+	if(!result) {
+		result = xstrdup(arg);
+	}
+
+	return result;
+}
+
 static bool parse_options(int argc, char **argv) {
 	config_t *cfg;
 	int r;
@@ -175,7 +186,7 @@ static bool parse_options(int argc, char **argv) {
 
 		case OPT_CONFIG_FILE:
 			free(confbase);
-			confbase = xstrdup(optarg);
+			confbase = get_path_arg(optarg);
 			break;
 
 		case OPT_NO_DETACH:
@@ -263,14 +274,14 @@ static bool parse_options(int argc, char **argv) {
 
 			if(optarg) {
 				free(logfilename);
-				logfilename = xstrdup(optarg);
+				logfilename = get_path_arg(optarg);
 			}
 
 			break;
 
 		case OPT_PIDFILE:
 			free(pidfilename);
-			pidfilename = xstrdup(optarg);
+			pidfilename = get_path_arg(optarg);
 			break;
 
 		default:

--- a/src/utils.c
+++ b/src/utils.c
@@ -81,6 +81,57 @@ size_t bin2hex(const void *vsrc, char *dst, size_t length) {
 	return length * 2;
 }
 
+char *absolute_path(const char *path) {
+#ifdef HAVE_WINDOWS
+	// Works for nonexistent paths
+	return _fullpath(NULL, path, 0);
+#else
+
+	if(!path || !*path) {
+		return NULL;
+	}
+
+	// If an absolute path was passed, return its copy
+	if(*path == '/') {
+		return xstrdup(path);
+	}
+
+	// Try using realpath. If it fails for any reason
+	// other than that the file was not found, bail out.
+	char *abs = realpath(path, NULL);
+
+	if(abs || errno != ENOENT) {
+		return abs;
+	}
+
+	// Since the file does not exist, we're forced to use a fallback.
+	// Get current working directory and concatenate it with the argument.
+	char cwd[PATH_MAX];
+
+	if(!getcwd(cwd, sizeof(cwd))) {
+		return NULL;
+	}
+
+	// Remove trailing slash if present since we'll be adding our own
+	size_t cwdlen = strlen(cwd);
+
+	if(cwdlen && cwd[cwdlen - 1] == '/') {
+		cwd[cwdlen - 1] = '\0';
+	}
+
+	// We don't do any normalization because it's complicated, and the payoff is small.
+	// If user passed something like '.././../foo' — that's their choice; fopen works either way.
+	xasprintf(&abs, "%s/%s", cwd, path);
+
+	if(strlen(abs) >= PATH_MAX) {
+		free(abs);
+		abs = NULL;
+	}
+
+	return abs;
+#endif
+}
+
 size_t b64decode_tinc(const char *src, void *dst, size_t length) {
 	size_t i;
 	uint32_t triplet = 0;

--- a/src/utils.h
+++ b/src/utils.h
@@ -74,6 +74,8 @@ extern bool check_id(const char *id);
 extern bool check_netname(const char *netname, bool strict);
 char *replace_name(const char *name);
 
+char *absolute_path(const char *path) ATTR_MALLOC;
+
 extern FILE *fopenmask(const char *filename, const char *mode, mode_t perms);
 
 #endif

--- a/test/integration/testlib/check.py
+++ b/test/integration/testlib/check.py
@@ -1,6 +1,8 @@
 """Simple assertions which print the expected and received values on failure."""
 
+import os.path
 import typing as T
+from pathlib import Path
 
 from .log import log
 
@@ -86,3 +88,9 @@ def files_eq(path0: str, path1: str) -> None:
 
     if content0 != content1:
         raise ValueError(f"expected files {path0} and {path1} to match")
+
+
+def file_exists(path: T.Union[str, Path]) -> None:
+    """Check that file or directory exists."""
+    if not os.path.exists(path):
+        raise ValueError("expected path '{path}' to exist")

--- a/test/integration/testlib/util.py
+++ b/test/integration/testlib/util.py
@@ -7,6 +7,7 @@ import random
 import string
 import socket
 import typing as T
+from pathlib import Path
 
 from . import check
 from .log import log
@@ -29,6 +30,15 @@ def random_port() -> int:
             return port
         except OSError as ex:
             log.debug("could not bind to random port %d", port, exc_info=ex)
+
+
+def remove_file(path: T.Union[str, Path]) -> bool:
+    """Try to remove file without failing if it does not exist."""
+    try:
+        os.remove(path)
+        return True
+    except FileNotFoundError:
+        return False
 
 
 def random_string(k: int) -> str:

--- a/test/unit/test_utils.c
+++ b/test/unit/test_utils.c
@@ -1,6 +1,49 @@
 #include "unittest.h"
 #include "../../src/utils.h"
 
+#define FAKE_PATH "nonexistentreallyfakepath"
+
+typedef struct {
+	const char *arg;
+	const char *want;
+} testcase_t;
+
+static void test_unix_absolute_path_on_absolute_returns_it(void **state) {
+	(void)state;
+
+	const char *paths[] = {"/", "/foo", "/foo/./../bar"};
+
+	for(size_t i = 0; i < sizeof(paths) / sizeof(*paths); ++i) {
+		char *got = absolute_path(paths[i]);
+		assert_ptr_not_equal(paths[i], got);
+		assert_string_equal(paths[i], got);
+		free(got);
+	}
+}
+
+static void test_unix_absolute_path_on_empty_returns_null(void **state) {
+	(void)state;
+	assert_null(absolute_path(NULL));
+	assert_null(absolute_path("\0"));
+}
+
+static void test_unix_absolute_path_relative(void **state) {
+	(void)state;
+
+	testcase_t cases[] = {
+		{".", "/"},
+		{"foo", "/foo"},
+		{"./"FAKE_PATH, "/./"FAKE_PATH},
+		{"../foo/./../"FAKE_PATH, "/../foo/./../"FAKE_PATH},
+	};
+
+	for(size_t i = 0; i < sizeof(cases) / sizeof(*cases); ++i) {
+		char *got = absolute_path(cases[i].arg);
+		assert_string_equal(cases[i].want, got);
+		free(got);
+	}
+}
+
 static void test_int_to_str(const char *ref, int num) {
 	char *result = int_to_str(num);
 	assert_string_equal(ref, result);
@@ -56,8 +99,17 @@ static void test_is_decimal_pass_whitespace_prefix(void **state) {
 	assert_true(is_decimal(" \r\n\t 777"));
 }
 
+static int setup_path_unix(void **state) {
+	(void)state;
+	assert_int_equal(0, chdir("/"));
+	return 0;
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
+		cmocka_unit_test_setup(test_unix_absolute_path_on_absolute_returns_it, setup_path_unix),
+		cmocka_unit_test_setup(test_unix_absolute_path_on_empty_returns_null, setup_path_unix),
+		cmocka_unit_test_setup(test_unix_absolute_path_relative, setup_path_unix),
 		cmocka_unit_test(test_int_to_str_return_expected),
 		cmocka_unit_test(test_is_decimal_fail_empty),
 		cmocka_unit_test(test_is_decimal_fail_hex),
@@ -66,5 +118,10 @@ int main(void) {
 		cmocka_unit_test(test_is_decimal_pass_signs),
 		cmocka_unit_test(test_is_decimal_pass_whitespace_prefix),
 	};
+
+#ifdef HAVE_WINDOWS
+	cmocka_set_skip_filter("test_unix_*");
+#endif
+
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION


Ran into this many times when testing tinc manually:

    $ mkdir x
    $ tinc -c x init foo
    $ tinc -c x set DeviceType dummy
    $ tincd -c x -D
    Cannot open config file x/tinc.conf: No such file or directory
    Failed to read `x/tinc.conf': No such file or directory

while absolute paths work fine:

    $ tincd -c $PWD/x -D

It happens because `tincd` stores paths as they were passed, then does `chdir` to its configuration directory, and then tries to `fopen`.

I went for the simplest solution — resolve all paths to absolute before doing `chdir`.

Sadly, `realpath` fails if path does not exist (which is a problem for pidfile and logfile), so if that happens we fall back to concatenating `getcwd` and whatever was passed by the user.

It's what [others][cwalk] are using, with the exception that we're skipping normalization (`fopen` works either way, and I don't think it makes sense to drag so much complexity to make logs a bit prettier).

[cwalk]: https://github.com/likle/cwalk/blob/3aa1e36aa427c33351e7120b56e95f69e432d683/src/cwalk.c#L647

Not sure about logfile and pidfile. If you pass relative paths, they currently work as relative to configuration directory, although it isn't obvious and is not mentioned in the documentation. With this PR it's a bit more consistent, but may cause regressions (although 1.1 is officially a development release).

What are your thoughts? We could use the old behavior for these two, and get rid of `absolute_path` (`realpath` will do since configuration directory must exist before starting `tincd`).
