### PR TITLE
Wipe (some) secrets from memory after use

### DIFF
--- a/.ci/sanitizers/run.sh
+++ b/.ci/sanitizers/run.sh
@@ -8,13 +8,14 @@ logs="$GITHUB_WORKSPACE/sanitizer"
 
 case "$SANITIZER" in
 undefined)
-  flags='-fsanitize=integer -fsanitize=nullability'
+  flags='-fsanitize=integer -fsanitize=nullability -fno-sanitize=unsigned-integer-overflow'
   export UBSAN_OPTIONS="log_path=$logs/ubsan:print_stacktrace=1"
   ;;
 
 address)
   flags='-fsanitize-address-use-after-scope -fsanitize=pointer-compare -fsanitize=pointer-subtract'
   export ASAN_OPTIONS="log_path=$logs/asan:detect_invalid_pointer_pairs=2:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
+  export LSAN_OPTIONS="suppressions=$dir/suppress.txt:print_suppressions=0"
   ;;
 
 thread)

--- a/.ci/sanitizers/suppress.txt
+++ b/.ci/sanitizers/suppress.txt
@@ -1,0 +1,4 @@
+# known leak from one-time allocation
+# upstream refuses to fix such things: https://dev.gnupg.org/T4499
+leak:libgcrypt.so
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,12 +120,18 @@ jobs:
 
       - name: Run tests with OpenSSL 3
         run: bash .ci/sanitizers/run.sh openssl3
+        if: always()
 
       - name: Sanitize tests with default settings
         run: bash .ci/sanitizers/run.sh default
+        if: always()
 
       - name: Sanitize tests without legacy protocol
         run: bash .ci/sanitizers/run.sh nolegacy
+        if: always()
+
+      - name: Run tests with libgcrypt
+        run: bash .ci/sanitizers/run.sh gcrypt
         if: always()
 
       - name: Upload test results

--- a/src/chacha-poly1305/chacha-poly1305.c
+++ b/src/chacha-poly1305/chacha-poly1305.c
@@ -10,16 +10,14 @@ struct chacha_poly1305_ctx {
 };
 
 chacha_poly1305_ctx_t *chacha_poly1305_init(void) {
-	chacha_poly1305_ctx_t *ctx = xzalloc(sizeof(*ctx));
-	return ctx;
+	return xzalloc(sizeof(chacha_poly1305_ctx_t));
 }
 
 void chacha_poly1305_exit(chacha_poly1305_ctx_t *ctx) {
-	free(ctx);
+	xzfree(ctx, sizeof(chacha_poly1305_ctx_t));
 }
 
-bool chacha_poly1305_set_key(chacha_poly1305_ctx_t *ctx, const void *vkey) {
-	const uint8_t *key = vkey;
+bool chacha_poly1305_set_key(chacha_poly1305_ctx_t *ctx, const uint8_t *key) {
 	chacha_keysetup(&ctx->main_ctx, key, 256);
 	chacha_keysetup(&ctx->header_ctx, key + 32, 256);
 	return true;

--- a/src/chacha-poly1305/chacha-poly1305.h
+++ b/src/chacha-poly1305/chacha-poly1305.h
@@ -7,7 +7,7 @@ typedef struct chacha_poly1305_ctx chacha_poly1305_ctx_t;
 
 extern chacha_poly1305_ctx_t *chacha_poly1305_init(void);
 extern void chacha_poly1305_exit(chacha_poly1305_ctx_t *);
-extern bool chacha_poly1305_set_key(chacha_poly1305_ctx_t *ctx, const void *key);
+extern bool chacha_poly1305_set_key(chacha_poly1305_ctx_t *ctx, const uint8_t *key);
 
 extern bool chacha_poly1305_encrypt(chacha_poly1305_ctx_t *ctx, uint64_t seqnr, const void *indata, size_t inlen, void *outdata, size_t *outlen);
 extern bool chacha_poly1305_decrypt(chacha_poly1305_ctx_t *ctx, uint64_t seqnr, const void *indata, size_t inlen, void *outdata, size_t *outlen);

--- a/src/conf.c
+++ b/src/conf.c
@@ -98,7 +98,7 @@ config_t *new_config(void) {
 
 void free_config(config_t *cfg) {
 	free(cfg->variable);
-	free(cfg->value);
+	free_string(cfg->value);
 	free(cfg->file);
 	free(cfg);
 }

--- a/src/ed25519/ecdh.c
+++ b/src/ed25519/ecdh.c
@@ -36,16 +36,17 @@ ecdh_t *ecdh_generate_public(void *pubkey) {
 	uint8_t seed[32];
 	randomize(seed, sizeof(seed));
 	ed25519_create_keypair(pubkey, ecdh->private, seed);
+	memzero(seed, sizeof(seed));
 
 	return ecdh;
 }
 
 bool ecdh_compute_shared(ecdh_t *ecdh, const void *pubkey, void *shared) {
 	ed25519_key_exchange(shared, pubkey, ecdh->private);
-	free(ecdh);
+	ecdh_free(ecdh);
 	return true;
 }
 
 void ecdh_free(ecdh_t *ecdh) {
-	free(ecdh);
+	xzfree(ecdh, sizeof(ecdh_t));
 }

--- a/src/ed25519/ecdsagen.c
+++ b/src/ed25519/ecdsagen.c
@@ -40,6 +40,7 @@ ecdsa_t *ecdsa_generate(void) {
 	uint8_t seed[32];
 	randomize(seed, sizeof(seed));
 	ed25519_create_keypair(ecdsa->public, ecdsa->private, seed);
+	memzero(seed, sizeof(seed));
 
 	return ecdsa;
 }
@@ -59,6 +60,8 @@ static bool write_pem(FILE *fp, const char *type, void *vbuf, size_t size) {
 		buf += todo;
 		size -= todo;
 	}
+
+	memzero(base64, sizeof(base64));
 
 	fprintf(fp, "-----END %s-----\n", type);
 	return !ferror(fp);

--- a/src/edge.c
+++ b/src/edge.c
@@ -71,10 +71,12 @@ edge_t *new_edge(void) {
 }
 
 void free_edge(edge_t *e) {
-	sockaddrfree(&e->address);
-	sockaddrfree(&e->local_address);
+	if(e) {
+		sockaddrfree(&e->address);
+		sockaddrfree(&e->local_address);
 
-	free(e);
+		free(e);
+	}
 }
 
 void edge_add(edge_t *e) {

--- a/src/gcrypt/digest.c
+++ b/src/gcrypt/digest.c
@@ -111,6 +111,10 @@ bool digest_open_by_nid(digest_t *digest, nid_t nid, size_t maclength) {
 }
 
 void digest_close(digest_t *digest) {
+	if(!digest) {
+		return;
+	}
+
 	if(digest->hmac) {
 		gcry_md_close(digest->hmac);
 	}

--- a/src/gcrypt/pem.c
+++ b/src/gcrypt/pem.c
@@ -96,8 +96,8 @@ bool pem_encode(FILE *fp, const char *header, uint8_t *buf, size_t size) {
 	char b64[B64_SIZE(size)];
 	const size_t b64len = b64encode(b64, buf, size);
 
-	for(char *p = b64; p < b64 + b64len; p += 64) {
-		if(fprintf(fp, "%.64s\n", p) <= 0) {
+	for(size_t i = 0; i < b64len; i += 64) {
+		if(fprintf(fp, "%.64s\n", &b64[i]) <= 0) {
 			return false;
 		}
 	}

--- a/src/gcrypt/rsa.c
+++ b/src/gcrypt/rsa.c
@@ -71,7 +71,7 @@ static size_t ber_read_len(unsigned char **p, size_t *buflen) {
 			return 0;
 		}
 
-		while(len--) {
+		for(; len; --len) {
 			result = (size_t)(result << 8);
 			result |= *(*p)++;
 			(*buflen)--;

--- a/src/gcrypt/rsagen.c
+++ b/src/gcrypt/rsagen.c
@@ -26,6 +26,7 @@
 #include "pem.h"
 #include "../rsagen.h"
 #include "../xalloc.h"
+#include "../utils.h"
 
 // ASN.1 tags.
 typedef enum {
@@ -240,7 +241,9 @@ bool rsa_write_pem_private_key(rsa_t *rsa, FILE *fp) {
 	gcry_mpi_release(params[dq]);
 	gcry_mpi_release(params[u]);
 
-	return pem_encode(fp, "RSA PRIVATE KEY", derbuf, derlen);
+	bool success = pem_encode(fp, "RSA PRIVATE KEY", derbuf, derlen);
+	memzero(derbuf, sizeof(derbuf));
+	return success;
 }
 
 static gcry_mpi_t find_mpi(const gcry_sexp_t rsa, const char *token) {

--- a/src/have.h
+++ b/src/have.h
@@ -29,6 +29,8 @@
 #define _CRT_NONSTDC_NO_WARNINGS
 #endif
 
+#define __STDC_WANT_LIB_EXT1__ 1
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/src/keys.c
+++ b/src/keys.c
@@ -227,13 +227,13 @@ rsa_t *read_rsa_private_key(splay_tree_t *config_tree, char **keyfile) {
 	if(get_config_string(rsa_priv_conf, &d)) {
 		if(!get_config_string(lookup_config(config_tree, "PublicKey"), &n)) {
 			logger(DEBUG_ALWAYS, LOG_ERR, "PrivateKey used but no PublicKey found!");
-			free(d);
+			free_string(d);
 			return NULL;
 		}
 
 		key = rsa_set_hex_private_key(n, "FFFF", d);
 		free(n);
-		free(d);
+		free_string(d);
 
 		if(key && keyfile && rsa_priv_conf->file) {
 			*keyfile = xstrdup(rsa_priv_conf->file);

--- a/src/meson.build
+++ b/src/meson.build
@@ -73,8 +73,11 @@ endif
 check_functions = [
   'asprintf',
   'daemon',
+  'explicit_bzero',
+  'explicit_memset',
   'fchmod',
   'gettimeofday',
+  'memset_s',
   'mlockall',
   'putenv',
   'strsignal',

--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -267,7 +267,7 @@ bool setup_myself_reloadable(void) {
 			proxytype = PROXY_EXEC;
 		} else {
 			logger(DEBUG_ALWAYS, LOG_ERR, "Unknown proxy type %s!", proxy);
-			free(proxy);
+			free_string(proxy);
 			return false;
 		}
 
@@ -277,10 +277,10 @@ bool setup_myself_reloadable(void) {
 		free(proxyport);
 		proxyport = NULL;
 
-		free(proxyuser);
+		free_string(proxyuser);
 		proxyuser = NULL;
 
-		free(proxypass);
+		free_string(proxypass);
 		proxypass = NULL;
 
 		switch(proxytype) {
@@ -291,7 +291,7 @@ bool setup_myself_reloadable(void) {
 		case PROXY_EXEC:
 			if(!space || !*space) {
 				logger(DEBUG_ALWAYS, LOG_ERR, "Argument expected for proxy type exec!");
-				free(proxy);
+				free_string(proxy);
 				return false;
 			}
 
@@ -312,7 +312,7 @@ bool setup_myself_reloadable(void) {
 				logger(DEBUG_ALWAYS, LOG_ERR, "Host and port argument expected for proxy!");
 				proxyport = NULL;
 				proxyhost = NULL;
-				free(proxy);
+				free_string(proxy);
 				return false;
 			}
 
@@ -338,7 +338,7 @@ bool setup_myself_reloadable(void) {
 			break;
 		}
 
-		free(proxy);
+		free_string(proxy);
 	}
 
 	bool choice;

--- a/src/node.c
+++ b/src/node.c
@@ -89,6 +89,10 @@ node_t *new_node(void) {
 }
 
 void free_node(node_t *n) {
+	if(!n) {
+		return;
+	}
+
 	splay_empty_tree(&n->subnet_tree);
 	splay_empty_tree(&n->edge_tree);
 

--- a/src/openssl/rsa.c
+++ b/src/openssl/rsa.c
@@ -113,7 +113,7 @@ exit:
 	if(!rsa)
 #endif
 	{
-		BN_free(bn_d);
+		BN_clear_free(bn_d);
 		BN_free(bn_e);
 		BN_free(bn_n);
 	}

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -80,8 +80,10 @@ static int past_request_compare(const past_request_t *a, const past_request_t *b
 }
 
 static void free_past_request(past_request_t *r) {
-	free((char *)r->request);
-	free(r);
+	if(r) {
+		free((char *)r->request);
+		free(r);
+	}
 }
 
 static splay_tree_t past_request_tree = {

--- a/src/script.c
+++ b/src/script.c
@@ -134,7 +134,7 @@ void environment_init(environment_t *env) {
 
 void environment_exit(environment_t *env) {
 	for(int i = 0; i < env->n; i++) {
-		free(env->entries[i]);
+		free_string(env->entries[i]);
 	}
 
 	free(env->entries);

--- a/src/sptps.h
+++ b/src/sptps.h
@@ -47,6 +47,26 @@ typedef enum sptps_state_t {
 	SPTPS_ACK = 4,           // Waiting for an ACKnowledgement record
 } sptps_state_t;
 
+PACKED(struct sptps_kex_t {
+	uint8_t version;
+	uint8_t nonce[ECDH_SIZE];
+	uint8_t pubkey[ECDH_SIZE];
+});
+
+typedef struct sptps_kex_t sptps_kex_t;
+
+STATIC_ASSERT(sizeof(sptps_kex_t) == 65, "sptps_kex_t has invalid size");
+
+typedef union sptps_key_t {
+	struct {
+		uint8_t key0[CHACHA_POLY1305_KEYLEN];
+		uint8_t key1[CHACHA_POLY1305_KEYLEN];
+	};
+	uint8_t both[CHACHA_POLY1305_KEYLEN * 2];
+} sptps_key_t;
+
+STATIC_ASSERT(sizeof(sptps_key_t) == 128, "sptps_key_t has invalid size");
+
 typedef struct sptps {
 	bool initiator;
 	bool datagram;
@@ -72,9 +92,9 @@ typedef struct sptps {
 	ecdsa_t *hiskey;
 	ecdh_t *ecdh;
 
-	uint8_t *mykex;
-	uint8_t *hiskex;
-	uint8_t *key;
+	sptps_kex_t *mykex;
+	sptps_kex_t *hiskex;
+	sptps_key_t *key;
 	uint8_t *label;
 	size_t labellen;
 

--- a/src/sptps_keypair.c
+++ b/src/sptps_keypair.c
@@ -62,14 +62,14 @@ static int generate_keypair(char *argv[]) {
 	if(fp) {
 		if(!ecdsa_write_pem_private_key(key, fp)) {
 			fprintf(stderr, "Could not write ECDSA private key\n");
-			free(key);
+			ecdsa_free(key);
 			return 1;
 		}
 
 		fclose(fp);
 	} else {
 		fprintf(stderr, "Could not open '%s' for writing: %s\n", argv[1], strerror(errno));
-		free(key);
+		ecdsa_free(key);
 		return 1;
 	}
 
@@ -80,12 +80,12 @@ static int generate_keypair(char *argv[]) {
 			fprintf(stderr, "Could not write ECDSA public key\n");
 		}
 
-		free(key);
+		ecdsa_free(key);
 		fclose(fp);
 		return 0;
 	} else {
 		fprintf(stderr, "Could not open '%s' for writing: %s\n", argv[2], strerror(errno));
-		free(key);
+		ecdsa_free(key);
 		return 1;
 	}
 }

--- a/src/sptps_test.c
+++ b/src/sptps_test.c
@@ -543,14 +543,14 @@ static int run_test(int argc, char *argv[]) {
 
 	if(!fp) {
 		fprintf(stderr, "Could not open %s: %s\n", argv[2], strerror(errno));
-		free(mykey);
+		ecdsa_free(mykey);
 		return 1;
 	}
 
 	ecdsa_t *hiskey = NULL;
 
 	if(!(hiskey = ecdsa_read_pem_public_key(fp))) {
-		free(mykey);
+		ecdsa_free(mykey);
 		return 1;
 	}
 
@@ -563,8 +563,8 @@ static int run_test(int argc, char *argv[]) {
 	sptps_t s;
 
 	if(!sptps_start(&s, &sock, initiator, datagram, mykey, hiskey, "sptps_test", 10, send_data, receive_record)) {
-		free(mykey);
-		free(hiskey);
+		ecdsa_free(mykey);
+		ecdsa_free(hiskey);
 		return 1;
 	}
 
@@ -575,8 +575,8 @@ static int run_test(int argc, char *argv[]) {
 
 		if(in < 0) {
 			fprintf(stderr, "Could not init stdin reader thread\n");
-			free(mykey);
-			free(hiskey);
+			ecdsa_free(mykey);
+			ecdsa_free(hiskey);
 			return 1;
 		}
 	}
@@ -603,8 +603,8 @@ static int run_test(int argc, char *argv[]) {
 		FD_SET(sock, &fds);
 
 		if(select(max_fd + 1, &fds, NULL, NULL, NULL) <= 0) {
-			free(mykey);
-			free(hiskey);
+			ecdsa_free(mykey);
+			ecdsa_free(hiskey);
 			return 1;
 		}
 
@@ -617,8 +617,8 @@ static int run_test(int argc, char *argv[]) {
 
 			if(len < 0) {
 				fprintf(stderr, "Could not read from stdin: %s\n", strerror(errno));
-				free(mykey);
-				free(hiskey);
+				ecdsa_free(mykey);
+				ecdsa_free(hiskey);
 				return 1;
 			}
 
@@ -649,8 +649,8 @@ static int run_test(int argc, char *argv[]) {
 					sptps_send_record(&s, 0, buf, len);
 				}
 			} else if(!sptps_send_record(&s, buf[0] == '!' ? 1 : 0, buf, (len == 1 && buf[0] == '\n') ? 0 : buf[0] == '*' ? sizeof(buf) : (size_t)len)) {
-				free(mykey);
-				free(hiskey);
+				ecdsa_free(mykey);
+				ecdsa_free(hiskey);
 				return 1;
 			}
 		}
@@ -660,8 +660,8 @@ static int run_test(int argc, char *argv[]) {
 
 			if(len < 0) {
 				fprintf(stderr, "Could not read from socket: %s\n", sockstrerror(sockerrno));
-				free(mykey);
-				free(hiskey);
+				ecdsa_free(mykey);
+				ecdsa_free(hiskey);
 				return 1;
 			}
 
@@ -691,8 +691,8 @@ static int run_test(int argc, char *argv[]) {
 
 				if(!done) {
 					if(!datagram) {
-						free(mykey);
-						free(hiskey);
+						ecdsa_free(mykey);
+						ecdsa_free(hiskey);
 						return 1;
 					}
 				}
@@ -705,8 +705,8 @@ static int run_test(int argc, char *argv[]) {
 
 	bool stopped = sptps_stop(&s);
 
-	free(mykey);
-	free(hiskey);
+	ecdsa_free(mykey);
+	ecdsa_free(hiskey);
 	closesocket(sock);
 
 	return !stopped;

--- a/src/utils.c
+++ b/src/utils.c
@@ -18,6 +18,8 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include <assert.h>
+
 #include "logger.h"
 #include "system.h"
 #include "utils.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -26,6 +26,7 @@
 #include "crypto.h"
 
 #define B64_SIZE(len) ((len) * 4 / 3 + 5)
+#define HEX_SIZE(len) ((len) * 2 + 1)
 
 extern size_t hex2bin(const char *src, void *dst, size_t length);
 extern size_t bin2hex(const void *src, char *dst, size_t length);

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -47,6 +47,13 @@ tests = {
   'utils': {
     'code': 'test_utils.c',
   },
+  'xalloc': {
+    'code': 'test_xalloc.c',
+  },
+  'memzero_null': {
+    'code': 'test_memzero_null.c',
+    'fail': true,
+  },
   'splay_tree': {
     'code': 'test_splay_tree.c',
     'link': link_tinc,

--- a/test/unit/test_memzero_null.c
+++ b/test/unit/test_memzero_null.c
@@ -1,0 +1,12 @@
+// Test that memzero() with NULL pointer crashes the program
+
+#include "config.h"
+#undef HAVE_ATTR_NONNULL
+
+#include "unittest.h"
+#include "../../src/xalloc.h"
+
+int main(void) {
+	memzero(NULL, 1);
+	return 0;
+}

--- a/test/unit/test_random_noinit.c
+++ b/test/unit/test_random_noinit.c
@@ -9,14 +9,8 @@ int main(void) {
 #else
 #include "../../src/random.h"
 
-static void on_abort(int sig) {
-	(void)sig;
-	exit(1);
-}
-
 int main(void) {
-	signal(SIGABRT, on_abort);
-	u_int8_t buf[16];
+	uint8_t buf[16];
 	randomize(buf, sizeof(buf));
 	return 0;
 }

--- a/test/unit/test_xalloc.c
+++ b/test/unit/test_xalloc.c
@@ -1,0 +1,61 @@
+#include "unittest.h"
+#include "../../src/xalloc.h"
+
+static const uint8_t ref[] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+static void test_memzero_wipes_partial(void **state) {
+	(void)state;
+
+	uint8_t buf[sizeof(ref)];
+	memcpy(buf, ref, sizeof(buf));
+
+	const size_t len = 2;
+	memzero(buf, len);
+	assert_int_equal(0, buf[0]);
+	assert_int_equal(0, buf[1]);
+
+	assert_memory_equal(&buf[len], &ref[len], sizeof(ref) - len);
+}
+
+static void test_memzero_wipes_buffer(void **state) {
+	(void)state;
+
+	uint8_t buf[sizeof(ref)];
+	uint8_t zero[sizeof(ref)] = {0};
+
+	memcpy(buf, ref, sizeof(buf));
+	assert_memory_equal(ref, buf, sizeof(buf));
+
+	memzero(buf, sizeof(buf));
+	assert_memory_not_equal(buf, ref, sizeof(buf));
+	assert_memory_equal(zero, buf, sizeof(buf));
+}
+
+static void test_memzero_zerolen_does_not_change_memory(void **state) {
+	(void)state;
+
+	uint8_t buf[sizeof(ref)];
+
+	memcpy(buf, ref, sizeof(buf));
+	assert_memory_equal(ref, buf, sizeof(buf));
+
+	memzero(buf, 0);
+	assert_memory_equal(ref, buf, sizeof(buf));
+}
+
+// This test will fail under ASAN if xzfree forgets to call free() or overflows the buffer
+static void test_xzfree_frees_memory(void **state) {
+	(void)state;
+
+	xzfree(xmalloc(64), 64);
+}
+
+int main(void) {
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_memzero_wipes_partial),
+		cmocka_unit_test(test_memzero_wipes_buffer),
+		cmocka_unit_test(test_memzero_zerolen_does_not_change_memory),
+		cmocka_unit_test(test_xzfree_frees_memory),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
While not a panacea, this is considered to be a good practice which doesn't cost us much.

The cryptographic libraries we're using are already doing that for some of their own data structures. This should additionally cover EC keys, a few strings potentially containing passwords, and various temporary key buffers.

---


I finally remembered to add libgcrypt to CI. This is not related to the main PR, but is bundled here to avoid creating even more conflicts.
