### PR TITLE
Handle `Port 0`: use actual port in tincd logs / tinc get Port / invitation URLs and files

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -109,6 +109,7 @@ src_lib_common = [
   'logger.c',
   'names.c',
   'netutl.c',
+  'pidfile.c',
   'script.c',
   'splay_tree.c',
   'sptps.c',

--- a/src/net.h
+++ b/src/net.h
@@ -124,6 +124,11 @@ typedef struct outgoing_t {
 	timeout_t ev;
 } outgoing_t;
 
+typedef struct ports_t {
+	char *tcp;
+	char *udp;
+} ports_t;
+
 extern list_t outgoing_list;
 
 extern int maxoutbufsize;
@@ -151,7 +156,7 @@ extern bool udp_sndbuf_warnings;
 extern int max_connection_burst;
 extern int fwmark;
 extern bool do_prune;
-extern char *myport;
+extern ports_t myport;
 extern bool device_standby;
 extern bool autoconnect;
 extern bool disablebuggypeers;

--- a/src/netutl.h
+++ b/src/netutl.h
@@ -25,6 +25,8 @@
 
 extern bool hostnames;
 
+// Converts service name (as listed in /etc/services) to port number. Returns 0 on error.
+extern uint16_t service_to_port(const char *service);
 extern struct addrinfo *str2addrinfo(const char *address, const char *service, int socktype) ATTR_MALLOC;
 extern sockaddr_t str2sockaddr(const char *address, const char *port);
 extern void sockaddr2str(const sockaddr_t *sa, char **address, char **port);
@@ -35,5 +37,6 @@ extern void sockaddrunmap(sockaddr_t *sa);
 extern void sockaddrfree(sockaddr_t *sa);
 extern void sockaddrcpy(sockaddr_t *dest, const sockaddr_t *src);
 extern void sockaddr_setport(sockaddr_t *sa, const char *port);
+extern uint16_t get_bound_port(int sockfd);
 
 #endif

--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -1,0 +1,38 @@
+#include "system.h"
+
+#include "pidfile.h"
+#include "names.h"
+
+pidfile_t *read_pidfile(void) {
+	FILE *f = fopen(pidfilename, "r");
+
+	if(!f) {
+		return NULL;
+	}
+
+	pidfile_t *pf = malloc(sizeof(pidfile_t));
+	int read = fscanf(f, "%20d %64s %128s port %128s", &pf->pid, pf->cookie, pf->host, pf->port);
+	fclose(f);
+
+	if(read != 4) {
+		free(pf);
+		pf = NULL;
+	}
+
+	return pf;
+}
+
+
+bool write_pidfile(const char *controlcookie, const char *address) {
+	const mode_t mask = umask(0);
+	umask(mask | 077);
+	FILE *f = fopen(pidfilename, "w");
+
+	if(!f) {
+		return false;
+	}
+
+	umask(mask);
+	fprintf(f, "%d %s %s\n", (int)getpid(), controlcookie, address);
+	return !fclose(f);
+}

--- a/src/pidfile.h
+++ b/src/pidfile.h
@@ -1,0 +1,16 @@
+#ifndef TINC_PIDFILE_H
+#define TINC_PIDFILE_H
+
+#include "system.h"
+
+typedef struct pidfile_t {
+	int pid;
+	char host[129];
+	char port[129];
+	char cookie[65];
+} pidfile_t;
+
+extern pidfile_t *read_pidfile(void) ATTR_MALLOC;
+extern bool write_pidfile(const char *controlcookie, const char *address);
+
+#endif // TINC_PIDFILE_H

--- a/src/protocol_auth.c
+++ b/src/protocol_auth.c
@@ -894,7 +894,7 @@ bool send_ack(connection_t *c) {
 		get_config_int(lookup_config(&config_tree, "Weight"), &c->estimated_weight);
 	}
 
-	return send_request(c, "%d %s %d %x", ACK, myport, c->estimated_weight, (c->options & 0xffffff) | (experimental ? (PROT_MINOR << 24) : 0));
+	return send_request(c, "%d %s %d %x", ACK, myport.udp, c->estimated_weight, (c->options & 0xffffff) | (experimental ? (PROT_MINOR << 24) : 0));
 }
 
 static void send_everything(connection_t *c) {
@@ -1067,7 +1067,7 @@ bool ack_h(connection_t *c, const char *request) {
 	if(getsockname(c->socket, &local_sa.sa, &local_salen) < 0) {
 		logger(DEBUG_ALWAYS, LOG_WARNING, "Could not get local socket address for connection with %s", c->name);
 	} else {
-		sockaddr_setport(&local_sa, myport);
+		sockaddr_setport(&local_sa, myport.udp);
 		c->edge->local_address = local_sa;
 	}
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -119,6 +119,24 @@ size_t b64decode_tinc(const char *src, void *dst, size_t length) {
 	}
 }
 
+bool is_decimal(const char *str) {
+	if(!str) {
+		return false;
+	}
+
+	errno = 0;
+	char *badchar = NULL;
+	strtol(str, &badchar, 10);
+	return !errno && badchar != str && !*badchar;
+}
+
+// itoa() conflicts with a similarly named function under MinGW.
+char *int_to_str(int num) {
+	char *str = NULL;
+	xasprintf(&str, "%d", num);
+	return str;
+}
+
 static size_t b64encode_tinc_internal(const void *src, char *dst, size_t length, const char *alphabet) {
 	uint32_t triplet;
 	const unsigned char *usrc = (unsigned char *)src;

--- a/src/utils.h
+++ b/src/utils.h
@@ -30,6 +30,12 @@
 extern size_t hex2bin(const char *src, void *dst, size_t length);
 extern size_t bin2hex(const void *src, char *dst, size_t length);
 
+// Returns true if string represents a base-10 integer.
+extern bool is_decimal(const char *str);
+
+// The reverse of atoi().
+extern char *int_to_str(int num);
+
 extern size_t b64encode_tinc(const void *src, char *dst, size_t length);
 extern size_t b64encode_tinc_urlsafe(const void *src, char *dst, size_t length);
 extern size_t b64decode_tinc(const char *src, void *dst, size_t length);

--- a/test/integration/testlib/proc.py
+++ b/test/integration/testlib/proc.py
@@ -229,9 +229,6 @@ class Tinc:
         if code is not None:
             check.equals(code, res)
 
-        # Check that port was not used by something else
-        check.not_in("Can't bind to ", err)
-
         return out if out else "", err if err else ""
 
     def tinc(self, *args: str) -> subp.Popen:

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -28,6 +28,9 @@ tests = {
     'code': 'test_random_noinit.c',
     'fail': true,
   },
+  'netutl': {
+    'code': 'test_netutl.c',
+  },
   'net': {
     'code': 'test_net.c',
     'mock': ['execute_script', 'environment_init', 'environment_exit'],
@@ -37,6 +40,9 @@ tests = {
   },
   'protocol': {
     'code': 'test_protocol.c',
+  },
+  'utils': {
+    'code': 'test_utils.c',
   },
   'splay_tree': {
     'code': 'test_splay_tree.c',

--- a/test/unit/test_netutl.c
+++ b/test/unit/test_netutl.c
@@ -1,0 +1,28 @@
+#include "unittest.h"
+#include "../../src/netutl.h"
+
+static void test_service_to_port_invalid(void **state) {
+	(void)state;
+
+	assert_int_equal(0, service_to_port(NULL));
+	assert_int_equal(0, service_to_port(""));
+	assert_int_equal(0, service_to_port("-1"));
+	assert_int_equal(0, service_to_port("foobar"));
+}
+
+static void test_service_to_port_valid(void **state) {
+	(void)state;
+
+	assert_int_equal(22, service_to_port("ssh"));
+	assert_int_equal(80, service_to_port("http"));
+	assert_int_equal(443, service_to_port("https"));
+	assert_int_equal(1234, service_to_port("1234"));
+}
+
+int main(void) {
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_service_to_port_invalid),
+		cmocka_unit_test(test_service_to_port_valid),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/unit/test_utils.c
+++ b/test/unit/test_utils.c
@@ -1,0 +1,70 @@
+#include "unittest.h"
+#include "../../src/utils.h"
+
+static void test_int_to_str(const char *ref, int num) {
+	char *result = int_to_str(num);
+	assert_string_equal(ref, result);
+	free(result);
+}
+
+static void test_int_to_str_return_expected(void **state) {
+	(void)state;
+
+	test_int_to_str("0", 0);
+	test_int_to_str("-1337", -1337);
+	test_int_to_str("65535", 65535);
+}
+
+static void test_is_decimal_fail_empty(void **state) {
+	(void)state;
+
+	assert_false(is_decimal(NULL));
+	assert_false(is_decimal(""));
+}
+
+static void test_is_decimal_fail_hex(void **state) {
+	(void)state;
+
+	assert_false(is_decimal("DEADBEEF"));
+	assert_false(is_decimal("0xCAFE"));
+}
+
+static void test_is_decimal_fail_junk_suffix(void **state) {
+	(void)state;
+
+	assert_false(is_decimal("123foobar"));
+	assert_false(is_decimal("777 "));
+}
+
+static void test_is_decimal_pass_simple(void **state) {
+	(void)state;
+
+	assert_true(is_decimal("0"));
+	assert_true(is_decimal("123"));
+}
+
+static void test_is_decimal_pass_signs(void **state) {
+	(void)state;
+
+	assert_true(is_decimal("-123"));
+	assert_true(is_decimal("+123"));
+}
+
+static void test_is_decimal_pass_whitespace_prefix(void **state) {
+	(void)state;
+
+	assert_true(is_decimal(" \r\n\t 777"));
+}
+
+int main(void) {
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_int_to_str_return_expected),
+		cmocka_unit_test(test_is_decimal_fail_empty),
+		cmocka_unit_test(test_is_decimal_fail_hex),
+		cmocka_unit_test(test_is_decimal_fail_junk_suffix),
+		cmocka_unit_test(test_is_decimal_pass_simple),
+		cmocka_unit_test(test_is_decimal_pass_signs),
+		cmocka_unit_test(test_is_decimal_pass_whitespace_prefix),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
This should cover #363.

Because TCP and UDP ports can differ if `Port 0` is used, `myport` was converted to a struct.

Since communication with tincd involves parsing the pidfile, we read the port from there instead of asking tincd. This is simpler, and does not requre adding more control request types, breaking compatibility with older daemons.

I had to write a small piece of yet another configuration parser. I'll look into extracting them into a separate 'library' so we don't reimplement the wheel over and over again.
