### PR TITLE
Changes to compiler flags & function attributes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,34 @@ endif
 cc_flags = [cc_defs]
 ld_flags = []
 
+if cc_name != 'msvc'
+  cc_flags += [
+    '-Qunused-arguments',
+    '-Wbad-function-cast',
+    '-Wduplicated-branches',
+    '-Wduplicated-cond',
+    '-Wformat-overflow=2',
+    '-Wformat-truncation=1', # 2 prints too much noise
+    '-Wformat=2',
+    '-Wlogical-op',
+    '-Wmissing-declarations',
+    '-Wmissing-noreturn',
+    '-Wmissing-prototypes',
+    '-Wno-embedded-directive',
+    '-Wold-style-definition',
+    '-Wredundant-decls',
+    '-Wreturn-type',
+    '-Wstrict-prototypes',
+    '-Wswitch-enum',
+    '-Wtrampolines', # may require executable stack which is disabled
+    '-Wvla', # VLAs are not supported by MSVC
+    '-Wwrite-strings',
+    '-fdiagnostics-show-option',
+    '-fno-strict-overflow',
+    '-fstrict-aliasing',
+  ]
+endif
+
 if opt_static.auto()
   static = os_name == 'windows'
 else
@@ -74,26 +102,15 @@ if opt_harden
   else
     cc_flags += [
       '-D_FORTIFY_SOURCE=2',
-      '-fwrapv',
-      '-fno-strict-overflow',
-      '-Wreturn-type',
-      '-Wold-style-definition',
-      '-Wmissing-declarations',
-      '-Wmissing-prototypes',
-      '-Wstrict-prototypes',
-      '-Wredundant-decls',
-      '-Wbad-function-cast',
-      '-Wwrite-strings',
-      '-fdiagnostics-show-option',
-      '-fstrict-aliasing',
-      '-Wmissing-noreturn',
+      '-fcf-protection=full',
+      '-fstack-protector-strong',
     ]
-    if cc_name == 'clang'
-      cc_flags += '-Qunused-arguments'
-    endif
-    ld_flags += ['-Wl,-z,relro', '-Wl,-z,now']
+    ld_flags += ['-Wl,-z,relro', '-Wl,-z,now', '-Wl,-z,noexecstack']
     if os_name == 'windows'
       ld_flags += ['-Wl,--dynamicbase', '-Wl,--nxcompat']
+    else
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458
+      cc_flags += '-fstack-clash-protection'
     endif
   endif
 endif

--- a/src/address_cache.c
+++ b/src/address_cache.c
@@ -213,7 +213,9 @@ const sockaddr_t *get_recent_address(address_cache_t *cache) {
 	}
 
 	// We're all out of addresses.
-	exit_configuration(&cache->config_tree);
+	exit_configuration(cache->config_tree);
+	cache->config_tree = NULL;
+
 	return false;
 }
 
@@ -255,7 +257,8 @@ void reset_address_cache(address_cache_t *cache, const sockaddr_t *sa) {
 	}
 
 	if(cache->config_tree) {
-		exit_configuration(&cache->config_tree);
+		exit_configuration(cache->config_tree);
+		cache->config_tree = NULL;
 	}
 
 	if(cache->ai) {
@@ -271,7 +274,8 @@ void reset_address_cache(address_cache_t *cache, const sockaddr_t *sa) {
 
 void close_address_cache(address_cache_t *cache) {
 	if(cache->config_tree) {
-		exit_configuration(&cache->config_tree);
+		exit_configuration(cache->config_tree);
+		cache->config_tree = NULL;
 	}
 
 	if(cache->ai) {

--- a/src/address_cache.h
+++ b/src/address_cache.h
@@ -43,8 +43,8 @@ typedef struct address_cache_t {
 void add_recent_address(address_cache_t *cache, const sockaddr_t *sa);
 const sockaddr_t *get_recent_address(address_cache_t *cache);
 
-address_cache_t *open_address_cache(struct node_t *node);
-void reset_address_cache(address_cache_t *cache, const sockaddr_t *sa);
 void close_address_cache(address_cache_t *cache);
+address_cache_t *open_address_cache(node_t *node) ATTR_DEALLOCATOR(close_address_cache);
+void reset_address_cache(address_cache_t *cache, const sockaddr_t *sa);
 
 #endif

--- a/src/bsd/tunemu.c
+++ b/src/bsd/tunemu.c
@@ -80,6 +80,7 @@ static pcap_t *pcap = NULL;
 static size_t data_buffer_length = 0;
 static uint8_t *data_buffer = NULL;
 
+static void tun_error(char *format, ...) ATTR_FORMAT(printf, 1, 2);
 static void tun_error(char *format, ...) {
 	va_list vl;
 	va_start(vl, format);

--- a/src/chacha-poly1305/chacha-poly1305.h
+++ b/src/chacha-poly1305/chacha-poly1305.h
@@ -5,8 +5,8 @@
 
 typedef struct chacha_poly1305_ctx chacha_poly1305_ctx_t;
 
-extern chacha_poly1305_ctx_t *chacha_poly1305_init(void);
 extern void chacha_poly1305_exit(chacha_poly1305_ctx_t *);
+extern chacha_poly1305_ctx_t *chacha_poly1305_init(void) ATTR_DEALLOCATOR(chacha_poly1305_exit);
 extern bool chacha_poly1305_set_key(chacha_poly1305_ctx_t *ctx, const uint8_t *key);
 
 extern bool chacha_poly1305_encrypt(chacha_poly1305_ctx_t *ctx, uint64_t seqnr, const void *indata, size_t inlen, void *outdata, size_t *outlen);

--- a/src/cipher.c
+++ b/src/cipher.c
@@ -28,11 +28,10 @@ cipher_t *cipher_alloc(void) {
 	return xzalloc(sizeof(cipher_t));
 }
 
-void cipher_free(cipher_t **cipher) {
-	if(cipher && *cipher) {
-		cipher_close(*cipher);
-		free(*cipher);
-		*cipher = NULL;
+void cipher_free(cipher_t *cipher) {
+	if(cipher) {
+		cipher_close(cipher);
+		free(cipher);
 	}
 }
 

--- a/src/cipher.h
+++ b/src/cipher.h
@@ -36,8 +36,8 @@
 #error Incorrect cryptographic library, please reconfigure.
 #endif
 
-extern cipher_t *cipher_alloc(void) ATTR_MALLOC;
-extern void cipher_free(cipher_t **cipher);
+extern void cipher_free(cipher_t *cipher);
+extern cipher_t *cipher_alloc(void) ATTR_MALLOC ATTR_DEALLOCATOR(cipher_free);
 extern bool cipher_open_by_name(cipher_t *cipher, const char *name);
 extern bool cipher_open_by_nid(cipher_t *cipher, nid_t nid);
 extern void cipher_close(cipher_t *cipher);

--- a/src/compression.h
+++ b/src/compression.h
@@ -18,8 +18,6 @@ typedef enum compression_level_t {
 	COMPRESS_LZO_HI = 11,
 
 	COMPRESS_LZ4 = 12,
-
-	COMPRESS_GUARD = INT_MAX, /* ensure that sizeof(compression_level_t) == sizeof(int) */
 } compression_level_t;
 
 STATIC_ASSERT(sizeof(compression_level_t) == sizeof(int), "compression_level_t has invalid size");

--- a/src/conf.c
+++ b/src/conf.c
@@ -87,9 +87,8 @@ void init_configuration(splay_tree_t *tree) {
 	tree->delete = (splay_action_t) free_config;
 }
 
-void exit_configuration(splay_tree_t **config_tree) {
-	splay_delete_tree(*config_tree);
-	*config_tree = NULL;
+void exit_configuration(splay_tree_t *config_tree) {
+	splay_delete_tree(config_tree);
 }
 
 config_t *new_config(void) {

--- a/src/conf.h
+++ b/src/conf.h
@@ -40,11 +40,11 @@ extern int maxtimeout;
 extern bool bypass_security;
 extern list_t cmdline_conf;
 
-extern splay_tree_t *create_configuration(void);
+extern void exit_configuration(splay_tree_t *config_tree);
+extern splay_tree_t *create_configuration(void) ATTR_MALLOC ATTR_DEALLOCATOR(exit_configuration);
 extern void init_configuration(splay_tree_t *);
-extern void exit_configuration(splay_tree_t **config_tree);
-extern config_t *new_config(void) ATTR_MALLOC;
 extern void free_config(config_t *config);
+extern config_t *new_config(void) ATTR_MALLOC ATTR_DEALLOCATOR(free_config);
 extern void config_add(splay_tree_t *config_tree, config_t *config);
 extern config_t *lookup_config(splay_tree_t *config_tree, const char *variable);
 extern config_t *lookup_config_next(splay_tree_t *config_tree, const config_t *config);

--- a/src/connection.c
+++ b/src/connection.c
@@ -148,7 +148,8 @@ void free_connection(connection_t *c) {
 	free(c->hostname);
 
 	if(c->config_tree) {
-		exit_configuration(&c->config_tree);
+		exit_configuration(c->config_tree);
+		c->config_tree = NULL;
 	}
 
 	free(c);

--- a/src/connection.h
+++ b/src/connection.h
@@ -79,7 +79,7 @@ typedef struct legacy_ctx_t {
 	legacy_crypto_t out;           /* cipher/digest we will use to send data to him */
 } legacy_ctx_t;
 
-legacy_ctx_t *new_legacy_ctx(rsa_t *rsa) ATTR_MALLOC;
+legacy_ctx_t *new_legacy_ctx(rsa_t *rsa);
 void free_legacy_ctx(legacy_ctx_t *ctx);
 #endif
 
@@ -131,8 +131,8 @@ extern connection_t *everyone;
 
 extern void init_connections(void);
 extern void exit_connections(void);
-extern connection_t *new_connection(void) ATTR_MALLOC;
 extern void free_connection(connection_t *c);
+extern connection_t *new_connection(void) ATTR_MALLOC ATTR_DEALLOCATOR(free_connection);
 extern void connection_add(connection_t *c);
 extern void connection_del(connection_t *c);
 extern bool dump_connections(struct connection_t *c);

--- a/src/digest.c
+++ b/src/digest.c
@@ -28,11 +28,10 @@ digest_t *digest_alloc(void) {
 	return xzalloc(sizeof(digest_t));
 }
 
-void digest_free(digest_t **digest) {
-	if(digest && *digest) {
-		digest_close(*digest);
-		free(*digest);
-		*digest = NULL;
+void digest_free(digest_t *digest) {
+	if(digest) {
+		digest_close(digest);
+		free(digest);
 	}
 }
 

--- a/src/digest.h
+++ b/src/digest.h
@@ -39,8 +39,8 @@ typedef struct digest digest_t;
 
 extern bool digest_open_by_name(digest_t *digest, const char *name, size_t maclength);
 extern bool digest_open_by_nid(digest_t *digest, nid_t nid, size_t maclength);
-extern digest_t *digest_alloc(void) ATTR_MALLOC;
-extern void digest_free(digest_t **digest);
+extern void digest_free(digest_t *digest);
+extern digest_t *digest_alloc(void) ATTR_MALLOC ATTR_DEALLOCATOR(digest_free);
 extern void digest_close(digest_t *digest);
 extern bool digest_create(digest_t *digest, const void *indata, size_t inlen, void *outdata) ATTR_WARN_UNUSED;
 extern bool digest_verify(digest_t *digest, const void *indata, size_t inlen, const void *digestdata) ATTR_WARN_UNUSED;

--- a/src/dropin.h
+++ b/src/dropin.h
@@ -26,8 +26,8 @@ extern int daemon(int, int);
 #endif
 
 #ifndef HAVE_ASPRINTF
-extern int asprintf(char **, const char *, ...);
-extern int vasprintf(char **, const char *, va_list ap);
+extern int asprintf(char **, const char *, ...) ATTR_FORMAT(printf, 2, 3);
+extern int vasprintf(char **, const char *, va_list ap) ATTR_FORMAT(printf, 2, 0);
 #endif
 
 #ifndef HAVE_GETTIMEOFDAY

--- a/src/ecdh.h
+++ b/src/ecdh.h
@@ -29,8 +29,8 @@
 typedef struct ecdh ecdh_t;
 #endif
 
-extern ecdh_t *ecdh_generate_public(void *pubkey) ATTR_MALLOC;
-extern bool ecdh_compute_shared(ecdh_t *ecdh, const void *pubkey, void *shared) ATTR_WARN_UNUSED;
 extern void ecdh_free(ecdh_t *ecdh);
+extern ecdh_t *ecdh_generate_public(void *pubkey) ATTR_MALLOC ATTR_DEALLOCATOR(ecdh_free);
+extern bool ecdh_compute_shared(ecdh_t *ecdh, const void *pubkey, void *shared) ATTR_WARN_UNUSED;
 
 #endif

--- a/src/ecdsa.h
+++ b/src/ecdsa.h
@@ -26,14 +26,14 @@
 typedef struct ecdsa ecdsa_t;
 #endif
 
-extern ecdsa_t *ecdsa_set_base64_public_key(const char *p) ATTR_MALLOC;
-extern char *ecdsa_get_base64_public_key(ecdsa_t *ecdsa);
-extern ecdsa_t *ecdsa_read_pem_public_key(FILE *fp) ATTR_MALLOC;
-extern ecdsa_t *ecdsa_read_pem_private_key(FILE *fp) ATTR_MALLOC;
+extern void ecdsa_free(ecdsa_t *ecdsa);
+extern ecdsa_t *ecdsa_set_base64_public_key(const char *p) ATTR_MALLOC ATTR_DEALLOCATOR(ecdsa_free);
+extern ecdsa_t *ecdsa_read_pem_public_key(FILE *fp) ATTR_MALLOC ATTR_DEALLOCATOR(ecdsa_free);
+extern ecdsa_t *ecdsa_read_pem_private_key(FILE *fp) ATTR_MALLOC ATTR_DEALLOCATOR(ecdsa_free);
+extern char *ecdsa_get_base64_public_key(ecdsa_t *ecdsa) ATTR_MALLOC;
 extern size_t ecdsa_size(ecdsa_t *ecdsa);
 extern bool ecdsa_sign(ecdsa_t *ecdsa, const void *in, size_t inlen, void *out) ATTR_WARN_UNUSED;
 extern bool ecdsa_verify(ecdsa_t *ecdsa, const void *in, size_t inlen, const void *out) ATTR_WARN_UNUSED;
 extern bool ecdsa_active(ecdsa_t *ecdsa);
-extern void ecdsa_free(ecdsa_t *ecdsa);
 
 #endif

--- a/src/ecdsagen.h
+++ b/src/ecdsagen.h
@@ -22,7 +22,7 @@
 
 #include "ecdsa.h"
 
-extern ecdsa_t *ecdsa_generate(void) ATTR_MALLOC;
+extern ecdsa_t *ecdsa_generate(void) ATTR_MALLOC ATTR_DEALLOCATOR(ecdsa_free);
 extern bool ecdsa_write_pem_public_key(ecdsa_t *ecdsa, FILE *fp) ATTR_WARN_UNUSED;
 extern bool ecdsa_write_pem_private_key(ecdsa_t *ecdsa, FILE *fp) ATTR_WARN_UNUSED;
 

--- a/src/ed25519/ecdsa.c
+++ b/src/ed25519/ecdsa.c
@@ -32,6 +32,11 @@ typedef struct {
 #include "../utils.h"
 #include "../xalloc.h"
 
+static ecdsa_t *ecdsa_new(void) ATTR_MALLOC ATTR_DEALLOCATOR(ecdsa_free);
+static ecdsa_t *ecdsa_new(void) {
+	return xzalloc(sizeof(ecdsa_t));
+}
+
 // Get and set ECDSA keys
 //
 ecdsa_t *ecdsa_set_base64_public_key(const char *p) {
@@ -42,7 +47,7 @@ ecdsa_t *ecdsa_set_base64_public_key(const char *p) {
 		return 0;
 	}
 
-	ecdsa_t *ecdsa = xzalloc(sizeof(*ecdsa));
+	ecdsa_t *ecdsa = ecdsa_new();
 	len = b64decode_tinc(p, ecdsa->public, len);
 
 	if(len != 32) {
@@ -123,7 +128,7 @@ exit:
 }
 
 ecdsa_t *ecdsa_read_pem_public_key(FILE *fp) {
-	ecdsa_t *ecdsa = xzalloc(sizeof(*ecdsa));
+	ecdsa_t *ecdsa = ecdsa_new();
 
 	if(read_pem(fp, "ED25519 PUBLIC KEY", ecdsa->public, sizeof(ecdsa->public))) {
 		return ecdsa;
@@ -134,7 +139,7 @@ ecdsa_t *ecdsa_read_pem_public_key(FILE *fp) {
 }
 
 ecdsa_t *ecdsa_read_pem_private_key(FILE *fp) {
-	ecdsa_t *ecdsa = xmalloc(sizeof(*ecdsa));
+	ecdsa_t *ecdsa = ecdsa_new();
 
 	if(read_pem(fp, "ED25519 PRIVATE KEY", ecdsa->private, sizeof(*ecdsa))) {
 		return ecdsa;

--- a/src/edge.h
+++ b/src/edge.h
@@ -42,8 +42,8 @@ typedef struct edge_t {
 extern splay_tree_t edge_weight_tree;          /* Tree with all known edges sorted on weight */
 
 extern void exit_edges(void);
-extern edge_t *new_edge(void) ATTR_MALLOC;
 extern void free_edge(edge_t *e);
+extern edge_t *new_edge(void) ATTR_MALLOC ATTR_DEALLOCATOR(free_edge);
 extern void init_edge_tree(splay_tree_t *tree);
 extern void edge_add(edge_t *e);
 extern void edge_del(edge_t *e);

--- a/src/fsck.c
+++ b/src/fsck.c
@@ -64,6 +64,7 @@ again:
 	goto again;
 }
 
+static void print_tinc_cmd(const char *format, ...) ATTR_FORMAT(printf, 1, 2);
 static void print_tinc_cmd(const char *format, ...) {
 	if(confbasegiven) {
 		fprintf(stderr, "%s -c %s ", exe_name, confbase);

--- a/src/fsck.c
+++ b/src/fsck.c
@@ -536,8 +536,7 @@ static bool check_public_keys(splay_tree_t *config, const char *name, rsa_t *rsa
 		fprintf(stderr, "WARNING: cannot read %s\n", host_file);
 	}
 
-	ecdsa_t *ec_pub = NULL;
-	read_ecdsa_public_key(&ec_pub, &config, name);
+	ecdsa_t *ec_pub = read_ecdsa_public_key(&config, name);
 
 	bool success = true;
 #ifndef DISABLE_LEGACY

--- a/src/gcrypt/cipher.c
+++ b/src/gcrypt/cipher.c
@@ -208,7 +208,7 @@ bool cipher_set_key_from_rsa(cipher_t *cipher, void *key, size_t len, bool encry
 
 bool cipher_encrypt(cipher_t *cipher, const void *indata, size_t inlen, void *outdata, size_t *outlen, bool oneshot) {
 	gcry_error_t err;
-	uint8_t pad[cipher->blklen];
+	uint8_t *pad = alloca(cipher->blklen);
 
 	if(cipher->padding) {
 		if(!oneshot) {

--- a/src/gcrypt/digest.c
+++ b/src/gcrypt/digest.c
@@ -149,7 +149,7 @@ bool digest_create(digest_t *digest, const void *indata, size_t inlen, void *out
 
 		memcpy(outdata, tmpdata, digest->maclength);
 	} else {
-		char tmpdata[len];
+		char *tmpdata = alloca(len);
 		gcry_md_hash_buffer(digest->algo, tmpdata, indata, inlen);
 		memcpy(outdata, tmpdata, digest->maclength);
 	}
@@ -159,7 +159,7 @@ bool digest_create(digest_t *digest, const void *indata, size_t inlen, void *out
 
 bool digest_verify(digest_t *digest, const void *indata, size_t inlen, const void *cmpdata) {
 	size_t len = digest->maclength;
-	uint8_t outdata[len];
+	uint8_t *outdata = alloca(len);
 
 	return digest_create(digest, indata, inlen, outdata) && !memcmp(cmpdata, outdata, len);
 }

--- a/src/gcrypt/pem.c
+++ b/src/gcrypt/pem.c
@@ -93,7 +93,7 @@ bool pem_encode(FILE *fp, const char *header, uint8_t *buf, size_t size) {
 		return false;
 	}
 
-	char b64[B64_SIZE(size)];
+	char *b64 = alloca(B64_SIZE(size));
 	const size_t b64len = b64encode(b64, buf, size);
 
 	for(size_t i = 0; i < b64len; i += 64) {

--- a/src/gcrypt/prf.c
+++ b/src/gcrypt/prf.c
@@ -32,7 +32,9 @@ static const size_t mdlen = 64;
 static const size_t blklen = 128;
 
 static bool hmac_sha512(const uint8_t *key, size_t keylen, const uint8_t *msg, size_t msglen, uint8_t *out) {
-	uint8_t tmp[blklen + mdlen];
+	const size_t tmplen = blklen + mdlen;
+	uint8_t *tmp = alloca(tmplen);
+
 	sha512_context md;
 
 	if(keylen <= blklen) {
@@ -69,7 +71,7 @@ static bool hmac_sha512(const uint8_t *key, size_t keylen, const uint8_t *msg, s
 	// opad
 	memxor(tmp, 0x36 ^ 0x5c, blklen);
 
-	if(sha512(tmp, sizeof(tmp), out) != 0) {
+	if(sha512(tmp, tmplen, out) != 0) {
 		return false;
 	}
 
@@ -86,28 +88,30 @@ bool prf(const uint8_t *secret, size_t secretlen, uint8_t *seed, size_t seedlen,
 	   It consists of the previous HMAC result plus the seed.
 	 */
 
-	uint8_t data[mdlen + seedlen];
+	const size_t datalen = mdlen + seedlen;
+	uint8_t *data = alloca(datalen);
+
 	memset(data, 0, mdlen);
 	memcpy(data + mdlen, seed, seedlen);
 
-	uint8_t hash[mdlen];
+	uint8_t *hash = alloca(mdlen);
 
 	while(outlen > 0) {
 		/* Inner HMAC */
-		if(!hmac_sha512(secret, secretlen, data, sizeof(data), data)) {
+		if(!hmac_sha512(secret, secretlen, data, datalen, data)) {
 			return false;
 		}
 
 		/* Outer HMAC */
 		if(outlen >= mdlen) {
-			if(!hmac_sha512(secret, secretlen, data, sizeof(data), out)) {
+			if(!hmac_sha512(secret, secretlen, data, datalen, out)) {
 				return false;
 			}
 
 			out += mdlen;
 			outlen -= mdlen;
 		} else {
-			if(!hmac_sha512(secret, secretlen, data, sizeof(data), hash)) {
+			if(!hmac_sha512(secret, secretlen, data, datalen, hash)) {
 				return false;
 			}
 

--- a/src/gcrypt/rsa.c
+++ b/src/gcrypt/rsa.c
@@ -111,8 +111,12 @@ static bool ber_read_mpi(unsigned char **p, size_t *buflen, gcry_mpi_t *mpi) {
 	return mpi ? !err : true;
 }
 
+rsa_t *rsa_new(void) {
+	return xzalloc(sizeof(rsa_t));
+}
+
 rsa_t *rsa_set_hex_public_key(const char *n, const char *e) {
-	rsa_t *rsa = xzalloc(sizeof(rsa_t));
+	rsa_t *rsa = rsa_new();
 
 	gcry_error_t err = gcry_mpi_scan(&rsa->n, GCRYMPI_FMT_HEX, n, 0, NULL);
 
@@ -130,7 +134,7 @@ rsa_t *rsa_set_hex_public_key(const char *n, const char *e) {
 }
 
 rsa_t *rsa_set_hex_private_key(const char *n, const char *e, const char *d) {
-	rsa_t *rsa = xzalloc(sizeof(rsa_t));
+	rsa_t *rsa = rsa_new();
 
 	gcry_error_t err = gcry_mpi_scan(&rsa->n, GCRYMPI_FMT_HEX, n, 0, NULL);
 
@@ -162,7 +166,7 @@ rsa_t *rsa_read_pem_public_key(FILE *fp) {
 		return NULL;
 	}
 
-	rsa_t *rsa = xzalloc(sizeof(rsa_t));
+	rsa_t *rsa = rsa_new();
 
 	if(!ber_skip_sequence(&derp, &derlen)
 	                || !ber_read_mpi(&derp, &derlen, &rsa->n)
@@ -185,7 +189,7 @@ rsa_t *rsa_read_pem_private_key(FILE *fp) {
 		return NULL;
 	}
 
-	rsa_t *rsa = xzalloc(sizeof(rsa_t));
+	rsa_t *rsa = rsa_new();
 
 	if(!ber_skip_sequence(&derp, &derlen)
 	                || !ber_read_mpi(&derp, &derlen, NULL)

--- a/src/gcrypt/rsa.h
+++ b/src/gcrypt/rsa.h
@@ -22,11 +22,16 @@
 
 #include <gcrypt.h>
 
+#include "../rsa.h"
+#include "../xalloc.h"
+
 #define TINC_RSA_INTERNAL
 typedef struct rsa {
 	gcry_mpi_t n;
 	gcry_mpi_t e;
 	gcry_mpi_t d;
 } rsa_t;
+
+extern rsa_t *rsa_new(void) ATTR_MALLOC ATTR_DEALLOCATOR(rsa_free);
 
 #endif

--- a/src/gcrypt/rsagen.c
+++ b/src/gcrypt/rsagen.c
@@ -297,7 +297,7 @@ rsa_t *rsa_generate(size_t bits, unsigned long exponent) {
 		return NULL;
 	}
 
-	rsa_t *rsa = xzalloc(sizeof(*rsa));
+	rsa_t *rsa = rsa_new();
 
 	rsa->n = find_mpi(s_rsa, "n");
 	rsa->e = find_mpi(s_rsa, "e");

--- a/src/have.h
+++ b/src/have.h
@@ -63,6 +63,12 @@
 #endif
 #endif
 
+#if defined(HAVE_ATTR_MALLOC_WITH_ARG)
+#define ATTR_DEALLOCATOR(dealloc) __attribute__((__malloc__(dealloc)))
+#else
+#define ATTR_DEALLOCATOR(dealloc)
+#endif
+
 #ifdef HAVE_ATTR_MALLOC
 #define ATTR_MALLOC __attribute__((__malloc__))
 #else

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -105,6 +105,7 @@ void ifconfig_address(FILE *out, const char *value) {
 		ipv6 = address;
 		break;
 
+	case SUBNET_MAC:
 	default:
 		return;
 	}
@@ -208,6 +209,7 @@ void ifconfig_route(FILE *out, const char *value) {
 			fprintf(out, "ip route add %s via %s dev \"$INTERFACE\" onlink\n", subnet_str, gateway_str);
 			break;
 
+		case SUBNET_MAC:
 		default:
 			return;
 		}
@@ -221,6 +223,7 @@ void ifconfig_route(FILE *out, const char *value) {
 			fprintf(out, "ip route add %s dev \"$INTERFACE\"\n", subnet_str);
 			break;
 
+		case SUBNET_MAC:
 		default:
 			return;
 		}
@@ -238,6 +241,7 @@ void ifconfig_route(FILE *out, const char *value) {
 			fprintf(out, "netsh interface ipv6 add route %s \"%%INTERFACE%%\" %s\n", subnet_str, gateway_str);
 			break;
 
+		case SUBNET_MAC:
 		default:
 			return;
 		}
@@ -251,6 +255,7 @@ void ifconfig_route(FILE *out, const char *value) {
 			fprintf(out, "netsh interface ipv6 add route %s \"%%INTERFACE%%\"\n", subnet_str);
 			break;
 
+		case SUBNET_MAC:
 		default:
 			return;
 		}
@@ -278,6 +283,7 @@ void ifconfig_route(FILE *out, const char *value) {
 			net2str(gateway_str, sizeof(gateway_str), &ipv6);
 			break;
 
+		case SUBNET_MAC:
 		default:
 			return;
 		}
@@ -298,6 +304,7 @@ void ifconfig_route(FILE *out, const char *value) {
 		fprintf(out, "route add -inet6 %s %s\n", subnet_str, gateway_str);
 		break;
 
+	case SUBNET_MAC:
 	default:
 		return;
 	}

--- a/src/keys.h
+++ b/src/keys.h
@@ -7,12 +7,12 @@
 
 extern bool disable_old_keys(const char *filename, const char *what);
 
-extern ecdsa_t *read_ecdsa_private_key(splay_tree_t *config_tree, char **keyfile);
-extern bool read_ecdsa_public_key(ecdsa_t **ecdsa, splay_tree_t **config_tree, const char *name);
+extern ecdsa_t *read_ecdsa_private_key(splay_tree_t *config_tree, char **keyfile) ATTR_MALLOC ATTR_DEALLOCATOR(ecdsa_free);
+extern ecdsa_t *read_ecdsa_public_key(splay_tree_t **config_tree, const char *name) ATTR_MALLOC ATTR_DEALLOCATOR(ecdsa_free);
 
 #ifndef DISABLE_LEGACY
-extern rsa_t *read_rsa_private_key(splay_tree_t *config, char **keyfile);
-extern rsa_t *read_rsa_public_key(splay_tree_t *config_tree, const char *name);
+extern rsa_t *read_rsa_private_key(splay_tree_t *config, char **keyfile) ATTR_MALLOC ATTR_DEALLOCATOR(rsa_free);
+extern rsa_t *read_rsa_public_key(splay_tree_t *config_tree, const char *name) ATTR_MALLOC ATTR_DEALLOCATOR(rsa_free);
 #endif
 
 #endif // TINC_KEYS_H

--- a/src/list.h
+++ b/src/list.h
@@ -45,10 +45,11 @@ typedef struct list_t {
 
 /* (De)constructors */
 
-extern list_t *list_alloc(list_action_t delete) ATTR_MALLOC;
 extern void list_free(list_t *list);
-extern list_node_t *list_alloc_node(void);
+extern list_t *list_alloc(list_action_t delete) ATTR_MALLOC ATTR_DEALLOCATOR(list_free);
+
 extern void list_free_node(list_t *list, list_node_t *node);
+extern list_node_t *list_alloc_node(void) ATTR_MALLOC ATTR_DEALLOCATOR(list_free_node);
 
 /* Insertion and deletion */
 

--- a/src/logger.c
+++ b/src/logger.c
@@ -239,6 +239,7 @@ void logger(debug_t level, int priority, const char *format, ...) {
 	real_logger(level, priority, message);
 }
 
+static void sptps_logger(sptps_t *s, int s_errno, const char *format, va_list ap) ATTR_FORMAT(printf, 3, 0);
 static void sptps_logger(sptps_t *s, int s_errno, const char *format, va_list ap) {
 	(void)s_errno;
 	char message[1024];

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,15 @@ foreach attr : ['malloc', 'nonnull', 'warn_unused_result', 'packed', 'format']
 endforeach
 
 if cc.compiles('''
+    #include <stdlib.h>
+    extern void *make() __attribute__((malloc(free)));
+    int main(void) { return 0; }
+''')
+  cdata.set('HAVE_ATTR_MALLOC_WITH_ARG', 1,
+            description: 'support for __attribute__((malloc(deallocator)))')
+endif
+
+if cc.compiles('''
     _Static_assert(1, "ok");
     int main(void) { return 0; }
 ''')

--- a/src/net.h
+++ b/src/net.h
@@ -199,7 +199,7 @@ extern void send_packet(struct node_t *n, vpn_packet_t *packet);
 extern void receive_tcppacket(struct connection_t *c, const char *buffer, size_t length);
 extern bool receive_tcppacket_sptps(struct connection_t *c, const char *buffer, size_t length);
 extern void broadcast_packet(const struct node_t *n, vpn_packet_t *packet);
-extern char *get_name(void);
+extern char *get_name(void) ATTR_MALLOC;
 extern void device_enable(void);
 extern void device_disable(void);
 extern bool setup_myself_reloadable(void);

--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -1643,6 +1643,7 @@ void broadcast_packet(const node_t *from, vpn_packet_t *packet) {
 
 		break;
 
+	case BMODE_NONE:
 	default:
 		break;
 	}

--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -903,7 +903,8 @@ static bool setup_myself(void) {
 
 		if(!cipher_open_by_name(myself->incipher, cipher)) {
 			logger(DEBUG_ALWAYS, LOG_ERR, "Unrecognized cipher type!");
-			cipher_free(&myself->incipher);
+			cipher_free(myself->incipher);
+			myself->incipher = NULL;
 			free(cipher);
 			return false;
 		}
@@ -938,7 +939,8 @@ static bool setup_myself(void) {
 
 		if(!digest_open_by_name(myself->indigest, digest, maclength)) {
 			logger(DEBUG_ALWAYS, LOG_ERR, "Unrecognized digest type!");
-			digest_free(&myself->indigest);
+			digest_free(myself->indigest);
+			myself->indigest = NULL;
 			free(digest);
 			return false;
 		}

--- a/src/netutl.h
+++ b/src/netutl.h
@@ -27,7 +27,7 @@ extern bool hostnames;
 
 // Converts service name (as listed in /etc/services) to port number. Returns 0 on error.
 extern uint16_t service_to_port(const char *service);
-extern struct addrinfo *str2addrinfo(const char *address, const char *service, int socktype) ATTR_MALLOC;
+extern struct addrinfo *str2addrinfo(const char *address, const char *service, int socktype) ATTR_DEALLOCATOR(freeaddrinfo);
 extern sockaddr_t str2sockaddr(const char *address, const char *port);
 extern void sockaddr2str(const sockaddr_t *sa, char **address, char **port);
 extern char *sockaddr2hostname(const sockaddr_t *sa) ATTR_MALLOC;

--- a/src/node.c
+++ b/src/node.c
@@ -99,10 +99,10 @@ void free_node(node_t *n) {
 	sockaddrfree(&n->address);
 
 #ifndef DISABLE_LEGACY
-	cipher_free(&n->incipher);
-	digest_free(&n->indigest);
-	cipher_free(&n->outcipher);
-	digest_free(&n->outdigest);
+	cipher_free(n->incipher);
+	digest_free(n->indigest);
+	cipher_free(n->outcipher);
+	digest_free(n->outdigest);
 #endif
 
 	ecdsa_free(n->ecdsa);

--- a/src/node.h
+++ b/src/node.h
@@ -121,8 +121,8 @@ extern struct node_t *myself;
 extern splay_tree_t node_tree;
 
 extern void exit_nodes(void);
-extern node_t *new_node(void) ATTR_MALLOC;
 extern void free_node(node_t *n);
+extern node_t *new_node(void) ATTR_MALLOC ATTR_DEALLOCATOR(free_node);
 extern void node_add(node_t *n);
 extern void node_del(node_t *n);
 extern node_t *lookup_node(char *name);

--- a/src/protocol_auth.c
+++ b/src/protocol_auth.c
@@ -82,6 +82,7 @@ static bool send_proxyrequest(connection_t *c) {
 	case PROXY_EXEC:
 		return true;
 
+	case PROXY_NONE:
 	default:
 		logger(DEBUG_ALWAYS, LOG_ERR, "Unknown proxy type");
 		return false;

--- a/src/protocol_key.c
+++ b/src/protocol_key.c
@@ -346,8 +346,11 @@ bool send_ans_key(node_t *to) {
 
 	randomize(key, keylen);
 
-	cipher_free(&to->incipher);
-	digest_free(&to->indigest);
+	cipher_free(to->incipher);
+	to->incipher = NULL;
+
+	digest_free(to->indigest);
+	to->indigest = NULL;
 
 	if(myself->incipher) {
 		to->incipher = cipher_alloc();
@@ -470,8 +473,11 @@ bool ans_key_h(connection_t *c, const char *request) {
 
 #ifndef DISABLE_LEGACY
 	/* Don't use key material until every check has passed. */
-	cipher_free(&from->outcipher);
-	digest_free(&from->outdigest);
+	cipher_free(from->outcipher);
+	from->outcipher = NULL;
+
+	digest_free(from->outdigest);
+	from->outdigest = NULL;
 #endif
 
 	if(!from->status.sptps) {
@@ -570,7 +576,8 @@ bool ans_key_h(connection_t *c, const char *request) {
 		from->outcipher = cipher_alloc();
 
 		if(!cipher_open_by_nid(from->outcipher, cipher)) {
-			cipher_free(&from->outcipher);
+			cipher_free(from->outcipher);
+			from->outcipher = NULL;
 			logger(DEBUG_ALWAYS, LOG_ERR, "Node %s (%s) uses unknown cipher!", from->name, from->hostname);
 			return false;
 		}
@@ -582,7 +589,8 @@ bool ans_key_h(connection_t *c, const char *request) {
 		from->outdigest = digest_alloc();
 
 		if(!digest_open_by_nid(from->outdigest, digest, maclength)) {
-			digest_free(&from->outdigest);
+			digest_free(from->outdigest);
+			from->outdigest = NULL;
 			logger(DEBUG_ALWAYS, LOG_ERR, "Node %s (%s) uses unknown digest!", from->name, from->hostname);
 			return false;
 		}

--- a/src/rsa.h
+++ b/src/rsa.h
@@ -27,10 +27,10 @@ typedef struct rsa rsa_t;
 #endif
 
 extern void rsa_free(rsa_t *rsa);
-extern rsa_t *rsa_set_hex_public_key(const char *n, const char *e) ATTR_MALLOC;
-extern rsa_t *rsa_set_hex_private_key(const char *n, const char *e, const char *d) ATTR_MALLOC;
-extern rsa_t *rsa_read_pem_public_key(FILE *fp) ATTR_MALLOC;
-extern rsa_t *rsa_read_pem_private_key(FILE *fp) ATTR_MALLOC;
+extern rsa_t *rsa_set_hex_public_key(const char *n, const char *e) ATTR_MALLOC ATTR_DEALLOCATOR(rsa_free);
+extern rsa_t *rsa_set_hex_private_key(const char *n, const char *e, const char *d) ATTR_MALLOC ATTR_DEALLOCATOR(rsa_free);
+extern rsa_t *rsa_read_pem_public_key(FILE *fp) ATTR_MALLOC ATTR_DEALLOCATOR(rsa_free);
+extern rsa_t *rsa_read_pem_private_key(FILE *fp) ATTR_MALLOC ATTR_DEALLOCATOR(rsa_free);
 extern size_t rsa_size(const rsa_t *rsa);
 extern bool rsa_public_encrypt(rsa_t *rsa, const void *in, size_t len, void *out) ATTR_WARN_UNUSED;
 extern bool rsa_private_decrypt(rsa_t *rsa, const void *in, size_t len, void *out) ATTR_WARN_UNUSED;

--- a/src/rsagen.h
+++ b/src/rsagen.h
@@ -22,7 +22,7 @@
 
 #include "rsa.h"
 
-extern rsa_t *rsa_generate(size_t bits, unsigned long exponent) ATTR_MALLOC;
+extern rsa_t *rsa_generate(size_t bits, unsigned long exponent) ATTR_DEALLOCATOR(rsa_free);
 extern bool rsa_write_pem_public_key(rsa_t *rsa, FILE *fp) ATTR_WARN_UNUSED;
 extern bool rsa_write_pem_private_key(rsa_t *rsa, FILE *fp) ATTR_WARN_UNUSED;
 

--- a/src/script.h
+++ b/src/script.h
@@ -29,8 +29,8 @@ typedef struct environment {
 	char **entries;
 } environment_t;
 
-extern int environment_add(environment_t *env, const char *format, ...);
-extern void environment_update(environment_t *env, int pos, const char *format, ...);
+extern int environment_add(environment_t *env, const char *format, ...) ATTR_FORMAT(printf, 2, 3);
+extern void environment_update(environment_t *env, int pos, const char *format, ...) ATTR_FORMAT(printf, 3, 4);
 extern void environment_init(environment_t *env);
 extern void environment_exit(environment_t *env);
 

--- a/src/splay_tree.h
+++ b/src/splay_tree.h
@@ -63,11 +63,11 @@ typedef struct splay_tree_t {
 
 /* (De)constructors */
 
-extern splay_tree_t *splay_alloc_tree(splay_compare_t compare, splay_action_t delete) ATTR_MALLOC;
 extern void splay_free_tree(splay_tree_t *tree);
+extern splay_tree_t *splay_alloc_tree(splay_compare_t compare, splay_action_t delete) ATTR_MALLOC ATTR_DEALLOCATOR(splay_free_tree);
 
-extern splay_node_t *splay_alloc_node(void) ATTR_MALLOC;
 extern void splay_free_node(splay_tree_t *tree, splay_node_t *node);
+extern splay_node_t *splay_alloc_node(void) ATTR_MALLOC ATTR_DEALLOCATOR(splay_free_node);
 
 /* Insertion and deletion */
 

--- a/src/sptps.c
+++ b/src/sptps.c
@@ -68,6 +68,7 @@ void sptps_log_stderr(sptps_t *s, int s_errno, const char *format, va_list ap) {
 void (*sptps_log)(sptps_t *s, int s_errno, const char *format, va_list ap) = sptps_log_stderr;
 
 // Log an error message.
+static bool error(sptps_t *s, int s_errno, const char *format, ...) ATTR_FORMAT(printf, 3, 4);
 static bool error(sptps_t *s, int s_errno, const char *format, ...) {
 	(void)s;
 	(void)s_errno;
@@ -83,6 +84,7 @@ static bool error(sptps_t *s, int s_errno, const char *format, ...) {
 	return false;
 }
 
+static void warning(sptps_t *s, const char *format, ...) ATTR_FORMAT(printf, 2, 3);
 static void warning(sptps_t *s, const char *format, ...) {
 	va_list ap;
 	va_start(ap, format);
@@ -640,7 +642,7 @@ size_t sptps_receive_data(sptps_t *s, const void *vdata, size_t len) {
 		s->inbuf = realloc(s->inbuf, s->reclen + 19UL);
 
 		if(!s->inbuf) {
-			return error(s, errno, strerror(errno));
+			return error(s, errno, "%s", strerror(errno));
 		}
 
 		// Exit early if we have no more data to process.
@@ -718,7 +720,7 @@ bool sptps_start(sptps_t *s, void *handle, bool initiator, bool datagram, ecdsa_
 		s->late = malloc(s->replaywin);
 
 		if(!s->late) {
-			return error(s, errno, strerror(errno));
+			return error(s, errno, "%s", strerror(errno));
 		}
 
 		memset(s->late, 0, s->replaywin);
@@ -727,14 +729,14 @@ bool sptps_start(sptps_t *s, void *handle, bool initiator, bool datagram, ecdsa_
 	s->label = malloc(labellen);
 
 	if(!s->label) {
-		return error(s, errno, strerror(errno));
+		return error(s, errno, "%s", strerror(errno));
 	}
 
 	if(!datagram) {
 		s->inbuf = malloc(7);
 
 		if(!s->inbuf) {
-			return error(s, errno, strerror(errno));
+			return error(s, errno, "%s", strerror(errno));
 		}
 
 		s->buflen = 0;

--- a/src/sptps.h
+++ b/src/sptps.h
@@ -104,9 +104,9 @@ typedef struct sptps {
 } sptps_t;
 
 extern unsigned int sptps_replaywin;
-extern void sptps_log_quiet(sptps_t *s, int s_errno, const char *format, va_list ap);
-extern void sptps_log_stderr(sptps_t *s, int s_errno, const char *format, va_list ap);
-extern void (*sptps_log)(sptps_t *s, int s_errno, const char *format, va_list ap);
+extern void sptps_log_quiet(sptps_t *s, int s_errno, const char *format, va_list ap) ATTR_FORMAT(printf, 3, 0);
+extern void sptps_log_stderr(sptps_t *s, int s_errno, const char *format, va_list ap) ATTR_FORMAT(printf, 3, 0);
+extern void (*sptps_log)(sptps_t *s, int s_errno, const char *format, va_list ap) ATTR_FORMAT(printf, 3, 0);
 extern bool sptps_start(sptps_t *s, void *handle, bool initiator, bool datagram, ecdsa_t *mykey, ecdsa_t *hiskey, const void *label, size_t labellen, send_data_t send_data, receive_record_t receive_record);
 extern bool sptps_stop(sptps_t *s);
 extern bool sptps_send_record(sptps_t *s, uint8_t type, const void *data, uint16_t len);

--- a/src/sptps_test.c
+++ b/src/sptps_test.c
@@ -154,7 +154,7 @@ static struct option const long_options[] = {
 };
 
 static void usage(void) {
-	static const char *message =
+	fprintf(stderr,
 	        "Usage: %s [options] my_ed25519_key_file his_ed25519_key_file [host] port\n"
 	        "\n"
 	        "Valid options are:\n"
@@ -172,9 +172,8 @@ static void usage(void) {
 	        "  -4                      Use IPv4.\n"
 	        "  -6                      Use IPv6.\n"
 	        "\n"
-	        "Report bugs to tinc@tinc-vpn.org.\n";
-
-	fprintf(stderr, message, program_name);
+	        "Report bugs to tinc@tinc-vpn.org.\n",
+	        program_name);
 }
 
 #ifdef HAVE_WINDOWS

--- a/src/subnet.h
+++ b/src/subnet.h
@@ -65,8 +65,8 @@ typedef struct subnet_t {
 extern splay_tree_t subnet_tree;
 
 extern int subnet_compare(const struct subnet_t *a, const struct subnet_t *b);
-extern subnet_t *new_subnet(void) ATTR_MALLOC;
 extern void free_subnet(subnet_t *subnet);
+extern subnet_t *new_subnet(void) ATTR_MALLOC ATTR_DEALLOCATOR(free_subnet);
 extern void init_subnets(void);
 extern void exit_subnets(void);
 extern void init_subnet_tree(splay_tree_t *tree);

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -108,7 +108,7 @@ static struct option const long_options[] = {
 };
 
 static void version(void) {
-	static const char *message =
+	fprintf(stdout,
 	        "%s version %s (built %s %s, protocol %d.%d)\n"
 	        "Features:"
 #ifdef HAVE_READLINE
@@ -126,16 +126,15 @@ static void version(void) {
 	        "\n"
 	        "tinc comes with ABSOLUTELY NO WARRANTY.  This is free software,\n"
 	        "and you are welcome to redistribute it under certain conditions;\n"
-	        "see the file COPYING for details.\n";
-
-	printf(message, PACKAGE, BUILD_VERSION, BUILD_DATE, BUILD_TIME, PROT_MAJOR, PROT_MINOR);
+	        "see the file COPYING for details.\n",
+	        PACKAGE, BUILD_VERSION, BUILD_DATE, BUILD_TIME, PROT_MAJOR, PROT_MINOR);
 }
 
 static void usage(bool status) {
 	if(status) {
 		fprintf(stderr, "Try `%s --help\' for more information.\n", program_name);
 	} else {
-		static const char *message =
+		fprintf(stdout,
 		        "Usage: %s [options] command\n"
 		        "\n"
 		        "Valid options are:\n"
@@ -194,9 +193,8 @@ static void usage(bool status) {
 		        "  sign [FILE]                Generate a signed version of a file.\n"
 		        "  verify NODE [FILE]         Verify that a file was signed by the given NODE.\n"
 		        "\n"
-		        "Report bugs to tinc@tinc-vpn.org.\n";
-
-		printf(message, program_name);
+		        "Report bugs to tinc@tinc-vpn.org.\n",
+		        program_name);
 	}
 }
 

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -1623,7 +1623,8 @@ char *get_my_name(bool verbose) {
 	return NULL;
 }
 
-ecdsa_t *get_pubkey(FILE *f) {
+static ecdsa_t *get_pubkey(FILE *f) ATTR_MALLOC ATTR_DEALLOCATOR(ecdsa_free);
+static ecdsa_t *get_pubkey(FILE *f) {
 	char buf[4096];
 	char *value;
 

--- a/src/tincctl.h
+++ b/src/tincctl.h
@@ -49,7 +49,7 @@ extern const var_t variables[];
 extern size_t rstrip(char *value);
 extern char *get_my_name(bool verbose) ATTR_MALLOC;
 extern bool connect_tincd(bool verbose);
-extern bool sendline(int fd, const char *format, ...);
+extern bool sendline(int fd, const char *format, ...) ATTR_FORMAT(printf, 2, 3);
 extern bool recvline(int fd, char *line, size_t len);
 extern int check_port(const char *name);
 

--- a/src/tincctl.h
+++ b/src/tincctl.h
@@ -47,11 +47,10 @@ typedef struct {
 extern const var_t variables[];
 
 extern size_t rstrip(char *value);
-extern char *get_my_name(bool verbose);
+extern char *get_my_name(bool verbose) ATTR_MALLOC;
 extern bool connect_tincd(bool verbose);
 extern bool sendline(int fd, const char *format, ...);
 extern bool recvline(int fd, char *line, size_t len);
 extern int check_port(const char *name);
-extern ecdsa_t *get_pubkey(FILE *f);
 
 #endif

--- a/src/tincd.c
+++ b/src/tincd.c
@@ -130,7 +130,7 @@ static void usage(bool status) {
 		fprintf(stderr, "Try `%s --help\' for more information.\n",
 		        program_name);
 	else {
-		static const char *message =
+		fprintf(stdout,
 		        "Usage: %s [option]...\n"
 		        "\n"
 		        "  -c, --config=DIR              Read configuration options from DIR.\n"
@@ -152,9 +152,8 @@ static void usage(bool status) {
 		        "      --help                    Display this help and exit.\n"
 		        "      --version                 Output version information and exit.\n"
 		        "\n"
-		        "Report bugs to tinc@tinc-vpn.org.\n";
-
-		printf(message, program_name);
+		        "Report bugs to tinc@tinc-vpn.org.\n",
+		        program_name);
 	}
 }
 
@@ -419,7 +418,7 @@ int main(int argc, char **argv) {
 	}
 
 	if(show_version) {
-		static const char *message =
+		fprintf(stdout,
 		        "%s version %s (built %s %s, protocol %d.%d)\n"
 		        "Features:"
 #ifdef HAVE_OPENSSL
@@ -461,9 +460,8 @@ int main(int argc, char **argv) {
 		        "\n"
 		        "tinc comes with ABSOLUTELY NO WARRANTY.  This is free software,\n"
 		        "and you are welcome to redistribute it under certain conditions;\n"
-		        "see the file COPYING for details.\n";
-
-		printf(message, PACKAGE, BUILD_VERSION, BUILD_DATE, BUILD_TIME, PROT_MAJOR, PROT_MINOR);
+		        "see the file COPYING for details.\n",
+		        PACKAGE, BUILD_VERSION, BUILD_DATE, BUILD_TIME, PROT_MAJOR, PROT_MINOR);
 		return 0;
 	}
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -72,10 +72,10 @@ static inline suseconds_t jitter(void) {
 
 extern bool check_id(const char *id);
 extern bool check_netname(const char *netname, bool strict);
-char *replace_name(const char *name);
+char *replace_name(const char *name) ATTR_MALLOC;
 
 char *absolute_path(const char *path) ATTR_MALLOC;
 
-extern FILE *fopenmask(const char *filename, const char *mode, mode_t perms);
+extern FILE *fopenmask(const char *filename, const char *mode, mode_t perms) ATTR_DEALLOCATOR(fclose);
 
 #endif

--- a/src/xalloc.h
+++ b/src/xalloc.h
@@ -68,6 +68,7 @@ static inline char *xstrdup(const char *s) {
 	return p;
 }
 
+static inline int xvasprintf(char **strp, const char *fmt, va_list ap) ATTR_FORMAT(printf, 2, 0);
 static inline int xvasprintf(char **strp, const char *fmt, va_list ap) {
 #ifdef HAVE_WINDOWS
 	char buf[1024];


### PR DESCRIPTION
Bits and pieces that are somewhat related:

- change some compiler flags:
    - enable CFI checks (no effect on older CPUs, does [this][cfi] on modern x86; the article is about the kernel, but the tech is similar). Ubuntu has been doing that [for years][cet].
    - add more stack smashing checks (and make stack non-executable)
    - enable more warnings on top of `-Wall -Wextra` (particularly warn about VLAs which we cannot use anymore because of MSVC, and about missing enum `case`s, which helps when adding new values to enums)
- fix warnings triggered by new flags
- since doing that involves adding a bunch of `__attribute__((format))`, use the opportunity to add `__attribute__((malloc(dealloc))` so [newer GCC][dealloc] warn us about using wrong deallocators
- fix a couple of leaks found by `-fanalyzer` (gives lots of false positives, so it's a bit early to enable it permanently)
- use current year in copyright messages

[dealloc]: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html

Currently `tinc --version` says the copyright expired 3 years ago, `tincd --version` has its own opinion on this.
Let's just get the year from the OS and never touch the message again.

[cet]: https://wiki.ubuntu.com/ToolChain/CompilerFlags#A-fcf-protection
[cfi]: https://lwn.net/Articles/856514/

---

I would have posted this separately, but only cbadb52f011cb8b5a79640ee6bd71d9a2b43f60e can be split off without causing more conflicts (of which are are enough already from previous PRs), and it's only three lines.