### PR TITLE
CI: fix building Ubuntu packages (and ignore further failures)

### DIFF
--- a/.ci/package/build.sh
+++ b/.ci/package/build.sh
@@ -5,6 +5,11 @@ set -eu
 build_linux() {
   . /etc/os-release
 
+  # https://github.com/actions/checkout/issues/760
+  git config --global --add safe.directory "$PWD" || true
+  GIT_CEILING_DIRECTORIES=$PWD
+  export GIT_CEILING_DIRECTORIES
+
   case "$ID" in
   debian | ubuntu)
     bash .ci/package/deb/build.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,6 +192,7 @@ jobs:
       - name: Build package
         run: sh .ci/package/build.sh
         if: github.ref == 'refs/heads/1.1' || startsWith(github.ref, 'refs/tags/release-')
+        continue-on-error: true
 
       - name: Upload package
         uses: actions/upload-artifact@v2
@@ -200,10 +201,12 @@ jobs:
           path: |
             *.deb
             ~/rpmbuild/RPMS/*/*.rpm
+        continue-on-error: true
 
   pkg-publish:
     if: always() && (github.ref == 'refs/heads/1.1' || startsWith(github.ref, 'refs/tags/release-'))
     runs-on: ubuntu-latest
+    continue-on-error: true
     needs:
       - linux
       - mingw
@@ -302,12 +305,14 @@ jobs:
         shell: msys2 {0}
         run: sh .ci/package/build.sh
         if: github.ref == 'refs/heads/1.1' || startsWith(github.ref, 'refs/tags/release-')
+        continue-on-error: true
 
       - name: Upload package
         uses: actions/upload-artifact@v2
         with:
           name: pkg-windows
           path: .ci/package/win/tinc-*.exe
+        continue-on-error: true
 
       - name: Run tests without legacy protocol
         shell: msys2 {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Run tests with libgcrypt
         run: sudo -u build CI=1 HOST=${{ matrix.arch }} sh .ci/test/run.sh gcrypt
+        if: always()
 
       - name: Upload test results
         uses: actions/upload-artifact@v2
@@ -123,6 +124,7 @@ jobs:
 
       - name: Sanitize tests with default settings
         run: bash .ci/sanitizers/run.sh default
+        if: always()
 
       - name: Sanitize tests without legacy protocol
         run: bash .ci/sanitizers/run.sh nolegacy
@@ -174,6 +176,7 @@ jobs:
 
       - name: Run tests with default settings
         run: sudo -u build CI=1 sh .ci/test/run.sh default
+        if: always()
 
       - name: Run tests without legacy protocol
         run: sudo -u build CI=1 sh .ci/test/run.sh nolegacy
@@ -181,6 +184,7 @@ jobs:
 
       - name: Run tests with libgcrypt
         run: sudo -u build CI=1 sh .ci/test/run.sh gcrypt
+        if: always()
 
       - name: Upload test results
         uses: actions/upload-artifact@v2
@@ -259,6 +263,7 @@ jobs:
 
       - name: Run tests with libgcrypt
         run: sh .ci/test/run.sh gcrypt
+        if: always()
 
       - name: Upload test results
         uses: actions/upload-artifact@v2
@@ -322,6 +327,7 @@ jobs:
       - name: Run tests with libgcrypt
         shell: msys2 {0}
         run: sh .ci/test/run.sh gcrypt
+        if: always()
 
       - name: Upload test results
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
The issue is described [here][issue]. It's pretty wild to have breaking changes in a stable distribution, even though it's a security fix.

[issue]: https://github.com/actions/checkout/issues/760

Package jobs turned out to be a pain. Since it's a just a minor additional feature of having CI and not its main task, let's not mark jobs as failed if it couldn't build or upload packages.

I'll still be looking at full results and fixing issues as they crop up.
