### PR TITLE
Fix reading broken keys using libgcrypt

### DIFF
--- a/src/gcrypt/asn1.h
+++ b/src/gcrypt/asn1.h
@@ -1,0 +1,10 @@
+#ifndef TINC_GCRYPT_ASN1_H
+#define TINC_GCRYPT_ASN1_H
+
+// https://luca.ntop.org/Teaching/Appunti/asn1.html
+typedef enum {
+	TAG_INTEGER = 2,
+	TAG_SEQUENCE = 16,
+} asn1_tag_t;
+
+#endif // TINC_GCRYPT_ASN1_H

--- a/src/gcrypt/rsagen.c
+++ b/src/gcrypt/rsagen.c
@@ -22,17 +22,12 @@
 #include <gcrypt.h>
 #include <assert.h>
 
+#include "asn1.h"
 #include "rsa.h"
 #include "pem.h"
 #include "../rsagen.h"
 #include "../xalloc.h"
 #include "../utils.h"
-
-// ASN.1 tags.
-typedef enum {
-	TAG_INTEGER = 2,
-	TAG_SEQUENCE = 16,
-} asn1_tag_t;
 
 static size_t der_tag_len(size_t n) {
 	if(n < 128) {

--- a/src/keys.c
+++ b/src/keys.c
@@ -134,6 +134,7 @@ ecdsa_t *read_ecdsa_private_key(splay_tree_t *config_tree, char **keyfile) {
 	if(fstat(fileno(fp), &s)) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Could not stat Ed25519 private key file `%s': %s'", fname, strerror(errno));
 		free(fname);
+		fclose(fp);
 		return false;
 	}
 
@@ -268,6 +269,7 @@ rsa_t *read_rsa_private_key(splay_tree_t *config_tree, char **keyfile) {
 	if(fstat(fileno(fp), &s)) {
 		logger(DEBUG_ALWAYS, LOG_ERR, "Could not stat RSA private key file `%s': %s'", fname, strerror(errno));
 		free(fname);
+		fclose(fp);
 		return NULL;
 	}
 

--- a/src/multicast_device.c
+++ b/src/multicast_device.c
@@ -144,6 +144,7 @@ static bool setup_device(void) {
 
 	logger(DEBUG_ALWAYS, LOG_INFO, "%s is a %s", device, device_info);
 
+	free(host);
 	return true;
 
 error:


### PR DESCRIPTION
The unsigned overflow check actually turned out to be useful. It uncovered an old bug in the asn.1 parser where it read sequence length without checking if it's preceeded by a `SEQUENCE` tag.

This is the reason UBSAN job was failing.

I posted the first commit as part of #372, but I want to do more testing on that one, so it's added here.
