### PR TITLE
Remove -Qunused-arguments

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,7 +53,6 @@ ld_flags = []
 
 if cc_name != 'msvc'
   cc_flags += [
-    '-Qunused-arguments',
     '-Wbad-function-cast',
     '-Wduplicated-branches',
     '-Wduplicated-cond',


### PR DESCRIPTION
I believe it's not actually needed anymore, let's check what BSD clangs think about that.

Should silence #383 if this is correct.
