### PR TITLE
CI: remove OpenSSL 3 from Fedora; add RHEL 9 & Alpine Edge

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -79,7 +79,8 @@ deps_linux_rhel() {
 
     if type dnf; then
       dnf install -y 'dnf-command(config-manager)'
-      dnf config-manager --enable powertools
+      dnf config-manager --enable powertools || true
+      dnf config-manager --enable crb || true
     fi
   fi
 
@@ -140,9 +141,16 @@ deps_linux() {
     deps_linux_debian "$@"
     ;;
 
-  centos | almalinux | fedora)
+  fedora)
     deps_linux_rhel "$@"
-    linux_openssl3
+    ;;
+
+  centos | almalinux)
+    deps_linux_rhel "$@"
+
+    if [ "${PLATFORM_ID:-}" != platform:el9 ]; then
+      linux_openssl3
+    fi
     ;;
 
   *) exit 1 ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,8 +150,10 @@ jobs:
       matrix:
         os:
           - alpine
+          - alpine:edge
           - centos:7 # aka RHEL 7
           - almalinux:8 # aka RHEL 8
+          - almalinux:9 # aka RHEL 9
           - fedora
           - debian:buster
           - debian:bullseye


### PR DESCRIPTION
Extracted from #386, since merging it may take some time, and we've been getting red CI for weeks.

Fedora 36 uses OpenSSL 3, so we remove it from there. It will continue to crop up as distributions move to OpenSSL 3.

Alpine Edge is useful to test newest versions of musl (I added it in #386 because it used some syscalls not needed by previous versions of musl).

RHEL 9 is quite obvious. It's a beta release, but it works fine, and the final release should be out soon.
