### PR TITLE
Don't tarpit localhost connections

### DIFF
--- a/src/netutl.c
+++ b/src/netutl.c
@@ -301,6 +301,23 @@ void sockaddr_setport(sockaddr_t *sa, const char *port) {
 	}
 }
 
+bool is_local_connection(const sockaddr_t *sa) {
+	switch(sa->sa.sa_family) {
+	case AF_INET:
+		// 127.0.0.0/8
+		return ntohl(sa->in.sin_addr.s_addr) >> 24 == 127;
+
+	case AF_INET6:
+		return IN6_IS_ADDR_LOOPBACK(&sa->in6.sin6_addr);
+
+	case AF_UNIX:
+		return true;
+
+	default:
+		return false;
+	}
+}
+
 uint16_t get_bound_port(int sockfd) {
 	sockaddr_t sa;
 	socklen_t salen = sizeof(sa);

--- a/src/netutl.h
+++ b/src/netutl.h
@@ -38,5 +38,6 @@ extern void sockaddrfree(sockaddr_t *sa);
 extern void sockaddrcpy(sockaddr_t *dest, const sockaddr_t *src);
 extern void sockaddr_setport(sockaddr_t *sa, const char *port);
 extern uint16_t get_bound_port(int sockfd);
+extern bool is_local_connection(const sockaddr_t *sa);
 
 #endif

--- a/test/unit/test_netutl.c
+++ b/test/unit/test_netutl.c
@@ -19,10 +19,60 @@ static void test_service_to_port_valid(void **state) {
 	assert_int_equal(1234, service_to_port("1234"));
 }
 
+static void test_is_local_connection_ipv4(void **state) {
+	(void)state;
+
+	sockaddr_t sa;
+
+	assert_true(inet_pton(AF_INET, "127.0.0.0", &sa.in.sin_addr));
+	sa.sa.sa_family = AF_INET;
+	assert_true(is_local_connection(&sa));
+
+	assert_true(inet_pton(AF_INET, "127.42.13.5", &sa.in.sin_addr));
+	sa.sa.sa_family = AF_INET;
+	assert_true(is_local_connection(&sa));
+
+	assert_true(inet_pton(AF_INET, "127.255.255.255", &sa.in.sin_addr));
+	sa.sa.sa_family = AF_INET;
+	assert_true(is_local_connection(&sa));
+
+	assert_true(inet_pton(AF_INET, "128.0.0.1", &sa.in.sin_addr));
+	sa.sa.sa_family = AF_INET;
+	assert_false(is_local_connection(&sa));
+}
+
+static void test_is_local_connection_ipv6(void **state) {
+	(void)state;
+
+	sockaddr_t sa;
+
+	assert_true(inet_pton(AF_INET6, "::1", &sa.in6.sin6_addr));
+	sa.sa.sa_family = AF_INET6;
+	assert_true(is_local_connection(&sa));
+
+	assert_true(inet_pton(AF_INET6, "::1:1", &sa.in6.sin6_addr));
+	sa.sa.sa_family = AF_INET6;
+	assert_false(is_local_connection(&sa));
+
+	assert_true(inet_pton(AF_INET6, "fe80::", &sa.in6.sin6_addr));
+	sa.sa.sa_family = AF_INET6;
+	assert_false(is_local_connection(&sa));
+}
+
+static void test_is_local_connection_unix(void **state) {
+	(void)state;
+
+	sockaddr_t sa = {.sa.sa_family = AF_UNIX};
+	assert_true(is_local_connection(&sa));
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(test_service_to_port_invalid),
 		cmocka_unit_test(test_service_to_port_valid),
+		cmocka_unit_test(test_is_local_connection_ipv4),
+		cmocka_unit_test(test_is_local_connection_ipv6),
+		cmocka_unit_test(test_is_local_connection_unix),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION





The reason Windows tests were hanging was pretty obvious in retrospect — since control connections use TCP there, connection limits apply to them, so they were getting tarpitted.

We could disable tarpit for tests, but I'm pretty sure this is also useful on end-user machines since it's really easy to get blocked by calling tincctl a dozen times in a row fromt a script.
