### PR TITLE
Shorter paths to PID files in integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,14 @@ jobs:
           CC: gcc-11
         if: always()
 
+      - name: Check that very long paths work
+        run: |
+          meson setup "$WD"
+          meson test -C "$WD" --verbose
+        env:
+          WD: /tmp/tinc_testing_directory_with_a_very_long_path_which_goes_over_the_108_char_limit_on_unix_socket_file_paths
+        if: always()
+
       - name: Archive test results
         run: sudo tar -caf tests.tar.gz /usr/local/etc
         continue-on-error: true

--- a/test/integration/cmd_misc.py
+++ b/test/integration/cmd_misc.py
@@ -121,7 +121,7 @@ def test_pid(foo: Tinc) -> None:
     check.is_in("Too many arguments", err)
 
     log.info("test pid without arguments")
-    pidfile = util.read_text(foo.sub("pid"))
+    pidfile = util.read_text(foo.pid_file)
     pid, _ = pidfile.split(maxsplit=1)
 
     out, _ = foo.cmd("pid")

--- a/test/integration/commandline.py
+++ b/test/integration/commandline.py
@@ -3,8 +3,10 @@
 """Test supported and unsupported commandline flags."""
 
 import os
+import shutil
 import signal
 import subprocess as subp
+import tempfile
 import time
 
 from testlib import check, util, path
@@ -12,44 +14,6 @@ from testlib.log import log
 from testlib.proc import Tinc, Script
 from testlib.test import Test
 from testlib.feature import SANDBOX_LEVEL
-
-tinc_flags = (
-    (0, ("get", "name")),
-    (0, ("-n", "foo", "get", "name")),
-    (0, ("-nfoo", "get", "name")),
-    (0, ("--net=foo", "get", "name")),
-    (0, ("--net", "foo", "get", "name")),
-    (0, ("-c", "conf", "-c", "conf")),
-    (0, ("-n", "net", "-n", "net")),
-    (0, ("--pidfile=pid", "--pidfile=pid")),
-    (1, ("-n", "foo", "get", "somethingreallyunknown")),
-    (1, ("--net",)),
-    (1, ("--net", "get", "name")),
-    (1, ("foo",)),
-    (1, ("-c", "conf", "-n", "n/e\\t")),
-)
-
-tincd_flags = (
-    (0, ("-D",)),
-    (0, ("--no-detach",)),
-    (0, ("-D", "-d")),
-    (0, ("-D", "-d2")),
-    (0, ("-D", "-d", "2")),
-    (0, ("-D", "-n", "foo")),
-    (0, ("-D", "-nfoo")),
-    (0, ("-D", "--net=foo")),
-    (0, ("-D", "--net", "foo")),
-    (0, ("-D", "-c", ".", "-c", ".")),
-    (0, ("-D", "-n", "net", "-n", "net")),
-    (0, ("-D", "-n", "net", "-o", "FakeOpt=42")),
-    (0, ("-D", "--logfile=log", "--logfile=log")),
-    (0, ("-D", "--pidfile=pid", "--pidfile=pid")),
-    (1, ("foo",)),
-    (1, ("--pidfile",)),
-    (1, ("--foo",)),
-    (1, ("-n", "net", "-o", "Compression=")),
-    (1, ("-c", "fakedir", "-n", "n/e\\t")),
-)
 
 
 def init(ctx: Test) -> Tinc:
@@ -69,6 +33,29 @@ def init(ctx: Test) -> Tinc:
 
 with Test("commandline flags") as context:
     node = init(context)
+    pf = node.pid_file
+
+    tincd_flags = (
+        (0, ("-D",)),
+        (0, ("--no-detach",)),
+        (0, ("-D", "-d")),
+        (0, ("-D", "-d2")),
+        (0, ("-D", "-d", "2")),
+        (0, ("-D", "-n", "foo")),
+        (0, ("-D", "-nfoo")),
+        (0, ("-D", "--net=foo")),
+        (0, ("-D", "--net", "foo")),
+        (0, ("-D", "-c", ".", "-c", ".")),
+        (0, ("-D", "-n", "net", "-n", "net")),
+        (0, ("-D", "-n", "net", "-o", "FakeOpt=42")),
+        (0, ("-D", "--logfile=log", "--logfile=log")),
+        (0, ("-D", f"--pidfile={pf}", f"--pidfile={pf}")),
+        (1, ("foo",)),
+        (1, ("--pidfile",)),
+        (1, ("--foo",)),
+        (1, ("-n", "net", "-o", "Compression=")),
+        (1, ("-c", "fakedir", "-n", "n/e\\t")),
+    )
 
     for code, flags in tincd_flags:
         COOKIE = util.random_string(10)
@@ -88,6 +75,22 @@ with Test("commandline flags") as context:
         log.debug('got code %d, ("%s", "%s")', server.returncode, stdout, stderr)
         check.equals(code, server.returncode)
 
+    tinc_flags = (
+        (0, ("get", "name")),
+        (0, ("-n", "foo", "get", "name")),
+        (0, ("-nfoo", "get", "name")),
+        (0, ("--net=foo", "get", "name")),
+        (0, ("--net", "foo", "get", "name")),
+        (0, ("-c", "conf", "-c", "conf")),
+        (0, ("-n", "net", "-n", "net")),
+        (0, (f"--pidfile={pf}", f"--pidfile={pf}")),
+        (1, ("-n", "foo", "get", "somethingreallyunknown")),
+        (1, ("--net",)),
+        (1, ("--net", "get", "name")),
+        (1, ("foo",)),
+        (1, ("-c", "conf", "-n", "n/e\\t")),
+    )
+
     for code, flags in tinc_flags:
         node.cmd(*flags, code=code)
 
@@ -96,33 +99,32 @@ def test_relative_path(ctx: Test, chroot: bool) -> None:
     """Test tincd with relative paths."""
 
     foo = init(ctx)
+    confdir = os.path.realpath(foo.sub("."))
 
-    conf_dir = os.path.realpath(foo.sub("."))
-    dirname = os.path.dirname(conf_dir)
-    basename = os.path.basename(conf_dir)
-    log.info("using confdir %s, dirname %s, basename %s", conf_dir, dirname, basename)
+    # Workaround for the 108-char limit on UNIX socket path length.
+    shortcut = tempfile.mkdtemp()
+    os.symlink(confdir, os.path.join(shortcut, "conf"))
+
+    log.info("using paths: confdir '%s', shortcut '%s'", confdir, shortcut)
 
     args = [
         path.TINCD_PATH,
         "-D",
         "-c",
-        basename,
+        "conf",
         "--pidfile",
         "pid",
         "--logfile",
-        ".//./log",
+        "conf/.//./log",
     ]
 
     if chroot:
         args.append("-R")
 
-    pidfile = os.path.join(dirname, "pid")
-    util.remove_file(pidfile)
+    pidfile = os.path.join(shortcut, "pid")
+    logfile = os.path.join(confdir, "log")
 
-    logfile = os.path.join(dirname, "log")
-    util.remove_file(logfile)
-
-    with subp.Popen(args, stderr=subp.STDOUT, cwd=dirname) as tincd:
+    with subp.Popen(args, stderr=subp.STDOUT, cwd=shortcut) as tincd:
         foo[Script.TINC_UP].wait(10)
 
         log.info("pidfile and logfile must exist at expected paths")
@@ -145,6 +147,9 @@ def test_relative_path(ctx: Test, chroot: bool) -> None:
         log.info("stopping tinc through '%s'", pidfile)
         foo.cmd("--pidfile", pidfile, "stop")
         check.equals(0, tincd.wait())
+
+    # Leave behind as debugging aid if there's an exception
+    shutil.rmtree(shortcut)
 
 
 with Test("relative path to tincd dir") as context:


### PR DESCRIPTION


Should hopefully close #401.

Test without these changes: https://github.com/hg/tinc/runs/6672588831?check_suite_focus=true#step:9:362