### PR TITLE
Fixes for a couple of small issues found by tests

### DIFF
--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -674,6 +674,7 @@ static bool add_listen_address(char *address, bool bindto) {
 		}
 
 		if(listen_sockets >= MAXSOCKETS) {
+			listen_sockets = MAXSOCKETS;
 			logger(DEBUG_ALWAYS, LOG_ERR, "Too many listening sockets");
 			freeaddrinfo(ai);
 			return false;
@@ -1095,6 +1096,7 @@ static bool setup_myself(void) {
 #endif
 
 		if(listen_sockets > MAXSOCKETS) {
+			listen_sockets = MAXSOCKETS;
 			logger(DEBUG_ALWAYS, LOG_ERR, "Too many listening sockets");
 			return false;
 		}

--- a/src/net_setup.c
+++ b/src/net_setup.c
@@ -1086,11 +1086,13 @@ static bool setup_myself(void) {
 
 	/* Open sockets */
 
-	if(!do_detach && getenv("LISTEN_FDS")) {
+	const char *listen_fds = getenv("LISTEN_FDS");
+
+	if(!do_detach && listen_fds) {
 		sockaddr_t sa;
 		socklen_t salen;
 
-		listen_sockets = atoi(getenv("LISTEN_FDS"));
+		listen_sockets = atoi(listen_fds);
 #ifdef HAVE_UNSETENV
 		unsetenv("LISTEN_FDS");
 #endif

--- a/src/tincd.c
+++ b/src/tincd.c
@@ -563,7 +563,9 @@ int main(int argc, char **argv) {
 
 	g_argv = argv;
 
-	if(getenv("LISTEN_PID") && atoi(getenv("LISTEN_PID")) == getpid()) {
+	const char *listen_pid = getenv("LISTEN_PID");
+
+	if(listen_pid && atoi(listen_pid) == getpid()) {
 		do_detach = false;
 	}
 


### PR DESCRIPTION



The first commit prevents going over `listen_socket` on tincd deinitialization.

The easiest way to trigger this is to start tincd with `LISTEN_FDS=9` (see additions to the test suite).



The second is a fix for what looks like another false-positive (although I guess it's possible in a multi-threaded program?). It happens with clang-tidy 14.

- https://github.com/hg/tinc/runs/6708258540?check_suite_focus=true#step:7:971
- https://github.com/hg/tinc/runs/6708568659?check_suite_focus=true#step:7:2641

