### PR TITLE
Notify 'tinc join' about invitation errors

### DIFF
--- a/doc/tinc.conf.5.in
+++ b/doc/tinc.conf.5.in
@@ -384,7 +384,7 @@ This only has effect when
 .Va Mode
 is set to
 .Qq switch .
-.It Va MaxConnectionBurst Li = Ar count Pq 100
+.It Va MaxConnectionBurst Li = Ar count Pq 10
 This option controls how many connections tinc accepts in quick succession.
 If there are more connections than the given number in a short time interval,
 tinc will reduce the number of accepted connections to only one per second,

--- a/doc/tinc.texi
+++ b/doc/tinc.texi
@@ -1153,7 +1153,7 @@ This option controls the amount of time MAC addresses are kept before they are r
 This only has effect when Mode is set to @samp{switch}.
 
 @cindex MaxConnectionBurst
-@item MaxConnectionBurst = <@var{count}> (100)
+@item MaxConnectionBurst = <@var{count}> (10)
 This option controls how many connections tinc accepts in quick succession.
 If there are more connections than the given number in a short time interval,
 tinc will reduce the number of accepted connections to only one per second,

--- a/src/invitation.h
+++ b/src/invitation.h
@@ -23,4 +23,8 @@
 int cmd_invite(int argc, char *argv[]);
 int cmd_join(int argc, char *argv[]);
 
+// Wait until data can be read from socket, or a timeout occurs.
+// true if socket is ready, false on timeout.
+bool wait_socket_recv(int fd);
+
 #endif

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -495,6 +495,10 @@ bool recvline(int fd, char *line, size_t len) {
 	}
 
 	while(!(newline = memchr(buffer, '\n', blen))) {
+		if(!wait_socket_recv(fd)) {
+			return false;
+		}
+
 		ssize_t nrecv = recv(fd, buffer + blen, sizeof(buffer) - blen, 0);
 
 		if(nrecv == -1 && sockerrno == EINTR) {


### PR DESCRIPTION
See #255

# New server, new client

```
Connected to localhost port 13394...
Request rejected: invitation is invalid or missing.
Invitation cancelled.
(exit code 1)
```

# New server, old client

```
Connected to localhost port 13394...
Invitation cancelled.
(exit code 1)
```

# Old server, new client

```
Connected to localhost port 655...
(10-second pause)
Timed out waiting for server to reply.
Cannot read greeting from peer
(exit code 1)
```

I'll refactor sptps record codes (`1`/`2`/`3`) in a separate PR.
