### PR TITLE
`version.py`: fix support for Python < 3.9

### DIFF
--- a/version.py
+++ b/version.py
@@ -20,5 +20,5 @@ cmd = [
 ]
 
 result = subp.run(cmd, stdout=subp.PIPE, encoding="utf-8", check=True)
-version = result.stdout.strip().removeprefix("release-")
+version = result.stdout.strip().replace("release-", "", 1)
 print(version)


### PR DESCRIPTION
Ugh. I put too much trust into pylint's compatibility checks (it notices these things… sometimes).

FreeBSD 13.1:

```
ninja: Entering directory `/usr/home/neko/tinc/build'
[1/21] Generating src/include/version_git.h with a custom command
Traceback (most recent call last):
  File "/usr/home/neko/tinc/version.py", line 23, in <module>
    version = result.stdout.strip().removeprefix("release-")
AttributeError: 'str' object has no attribute 'removeprefix'
```
