### PR TITLE
Correct a type mismatch

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -26,7 +26,7 @@
 #include "tincctl.h"
 #include "utils.h"
 
-void logger(int level, int priority, const char *format, ...) {
+void logger(debug_t level, int priority, const char *format, ...) {
 	(void)level;
 	(void)priority;
 	va_list ap;

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -80,7 +80,7 @@ char *scriptextension = defaultextension;
 static char *prompt;
 char *device = NULL;
 char *iface = NULL;
-int debug_level = -1;
+debug_t debug_level = -1;
 
 typedef enum option_t {
 	OPT_BAD_OPTION  = '?',


### PR DESCRIPTION
In one place in the source code, the debug level of type `int` was used and in other places of type `debug_t`. This commit introduces a change so that the type `debug_t` is used in both places. This also resolves a compiler warning.