### PR TITLE
fix build failures

### DIFF
--- a/src/net_socket.c
+++ b/src/net_socket.c
@@ -122,8 +122,8 @@ static bool bind_to_interface(int sd) {
 
 #if defined(SOL_SOCKET) && defined(SO_BINDTODEVICE)
 	memset(&ifr, 0, sizeof(ifr));
-	strncpy(ifr.ifr_ifrn.ifrn_name, iface, IFNAMSIZ);
-	ifr.ifr_ifrn.ifrn_name[IFNAMSIZ - 1] = 0;
+	strncpy(ifr.ifr_name, iface, IFNAMSIZ);
+	ifr.ifr_name[IFNAMSIZ - 1] = 0;
 
 	status = setsockopt(sd, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr, sizeof(ifr));
 
@@ -233,8 +233,8 @@ int setup_listen_socket(const sockaddr_t *sa) {
 		struct ifreq ifr;
 
 		memset(&ifr, 0, sizeof(ifr));
-		strncpy(ifr.ifr_ifrn.ifrn_name, iface, IFNAMSIZ);
-		ifr.ifr_ifrn.ifrn_name[IFNAMSIZ - 1] = 0;
+		strncpy(ifr.ifr_name, iface, IFNAMSIZ);
+		ifr.ifr_name[IFNAMSIZ - 1] = 0;
 
 		if(setsockopt(nfd, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr, sizeof(ifr))) {
 			closesocket(nfd);

--- a/src/raw_socket_device.c
+++ b/src/raw_socket_device.c
@@ -55,8 +55,8 @@ static bool setup_device(void) {
 	fcntl(device_fd, F_SETFD, FD_CLOEXEC);
 #endif
 
-	strncpy(ifr.ifr_ifrn.ifrn_name, iface, IFNAMSIZ);
-	ifr.ifr_ifrn.ifrn_name[IFNAMSIZ - 1] = 0;
+	strncpy(ifr.ifr_name, iface, IFNAMSIZ);
+	ifr.ifr_name[IFNAMSIZ - 1] = 0;
 
 	if(ioctl(device_fd, SIOCGIFINDEX, &ifr)) {
 		close(device_fd);


### PR DESCRIPTION
seeing some build failure while building for macos sequoia, the error is below:

```
  net_socket.c:105:14: error: no member named 'ifr_ifrn' in 'struct ifreq'
    105 |         strncpy(ifr.ifr_ifrn.ifrn_name, iface, IFNAMSIZ);
        |                 ~~~ ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/secure/_string.h:128:28: note: expanded from macro 'strncpy'
    128 |                 __builtin___strncpy_chk (dest, __VA_ARGS__, __darwin_obsz (dest))
        |                                          ^~~~
  net_socket.c:105:14: error: no member named 'ifr_ifrn' in 'struct ifreq'
    105 |         strncpy(ifr.ifr_ifrn.ifrn_name, iface, IFNAMSIZ);
        |                 ~~~ ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/secure/_string.h:128:62: note: expanded from macro 'strncpy'
    128 |                 __builtin___strncpy_chk (dest, __VA_ARGS__, __darwin_obsz (dest))
        |                                                                            ^~~~
  /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/secure/_common.h:41:54: note: expanded from macro '__darwin_obsz'
     41 | #define __darwin_obsz(object) __builtin_object_size (object, _USE_FORTIFY_LEVEL > 1 ? 1 : 0)
        |                                                      ^~~~~~
```

full build log, https://github.com/Homebrew/homebrew-core/actions/runs/10837004674/job/30072048690

relates to https://github.com/Homebrew/homebrew-core/pull/190728