### PR TITLE
fix: resolve -Wdiscarded-qualifiers warnings in ifconfig_route and complete_config

### DIFF
--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -178,7 +178,7 @@ void ifconfig_address(FILE *out, const char *value) {
 #endif
 }
 
-void ifconfig_route(FILE *out, const char *value) {
+void ifconfig_route(FILE *out, char *value) {
 	subnet_t subnet = {0}, gateway = {0};
 	char subnet_str[MAXNETSTR] = "", gateway_str[MAXNETSTR] = "";
 	char *sep = strchr(value, ' ');

--- a/src/ifconfig.h
+++ b/src/ifconfig.h
@@ -26,7 +26,7 @@ extern void ifconfig_dhcp(FILE *out);
 extern void ifconfig_dhcp6(FILE *out);
 extern void ifconfig_slaac(FILE *out);
 extern void ifconfig_address(FILE *out, const char *value);
-extern void ifconfig_route(FILE *out, const char *value);
+extern void ifconfig_route(FILE *out, char *value);
 extern void ifconfig_header(FILE *out);
 extern bool ifconfig_footer(FILE *out);
 

--- a/src/tincctl.c
+++ b/src/tincctl.c
@@ -3098,7 +3098,7 @@ static char *complete_config(const char *text, int state) {
 	}
 
 	while(variables[i].name) {
-		char *dot = strchr(text, '.');
+		const char *dot = strchr(text, '.');
 
 		if(dot) {
 			if((variables[i].type & VAR_HOST) && !strncasecmp(variables[i].name, dot + 1, strlen(dot + 1))) {


### PR DESCRIPTION
In ifconfig_route, remove const from the value parameter as it is written through via sep (*sep++ = 0) and is only called from finalize_join() with a mutable buffer.

In complete_config, change dot to const char* as it is only used for pointer arithmetic and reading, never written through.